### PR TITLE
Finishing stage moved to always, junit, remove sumaform_env param

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_testsuite
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_testsuite
@@ -6,11 +6,12 @@ properties([
     disableConcurrentBuilds(),
 ])
 
+def deployed = false
+
 pipeline {
 
     parameters {
         string(defaultValue: 'Manager-3.2', description: 'Testsuite GitHub branch: It should match the value at manager-3.2-2obs', name: 'testsuite_branch')
-        string(defaultValue: '32/VARS-full-NUE.sh', description: 'Sumaform Test Runner environment to use', name: 'sumaform_env')
         string(defaultValue: 'galaxy-ci@suse.de', description: 'Email address to be used as recipient for the report', name: 'mailto')
     }
 
@@ -31,6 +32,7 @@ pipeline {
                 checkout scm
                 git branch: 'master', url: 'https://gitlab.suse.de/galaxy/sumaform-test-runner.git'
                 sh "bash jenkins-deploy.sh ${params.sumaform_env} ${params.mailto} ${params.testsuite_branch}"
+                script { deployed = true }
             }
         }
 
@@ -58,8 +60,8 @@ pipeline {
     post {
         always{
             script {
-                if (env.deployed == true){
-                    sh "TESTSUITE_SET=finishing bash jenkins-test-runner.sh ${params.sumaform_env}"
+                if (deployed == true){
+                    sh "TESTSUITE_SET=finishing bash jenkins-test-runner.sh ${params.sumaform_env} ||:"
                     publishHTML( target: [
                                 allowMissing: true,
                                 alwaysLinkToLastBuild: false,
@@ -68,6 +70,7 @@ pipeline {
                                 reportFiles: 'cucumber_report.html',
                                 reportName: "TestSuite Report"]
                     )
+                    junit allowEmptyResults: true, testResults: "results/build-${env.BUILD_NUMBER}/results_junit/*.xml"
                 }
             }
         }


### PR DESCRIPTION
On that PR we move some final actions from a regular stage to a post-stage, which is always triggered.

In addition:
-  we include junit test collection.
- we remove `sumaform_env` parameter, as having it, the pipeline will override the value set manually on each job. We will use the same pipeline for both NUE and PROVO env.