### PR TITLE
[6376] Checkout ci repo after cleanws, to fix rubocop not found

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unitpsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unitpsql
@@ -28,15 +28,22 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {
         cron('H/5 * * * *')
-       }
+    }
+    
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -58,9 +65,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
   }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog
@@ -30,7 +30,11 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {
         cron('H/5 * * * *')
     }
@@ -39,6 +43,8 @@ pipeline {
           steps {
               echo 'Clean up previous workspace'
               cleanWs()
+              echo 'Check out SCM'
+              checkout scm
           }
       }
       stage('Check Pull Request for changelog') {
@@ -65,9 +71,11 @@ pipeline {
     }
    // postactions
    post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_checkstyle
@@ -26,13 +26,19 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers { cron('H/5 * * * *')  }
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -53,9 +59,11 @@ pipeline {
         }
     }
    post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
@@ -25,13 +25,19 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers { cron('H/5 * * * *')  }
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -52,9 +58,11 @@ pipeline {
         }
     }
    post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_psql_unit
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_psql_unit
@@ -28,13 +28,19 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {  cron('H/5 * * * *')  }
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -56,9 +62,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_rubocop
@@ -29,6 +29,8 @@ pipeline {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -48,9 +50,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_oracle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_oracle
@@ -39,10 +39,12 @@ pipeline {
   triggers { cron('H/5 * * * *') }
   stages {
     stage('Clean Up Workspace') {
-            steps {
-                echo 'Clean up previous workspace'
-                cleanWs()
-            }
+        steps {
+            echo 'Clean up previous workspace'
+            cleanWs()
+            echo 'Check out SCM'
+            checkout scm
+        }
     }
     stage('Check Pull Request') {
       steps {
@@ -61,9 +63,11 @@ pipeline {
        }
   }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_postgre
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_postgre
@@ -39,10 +39,12 @@ pipeline {
   triggers { cron('H/5 * * * *') }
   stages {
     stage('Clean Up Workspace') {
-            steps {
-                echo 'Clean up previous workspace'
-                cleanWs()
-            }
+        steps {
+            echo 'Clean up previous workspace'
+            cleanWs()
+            echo 'Check out SCM'
+            checkout scm
+        }
     }
     stage('Check Pull Request') {
       steps {
@@ -62,9 +64,11 @@ pipeline {
   
   }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_sql_standard_name
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_sql_standard_name
@@ -35,6 +35,8 @@ pipeline {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -53,9 +55,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittest
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittest
@@ -27,15 +27,22 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {
         cron('H/5 * * * *')
-       }
+    }
+    
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -57,9 +64,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unitpsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unitpsql
@@ -28,15 +28,22 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {
         cron('H/5 * * * *')
-       }
+    }
+    
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -58,9 +65,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
   }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog
@@ -30,17 +30,23 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {
         cron('H/5 * * * *')
     }
     stages {
-      stage('Clean Up Workspace') {
+        stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
-      }
+        }
       stage('Check Pull Request for changelog') {
         steps {
                 echo 'Check if a PR need changelog test'
@@ -65,9 +71,11 @@ pipeline {
     }
    // postactions
    post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_checkstyle
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_checkstyle
@@ -26,13 +26,19 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers { cron('H/5 * * * *')  }
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -53,9 +59,11 @@ pipeline {
         }
     }
    post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
@@ -26,13 +26,19 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers { cron('H/5 * * * *')  }
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -53,9 +59,11 @@ pipeline {
         }
     }
    post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_psql_unit
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_psql_unit
@@ -28,13 +28,19 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {  cron('H/5 * * * *')  }
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_rubocop
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_rubocop
@@ -29,6 +29,8 @@ pipeline {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -48,9 +50,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_oracle
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_oracle
@@ -39,10 +39,12 @@ pipeline {
   triggers { cron('H/5 * * * *') }
   stages {
     stage('Clean Up Workspace') {
-      steps {
-          echo 'Clean up previous workspace'
-          cleanWs()
-      }
+        steps {
+            echo 'Clean up previous workspace'
+            cleanWs()
+            echo 'Check out SCM'
+            checkout scm
+        }
     }
     stage('Check Pull Request') {
       steps {
@@ -61,9 +63,11 @@ pipeline {
     }
   }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_postgre
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_postgre
@@ -38,10 +38,12 @@ pipeline {
   // trigger
   triggers { cron('H/5 * * * *') }
   stages {
-      stage('Clean Up Workspace') {
+    stage('Clean Up Workspace') {
         steps {
             echo 'Clean up previous workspace'
             cleanWs()
+            echo 'Check out SCM'
+            checkout scm
         }
     }
     stage('Check Pull Request') {
@@ -62,9 +64,11 @@ pipeline {
   
   }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_sql_standard_name
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_sql_standard_name
@@ -27,6 +27,8 @@ pipeline {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -45,9 +47,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittest
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittest
@@ -27,15 +27,22 @@ pipeline {
    }
    // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
-   // trigger
+    
+    parameters {
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+    
     triggers {
         cron('H/5 * * * *')
-       }
+    }
+    
     stages {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
                 cleanWs()
+                echo 'Check out SCM'
+                checkout scm
             }
         }
         stage('Check Pull Request') {
@@ -57,9 +64,11 @@ pipeline {
         }
     }
   post { 
-        success {
-            echo 'Clean up current workspace, when job success.'
-            cleanWs()
+        script {
+            if (params.cleanWorkspace == true) {
+                echo 'Clean up current workspace, when job success.'
+                cleanWs()
+            }
         }
     }
 }


### PR DESCRIPTION
Task: https://github.com/SUSE/spacewalk/issues/6376

### Fixing rubocop job
This job needs files inside susemanager-ci repo, but the step cleanws at first stage is deleting also the repo checked out. There is no way to clean up before the checkout of pipelines repo, we don't want to use deletedir of a specific folder because it can be tricky, as pipelines also creates tmp and script dirs, only cleaned with cleanws step.

Solution:
- Checkout ci repo after cleanws, to fix rubocop script not found.
- Also added a bonus, boolean parameter in case you want to run the pipeline manually, avoiding clean up workspace after job success.