### PR TITLE
New force_test parameter on merge_enabled tets, so it will run always

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
@@ -25,7 +25,7 @@ pipeline {
                 " -g \"${env.WORKSPACE}\" "
 
         gitarro_enable_merging = "-r ${repository}" +
-                " -c merge_enabled -d \"Merging enabled (requires changelog_test passing)\" " +
+                " --force_test -c merge_enabled -d \"Merging enabled (requires changelog_test passing)\" " +
                 " -u ${env.BUILD_URL}" +
                 " -g \"${env.WORKSPACE}\" "
     }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog_test
@@ -25,7 +25,7 @@ pipeline {
                 " -g \"${env.WORKSPACE}\" "
 
         gitarro_enable_merging = "-r ${repository}" +
-                " -c merge_enabled -d \"Merging enabled (requires changelog_test passing)\" " +
+                " --force_test -c merge_enabled -d \"Merging enabled (requires changelog_test passing)\" " +
                 " -u ${env.BUILD_URL}" +
                 " -g \"${env.WORKSPACE}\" "
     }


### PR DESCRIPTION
New force_test parameter added on changelog_test pipelines for Uyuni and SUMA, so it will run always the merged_enabled test even if we don't have a comment or a checkbox to re-trigger it.
This is to fix a corner case, when the changelog_test fails, we mark the merged_enabled to false, then we re-run the changelog_test with the checkbox but the merged_enabled doesn't change its status (as it is not triggered because has not a checkbox marked in the PR description)