### PR TITLE
Increase the time to check a PR to 2 days old

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -16,7 +16,7 @@ pipeline {
       repository = 'SUSE/spacewalk'
       gitarro_cmd = 'gitarro.ruby2.1'
       gitarro_local = 'ruby gitarro.rb'
-      check = " -r ${repository} -t placeholder --check --changed_since 3600"
+      check = " -r ${repository} -t placeholder --check --changed_since 172800"
     }
 
     agent { label 'suse-manager-unit-tests' }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
@@ -16,7 +16,7 @@ pipeline {
       repository = "uyuni-project/uyuni"
       gitarro_cmd = 'gitarro.ruby2.1'
       gitarro_local = 'ruby gitarro.rb'
-      check = " -r ${repository} -t placeholder --check --changed_since 3600"
+      check = " -r ${repository} -t placeholder --check --changed_since 172800"
     }
 
     agent { label 'suse-manager-unit-tests' }


### PR DESCRIPTION
Increasing from 1h to 2days the filter of PRs to check.
As we sometimes have issues in our Jenkins slaves, and that cause that we need to force-push our PR to be checked.
We have around 5-6 PR max younger than 2 days, so it should be fine. 
And it will safe us from some support discussions on IRC.