### PR TITLE
Improve Jenkins Pipelines to reduce GitHub calls

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -39,7 +40,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -53,8 +54,12 @@ pipeline {
                 echo 'Run tests!'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -39,7 +40,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -55,16 +56,21 @@ pipeline {
                 script {
                     gitarro_changelog_test_cmd = "${gitarro_cmd} ${gitarro_changelog_test}"
                     gitarro_enable_merging_cmd = "${gitarro_cmd} ${gitarro_enable_merging}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             gitarro_changelog_test_cmd = "${gitarro_local} ${gitarro_changelog_test}"
                             gitarro_enable_merging_cmd = "${gitarro_local} ${gitarro_enable_merging}"
+                    }                    
+                    if (params.PR_NUMBER != '') {
+                        gitarro_changelog_test_cmd = "${gitarro_changelog_test_cmd} -P ${params.PR_NUMBER}"
+                        gitarro_enable_merging_cmd = "${gitarro_enable_merging_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
-                sh "set +e;" +
-                        "${gitarro_changelog_test_cmd}; CLRET=\${?};" +
-                        "PR_NUMBER=\$(grep 'GITARRO_PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2);" +
-                        "if [ \$CLRET -eq 0 ]; then ${gitarro_enable_merging_cmd} -t /usr/bin/true -P \$PR_NUMBER; else ${gitarro_enable_merging_cmd} -t /usr/bin/false -P \$PR_NUMBER; fi;" +
-                        "exit \$CLRET"
+                sh "set +e; ${gitarro_changelog_test_cmd}; CLRET=\${?}; " +
+                   "if [ \$CLRET -eq 0 ]; then " +
+                   "${gitarro_enable_merging_cmd} -t /usr/bin/true; " +
+                   "else ${gitarro_enable_merging_cmd} -t /usr/bin/false; " +
+                   "fi; exit \$CLRET"
             }
         }
     }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -9,7 +9,7 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
     }
 
     environment {
@@ -22,7 +22,7 @@ pipeline {
     agent { label 'suse-manager-unit-tests' }
 
     triggers {
-        cron('H/5 * * * *')
+        cron('H/10 * * * *')
     }
 
     stages {
@@ -33,7 +33,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -60,7 +60,7 @@ pipeline {
 
                     contexts.each { context ->
                         commands = "${gitarro_cmd} ${check} -c ${context}"
-                        if (params.GITARRO_PR_NUMBER != "") {
+                        if (params.GITARRO_PR_NUMBER != '') {
                             commands = "${gitarro_local} ${check} -c ${context}"
                         }
                         PENDING = sh(
@@ -69,7 +69,15 @@ pipeline {
                             ).trim()
                         echo PENDING
                         if (PENDING.contains('TESTREQUIRED=true')) {
-                            build job: "manager-prs-${context}-pipeline",  parameters: [[$class: 'StringParameterValue', name: 'GITARRO_PR_NUMBER', value: params.GITARRO_PR_NUMBER]], wait: false
+                            PR_NUMBER = sh(script: "grep 'PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2", returnStdout: true).trim()
+                            build(
+                                job: "manager-prs-${context}-pipeline",
+                                parameters: [
+                                             [$class: 'StringParameterValue', name: 'GITARRO_PR_NUMBER', value: params.GITARRO_PR_NUMBER], 
+                                             [$class: 'StringParameterValue', name: 'PR_NUMBER', value: PR_NUMBER]
+                                            ],
+                                wait: false
+                            )
                         }
                     }
                 }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -33,7 +34,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -50,6 +51,10 @@ pipeline {
                     javacheckstyle_test_cmd = "${gitarro_cmd} ${javacheckstyle_test}"
                     if (params.GITARRO_PR_NUMBER != "") {
                         javacheckstyle_test_cmd = "${gitarro_local} ${javacheckstyle_test}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        javacheckstyle_test_cmd = "${javacheckstyle_test_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${javacheckstyle_test_cmd}"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -40,7 +41,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -54,8 +55,12 @@ pipeline {
                 echo 'Run psql unit tests'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -33,7 +34,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -49,6 +50,10 @@ pipeline {
                     jslint_test_cmd = "${gitarro_cmd} ${jslint_test}"
                     if (params.GITARRO_PR_NUMBER != "") {
                         jslint_test_cmd = "${gitarro_local} ${jslint_test}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        jslint_test_cmd = "${jslint_test_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${jslint_test_cmd}"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -21,7 +22,7 @@ pipeline {
         test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/rubocop.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
         gitarro_cmd = 'gitarro.ruby2.1'
-        gitarro_local = 'ruby gitarro.rb'
+        gitarro_local = 'ruby gitarro/gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 
     }
@@ -35,11 +36,13 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
-                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
-                                  extensions       : [[$class: 'LocalBranch']],
-                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                        dir('gitarro') {
+                            checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                      extensions       : [[$class: 'LocalBranch']],
+                                      userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                        }
                     }
                 }
             }
@@ -49,8 +52,12 @@ pipeline {
                 echo 'Run tests!'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${commands}"

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_oracle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_oracle
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -43,7 +44,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -57,9 +58,13 @@ pipeline {
                 echo 'Run schema tests oracle'
                 script {
                     runtest_oracle_cmd = "${gitarro_cmd} ${runtest_oracle}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             runtest_oracle_cmd = "${gitarro_local} ${runtest_oracle}"
                     }
+                    if (params.PR_NUMBER != '') {
+                        runtest_oracle_cmd = "${runtest_oracle_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }                    
                 }
                 sh "$runtest_oracle_cmd"
             }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -43,7 +44,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -58,9 +59,13 @@ pipeline {
                 echo 'Run tests'
                 script {
                     runtest_pg_cmd = "${gitarro_cmd} ${runtest_pg}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             runtest_pg_cmd = "${gitarro_local} ${runtest_pg}"
                     }
+                    if (params.PR_NUMBER != '') {
+                        runtest_pg_cmd = "${runtest_pg_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }     
                 }
                 sh "${runtest_pg_cmd}"
             }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
     
@@ -39,7 +40,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -52,9 +53,13 @@ pipeline {
             steps {
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                            commands = "${gitarro_local} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
                     }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }    
                 }
                 sh "${commands}"
             }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
@@ -9,8 +9,9 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
-         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
     environment {
@@ -39,7 +40,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -53,8 +54,12 @@ pipeline {
                 echo 'Run tests'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                            commands = "${gitarro_local} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -40,7 +41,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -55,8 +56,12 @@ pipeline {
                 echo 'Run tests!'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                            commands = "${gitarro_local} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog_test
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -39,7 +40,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -55,16 +56,21 @@ pipeline {
                 script {
                     gitarro_changelog_test_cmd = "${gitarro_cmd} ${gitarro_changelog_test}"
                     gitarro_enable_merging_cmd = "${gitarro_cmd} ${gitarro_enable_merging}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             gitarro_changelog_test_cmd = "${gitarro_local} ${gitarro_changelog_test}"
                             gitarro_enable_merging_cmd = "${gitarro_local} ${gitarro_enable_merging}"
+                    }                    
+                    if (params.PR_NUMBER != '') {
+                        gitarro_changelog_test_cmd = "${gitarro_changelog_test_cmd} -P ${params.PR_NUMBER}"
+                        gitarro_enable_merging_cmd = "${gitarro_enable_merging_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
-                sh "set +e;" +
-                        "${gitarro_changelog_test_cmd}; CLRET=\${?};" +
-                        "PR_NUMBER=\$(grep 'GITARRO_PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2);" +
-                        "if [ \$CLRET -eq 0 ]; then ${gitarro_enable_merging_cmd} -t /usr/bin/true -P \$PR_NUMBER; else ${gitarro_enable_merging_cmd} -t /usr/bin/false -P \$PR_NUMBER; fi;" +
-                        "exit \$CLRET"
+                sh "set +e; ${gitarro_changelog_test_cmd}; CLRET=\${?}; " +
+                   "if [ \$CLRET -eq 0 ]; then " +
+                   "${gitarro_enable_merging_cmd} -t /usr/bin/true; " +
+                   "else ${gitarro_enable_merging_cmd} -t /usr/bin/false; " +
+                   "fi; exit \$CLRET"
             }
         }
     }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
@@ -9,7 +9,7 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
     }
 
     environment {
@@ -22,7 +22,7 @@ pipeline {
     agent { label 'suse-manager-unit-tests' }
 
     triggers {
-        cron('H/5 * * * *')
+        cron('H/10 * * * *')
     }
 
     stages {
@@ -33,7 +33,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -57,7 +57,7 @@ pipeline {
                     ]
                     contexts.each { context ->
                         commands = "${gitarro_cmd} ${check} -c ${context}"
-                        if (params.GITARRO_PR_NUMBER != "") {
+                        if (params.GITARRO_PR_NUMBER != '') {
                             commands = "${gitarro_local} ${check} -c ${context}"
                         }
                         PENDING = sh(
@@ -66,8 +66,15 @@ pipeline {
                             ).trim()
                         echo PENDING
                         if (PENDING.contains('TESTREQUIRED=true')) {
-                            build job: "uyuni-prs-${context}-pipeline",  parameters: [[$class: 'StringParameterValue', name: 'GITARRO_PR_NUMBER', value: params.GITARRO_PR_NUMBER]], wait: false
-                        }
+                            PR_NUMBER = sh(script: "grep 'PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2", returnStdout: true).trim()
+                            build(
+                                job: "uyuni-prs-${context}-pipeline",
+                                parameters: [
+                                             [$class: 'StringParameterValue', name: 'GITARRO_PR_NUMBER', value: params.GITARRO_PR_NUMBER], 
+                                             [$class: 'StringParameterValue', name: 'PR_NUMBER', value: PR_NUMBER]
+                                            ],
+                                wait: false
+                            )                        }
                     }
                 }
             }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -33,7 +34,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -49,6 +50,10 @@ pipeline {
                     javacheckstyle_test_cmd = "${gitarro_cmd} ${javacheckstyle_test}"
                     if (params.GITARRO_PR_NUMBER != "") {
                         javacheckstyle_test_cmd = "${gitarro_local} ${javacheckstyle_test}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        javacheckstyle_test_cmd = "${javacheckstyle_test_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${javacheckstyle_test_cmd}"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -40,7 +41,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -54,8 +55,12 @@ pipeline {
                 echo 'Run psql unit tests'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                             commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -33,7 +34,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -49,6 +50,10 @@ pipeline {
                     jslint_test_cmd = "${gitarro_cmd} ${jslint_test}"
                     if (params.GITARRO_PR_NUMBER != "") {
                         jslint_test_cmd = "${gitarro_local} ${jslint_test}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        jslint_test_cmd = "${jslint_test_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${jslint_test_cmd}"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
     
@@ -21,7 +22,7 @@ pipeline {
         test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/rubocop.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
         gitarro_cmd = 'gitarro.ruby2.1'
-        gitarro_local = 'ruby gitarro.rb'
+        gitarro_local = 'ruby gitarro/gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 
     }
@@ -35,11 +36,13 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
-                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
-                                  extensions       : [[$class: 'LocalBranch']],
-                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                        dir('gitarro') {
+                            checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                      extensions       : [[$class: 'LocalBranch']],
+                                      userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                        }
                     }
                 }
             }
@@ -49,8 +52,12 @@ pipeline {
                 echo 'Run tests!'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                            commands = "${gitarro_local} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${commands}"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -43,7 +44,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -57,8 +58,12 @@ pipeline {
                 echo 'Run tests'
                 script {
                     runtest_pg_cmd = "${gitarro_cmd} ${runtest_pg}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                            runtest_pg_cmd = "${gitarro_local} ${runtest_pg}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        runtest_pg_cmd = "${gitarro_local} ${runtest_pg}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        runtest_pg_cmd = "${runtest_pg_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${runtest_pg_cmd}"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -8,7 +8,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
     
@@ -35,7 +36,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -48,8 +49,12 @@ pipeline {
             steps {
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                            commands = "${gitarro_local} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "${commands}"

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
@@ -9,7 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: "", description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
@@ -39,7 +40,7 @@ pipeline {
                 echo 'Check out SCM'
                 checkout scm
                 script {
-                    if (params.GITARRO_PR_NUMBER != "") {
+                    if (params.GITARRO_PR_NUMBER != '') {
                         echo 'Check out Gitarro PR'
                         checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
                                   extensions       : [[$class: 'LocalBranch']],
@@ -53,8 +54,12 @@ pipeline {
                 echo 'Run tests'
                 script {
                     commands = "${gitarro_cmd} ${runtest}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                            commands = "${gitarro_local} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
                     }
                 }
                 sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"


### PR DESCRIPTION
- Added a PR_NUMBER parameter in PR Check jobs, to be able to run on a specific PR directly
- Add the PR_NUMBER to the title of PR Check jobs executed
- Fix rubocop pipeline test that needs a script contained in pipelines repo