### PR TITLE
Hotfix/6376 avoid failure when no pending PRs

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unitpsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unitpsql
@@ -19,22 +19,11 @@ pipeline {
      filter = 'backend/'
      // the actual test is the git repo (inside spacewalk)
      test = "susemanager-utils/testing/automation/backend-unittest-pgsql.sh" 
-
-    // DO NOT EDIT THIS
-    // this are execution jobs
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u \"${env.BUILD_URL}\" " +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
    // run only on specific hosts
@@ -53,24 +42,25 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run tests against PR') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run tests!'
-                   sh "$runtest}"
-                  }
+                  sh "${runtest}"
+                  junit "**/backend/reports/pgsql_tests.xml" 
+            }
         }
     }
   post { 
-        always {
-            junit "spacewalk*/backend/reports/pgsql_tests.xml" 
-        }
         success {
             echo 'Clean up current workspace, when job success.'
             cleanWs()
         }
-    }
+  }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog
@@ -44,12 +44,15 @@ pipeline {
       stage('Check Pull Request for changelog') {
         steps {
                 echo 'Check if a PR need changelog test'
-                 sh "${gitarro_changelog_check} | grep \"TESTREQUIRED=true\" "
+                sh "${gitarro_changelog_check} 2>&1 | tee gitarro_check.log"
               }
         }
         // If there is a PR that doesn't contain context changelog, we run this.
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run changelog test') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                 echo 'Run changelog tests'
                 sh "set +e;" +

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_checkstyle
@@ -38,11 +38,14 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need checkstyle test'
-                 sh "${javacheckstyle_check} | grep \"TESTREQUIRED=true\" "
+                 sh "${javacheckstyle_check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run Javacheckstyle test') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run javacheckstyle tests'
                    sh "${javacheckstyle_test}"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
@@ -37,11 +37,14 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR needs JavaScript lint test'
-                 sh "${jslint_check} | grep \"TESTREQUIRED=true\" " // | grep \"TESTREQUIRED=true\" 
+                 sh "${jslint_check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run Javascript lint test') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run JavaScript lint tests'
                    sh "${jslint_test}"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_psql_unit
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_psql_unit
@@ -19,21 +19,11 @@ pipeline {
      git_fs = "${env.WORKSPACE}"      
      // the actual test is the git repo
      test = "susemanager-utils/testing/automation/java-unittests-pgsql.sh"
-
-    // this are execution jobs
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d ${description} " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d ${description} " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u ${env.BUILD_URL}" +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
    // run only on specific hosts
@@ -50,21 +40,22 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
-               }
+                 sh "${check} 2>&1 | tee gitarro_check.log"
+            }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run Java psql unit test') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run psql unit tests'
-                   sh "$runtest}"
-                  }
+                  sh "$runtest}"
+                  junit "**/java/test-results/*.xml"
+            }
         }
     }
   post { 
-        always {
-            junit "spacewalk*/java/test-results/*.xml"
-        }
         success {
             echo 'Clean up current workspace, when job success.'
             cleanWs()

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_rubocop
@@ -13,19 +13,11 @@ pipeline {
      git_fs = "${env.WORKSPACE}"      
      filter = 'testsuite/'
      test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/rubocop.sh" 
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u \"${env.BUILD_URL}\" " +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
     agent { label 'suse-manager-unit-tests' }
@@ -42,14 +34,17 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         stage('Run tests against PR') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run tests!'
-                   sh "$runtest}"
-                  }
+                  sh "${runtest}"
+            }
         }
     }
   post { 

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_oracle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_oracle
@@ -47,10 +47,13 @@ pipeline {
     stage('Check Pull Request') {
       steps {
         echo 'Check if a PR need a test'
-        sh "${check} | grep \"TESTREQUIRED=true\" "
+        sh "${check} 2>&1 | tee gitarro_check.log"
         }
       }
-     stage('Run tests oracle') {
+    stage('Run tests oracle') {
+      when {
+        expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+      }
        steps {
           echo 'Run schema tests oracle '
           sh "$runtest_oracle"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_postgre
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_postgre
@@ -47,14 +47,17 @@ pipeline {
     stage('Check Pull Request') {
       steps {
         echo 'Check if a PR need a test'
-        sh "${check} | grep \"TESTREQUIRED=true\" "
+        sh "${check} 2>&1 | tee gitarro_check.log"
         }
       }
      stage('Run schema tests postgresql') {
+          when {
+            expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+          }
           steps {
             echo 'Run tests'
-            sh "$runtest_pg"
-            }
+            sh "${runtest_pg}"
+          }
      }
   
   }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_sql_standard_name
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_sql_standard_name
@@ -40,13 +40,16 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         stage('Run sql schem filename tests') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
-                   sh "$runtest}"
-                  }
+                sh "${runtest}"
+            }
         }
     }
   post { 

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittest
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittest
@@ -18,21 +18,11 @@ pipeline {
      git_fs = "${env.WORKSPACE}"      
      // the actual test is the git repo
      test = "susemanager-utils/testing/automation/susemanager-unittest.sh"
-
-    // this are execution jobs
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d ${description} " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d ${description} " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u \"${env.BUILD_URL}\"" +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
    // run only on specific hosts
@@ -51,21 +41,22 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run tests') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run tests'
-                   sh "$runtest}"
-                  }
+                  sh "${runtest}"
+                  junit "**/susemanager/src/reports/tests.xml"
+            }
         }
     }
   post { 
-        always { 
-            junit "spacewalk*/susemanager/src/reports/tests.xml"
-        }
         success {
             echo 'Clean up current workspace, when job success.'
             cleanWs()

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unitpsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unitpsql
@@ -19,22 +19,11 @@ pipeline {
      filter = 'backend/'
      // the actual test is the git repo (inside spacewalk)
      test = "susemanager-utils/testing/automation/backend-unittest-pgsql.sh" 
-
-    // DO NOT EDIT THIS
-    // this are execution jobs
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u \"${env.BUILD_URL}\" " +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
    // run only on specific hosts
@@ -53,24 +42,25 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run tests against PR') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run tests!'
-                   sh "$runtest}"
-                  }
+                  sh "${runtest}"
+                  junit "**/backend/reports/pgsql_tests.xml" 
+            }
         }
     }
   post { 
-        always {
-            junit "spacewalk*/backend/reports/pgsql_tests.xml" 
-        }
         success {
             echo 'Clean up current workspace, when job success.'
             cleanWs()
         }
-    }
+  }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog
@@ -44,12 +44,15 @@ pipeline {
       stage('Check Pull Request for changelog') {
         steps {
                 echo 'Check if a PR need changelog test'
-                 sh "${gitarro_changelog_check} | grep \"TESTREQUIRED=true\" "
+                sh "${gitarro_changelog_check} 2>&1 | tee gitarro_check.log"
               }
         }
         // If there is a PR that doesn't contain context changelog, we run this.
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run changelog test') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                 echo 'Run changelog tests'
                 sh "set +e;" +

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_checkstyle
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_checkstyle
@@ -38,11 +38,14 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need checkstyle test'
-                 sh "${javacheckstyle_check} | grep \"TESTREQUIRED=true\" "
+                 sh "${javacheckstyle_check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run Javacheckstyle test') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run javacheckstyle tests'
                    sh "${javacheckstyle_test}"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
@@ -38,15 +38,18 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR needs JavaScript lint test'
-                 sh "${jslint_check} | grep \"TESTREQUIRED=true\" "
+                 sh "${jslint_check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run Javascript lint test') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run JavaScript lint tests'
                    sh "${jslint_test}"
-                  }
+            }
         }
     }
    post { 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_psql_unit
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_psql_unit
@@ -50,24 +50,21 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
-               }
+                 sh "${check} 2>&1 | tee gitarro_check.log"
+            }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run Java psql unit test') {
             steps {
                   echo 'Run psql unit tests'
-                   sh "$runtest}"
-                  }
+                  sh "${runtest}"
+                  junit "**/java/test-results/*.xml"
+            }
         }
     }
 
