### PR TITLE
Fix changelog_test return code pickup

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog
@@ -46,7 +46,8 @@ pipeline {
         stage('Run changelog test') {
             steps {
                 echo 'Run changelog tests'
-                sh "${gitarro_changelog_test} || CLRET=\$?;" +
+                sh "set +e;" +
+                   "${gitarro_changelog_test}; CLRET=\${?};" +
                    "PR_NUMBER=\$(grep 'GITARRO_PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2);" +
                    "if [ \$CLRET -eq 0 ]; then ${gitarro_enable_merging} -t /usr/bin/true -P \$PR_NUMBER; else ${gitarro_enable_merging} -t /usr/bin/false -P \$PR_NUMBER; fi;" +
                    "exit \$CLRET"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog
@@ -46,7 +46,8 @@ pipeline {
         stage('Run changelog test') {
             steps {
                 echo 'Run changelog tests'
-                sh "${gitarro_changelog_test} || CLRET=\$?;" +
+                sh "set +e;" +
+                   "${gitarro_changelog_test}; CLRET=\${?};" +
                    "PR_NUMBER=\$(grep 'GITARRO_PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2);" +
                    "if [ \$CLRET -eq 0 ]; then ${gitarro_enable_merging} -t /usr/bin/true -P \$PR_NUMBER; else ${gitarro_enable_merging} -t /usr/bin/false -P \$PR_NUMBER; fi;" +
                    "exit \$CLRET"


### PR DESCRIPTION
This is the only way I can fix this, as for some estrange reason the OR bash/sh operator doesn't seem to work on the declarative pipeline (CLRET was always empty)

@MalloZup if you have any better idea to use `||`, please tell me. I just ran out of ideas.

I switched uyuni job to use this branch, and it seems to be working fine:

https://ci.suse.de/job/Uyuni-PRs/job/Uyuni-PRs-changelog-pipeline/11903/
https://ci.suse.de/job/Uyuni-PRs/job/Uyuni-PRs-changelog-pipeline/11904/