### PR TITLE
Change the jenkins job scheduling for the performance testsuite to run every 2 hours

### DIFF
--- a/jenkins_pipelines/performance_testsuite/Jenkinsfile_performance_testsuite
+++ b/jenkins_pipelines/performance_testsuite/Jenkinsfile_performance_testsuite
@@ -18,7 +18,7 @@ pipeline {
         label 'performance-tests'
     }
     triggers {
-        cron('H/30 * * * *')
+        cron('* H/2 * * *')
     }
     stages {
         stage('Deploy VMs on ECP') {


### PR DESCRIPTION
Change the jenkins job scheduling for the performance testsuite to run every 2 hours