-    post { 
-        always {
-            junit "spacewalk*/java/test-results/*.xml"
-        }
+    post {
         success {
-            echo 'Clean up current workspace, when job success.'
             cleanWs()
         }
     }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_rubocop
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_rubocop
@@ -13,19 +13,11 @@ pipeline {
      git_fs = "${env.WORKSPACE}"      
      filter = 'testsuite/'
      test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/rubocop.sh" 
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u \"${env.BUILD_URL}\" " +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
     agent { label 'suse-manager-unit-tests' }
@@ -42,14 +34,17 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         stage('Run tests against PR') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run tests!'
-                   sh "$runtest}"
-                  }
+                   sh "${runtest}"
+            }
         }
     }
   post { 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_oracle
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_oracle
@@ -47,15 +47,18 @@ pipeline {
     stage('Check Pull Request') {
       steps {
         echo 'Check if a PR need a test'
-        sh "${check} | grep \"TESTREQUIRED=true\" "
+        sh "${check} 2>&1 | tee gitarro_check.log"
         }
       }
-     stage('Run tests oracle') {
-       steps {
-          echo 'Run schema tests oracle '
-          sh "$runtest_oracle"
-            }
-       }
+    stage('Run tests oracle') {
+      when {
+        expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+      }
+      steps {
+        echo 'Run schema tests oracle '
+        sh "$runtest_oracle"
+      }
+    }
   }
   post { 
         success {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_postgre
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_postgre
@@ -47,14 +47,17 @@ pipeline {
     stage('Check Pull Request') {
       steps {
         echo 'Check if a PR need a test'
-        sh "${check} | grep \"TESTREQUIRED=true\" "
+        sh "${check} 2>&1 | tee gitarro_check.log"
         }
       }
      stage('Run schema tests postgresql') {
+          when {
+            expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+          }
           steps {
             echo 'Run tests'
-            sh "$runtest_pg"
-            }
+            sh "${runtest_pg}"
+          }
      }
   
   }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_sql_standard_name
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_sql_standard_name
@@ -13,19 +13,11 @@ pipeline {
      filter = "schema/spacewalk"
      git_fs = "${env.WORKSPACE}"      
      test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/sql_schema_filename.py"
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d \"${description}\" " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u ${env.BUILD_URL}" +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
     agent { label 'suse-manager-unit-tests' }
@@ -40,13 +32,16 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         stage('Run sql schem filename tests') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
-                   sh "$runtest}"
-                  }
+                sh "${runtest}"
+            }
         }
     }
   post { 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittest
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittest
@@ -18,21 +18,11 @@ pipeline {
      git_fs = "${env.WORKSPACE}"      
      // the actual test is the git repo
      test = "susemanager-utils/testing/automation/susemanager-unittest.sh"
-
-    // this are execution jobs
-    check = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d ${description} " +
-                " -f ${filter} " +
-                " -t ${test} " +
-                " -g ${git_fs} " +
-                "--check --changed_since 3600" 
-
-    runtest = "gitarro.ruby2.1  -r ${repository}" + 
-                " -c ${context} -d ${description} " +
-                " -f ${filter} " +
-                " -g ${git_fs} " +
-                " -u \"${env.BUILD_URL}\"" +
-                " -t ${test} " 
+     gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+      
+     // this are execution jobs
+     check = "gitarro.ruby2.1 ${gitarro_common_params} --check --changed_since 3600" 
+     runtest = "gitarro.ruby2.1 ${gitarro_common_params} -u ${env.BUILD_URL}"
 
    }
    // run only on specific hosts
@@ -51,21 +41,22 @@ pipeline {
         stage('Check Pull Request') {
             steps {
                  echo 'Check if a PR need a test'
-                 sh "${check} | grep \"TESTREQUIRED=true\" "
+                 sh "${check} 2>&1 | tee gitarro_check.log"
                }
          }
         // THIS JOB RUN ONLY IF THE 1ST IS SUCCESSEFULL. ( so it is triggered by 1st)
         stage('Run tests') {
+            when {
+                expression { return readFile('gitarro_check.log').contains('TESTREQUIRED=true') }
+            }
             steps {
                   echo 'Run tests'
-                   sh "$runtest}"
-                  }
+                  sh "${runtest}"
+                  junit "**/susemanager/src/reports/tests.xml"
+            }
         }
     }
   post { 
-        always { 
-            junit "spacewalk*/susemanager/src/reports/tests.xml"
-        }
         success {
             echo 'Clean up current workspace, when job success.'
             cleanWs()


### PR DESCRIPTION
Task : https://github.com/SUSE/spacewalk/issues/6376

- Avoid failing when no pending PRs
- Avoid Junit failure if will the execution will not produce a report
- Fixing JUnit output path

Future work: I did it modifying the pipeline, parsing output of gitarro, so less impact in our system. Can be done modifying gitarro, so we return different exit codes and then parse those to exit always with 0 (to don't let fail the pipeline) or we read from a json file or env. variable produced by gitarro.