### PR TITLE
Reorganize folders

### DIFF
--- a/jenkins_pipelines/README.md
+++ b/jenkins_pipelines/README.md
@@ -4,12 +4,15 @@
 
 - 2) Manager performance testsuite
 
-- 3) Uyuni pipelines which are the same as 1)
+- 3) Manager and Uyuni testsuite pipelines for QA/QAM
+
+- 4) Uyuni pipelines which are the same as 1)
 
 
 This is not running anywhere, is only experimental code not in prod.
 
 - Manager Github pull-request cucumber functional tests
+
 
 ### Manager GitHub pull-request unit/tests
 
@@ -23,13 +26,19 @@ This pipelines use the same patterns, which is to use the gitarro tools for gith
 
 This dir contains pipelines related to scalabilty tests for suse-manager.
 
-#### How to make a pipeline from scratch 
+
+### Manager and Uyuni testsuite pipelines for QA/QAM
+
+This dir contains pipelines related to QA and QAM testsuites for suse-manager.
+
+
+### How to make a pipeline from scratch 
 
 If you are new to pipeline, start reading this:
 
 https://jenkins.io/doc/book/pipeline/getting-started/#defining-a-pipeline-in-scm
 
-##### Steps to create a pipeline:
+#### Steps to create a pipeline:
 
 0) Create a Jenkins Pipeline Job
 1) Configure Jenkins to clone from your custom PR Branch. ( in this way you can tests the pipeline before it get merged in master)  

--- a/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_testsuite
+++ b/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_testsuite
@@ -1,0 +1,87 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+])
+
+def deployed = false
+
+pipeline {
+
+    parameters {
+        // Note: We need to define this variable manually in our Jenkins configuration (to select the version we want to test)
+        // string(defaultValue: 'Manager-3.2', description: 'Testsuite GitHub branch: It should match the value at manager-3.2-2obs', name: 'testsuite_branch')
+        string(defaultValue: 'galaxy-ci@suse.de', description: 'Email address to be used as recipient for the report', name: 'mailto')
+    }
+
+    environment {
+      repository = 'SUSE/spacewalk'
+      deployed = false
+    }
+
+    agent { label 'sumaform-cucumber' }
+
+    triggers {
+        cron('H(0-30) 0-23/4 * * *')
+    }
+
+    stages {
+        stage('Deploy') {
+            steps {
+                checkout scm
+                git branch: 'master', url: 'https://gitlab.suse.de/galaxy/sumaform-test-runner.git'
+                sh "bash jenkins-deploy.sh ${params.sumaform_env} ${params.mailto} ${params.testsuite_branch}"
+                script { deployed = true }
+            }
+        }
+
+        stage('Core - Setup') {
+            steps {
+                script { env.deployed = true }
+                sh "TESTSUITE_SET=core bash jenkins-test-runner.sh ${params.sumaform_env}"
+            }
+        }
+
+        stage('Core - Initialize clients') {
+            steps {
+                sh "TESTSUITE_SET=init_clients RAKE_TASK=parallel bash jenkins-test-runner.sh ${params.sumaform_env}"
+            }
+        }
+        
+        stage('Secondary features') {
+            steps {
+                sh "TESTSUITE_SET=secondary bash jenkins-test-runner.sh ${params.sumaform_env} ||:"
+                sh "TESTSUITE_SET=secondary_parallelizable RAKE_TASK=parallel bash jenkins-test-runner.sh ${params.sumaform_env}"
+            }
+        }
+    }
+
+    post {
+        always{
+            script {
+                if (deployed == true){
+                    sh "TESTSUITE_SET=finishing bash jenkins-test-runner.sh ${params.sumaform_env} ||:"
+                    publishHTML( target: [
+                                allowMissing: true,
+                                alwaysLinkToLastBuild: false,
+                                keepAll: true,
+                                reportDir: "results/build-${env.BUILD_NUMBER}/cucumber_report/",
+                                reportFiles: 'cucumber_report.html',
+                                reportName: "TestSuite Report"]
+                    )
+                    junit allowEmptyResults: true, testResults: "results/build-${env.BUILD_NUMBER}/results_junit/*.xml"
+                }
+            }
+        }
+        success{
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_testsuite
+++ b/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_testsuite
@@ -11,12 +11,13 @@ def deployed = false
 pipeline {
 
     parameters {
-        string(defaultValue: 'Manager-3.2', description: 'Testsuite GitHub branch: It should match the value at manager-3.2-2obs', name: 'testsuite_branch')
+        // Note: We need to define this variable manually in our Jenkins configuration (to select the version we want to test)
+        // string(defaultValue: 'master', name: 'testsuite_branch')
         string(defaultValue: 'galaxy-ci@suse.de', description: 'Email address to be used as recipient for the report', name: 'mailto')
     }
 
     environment {
-      repository = 'SUSE/spacewalk'
+      repository = 'uyuni-project/uyuni'
       deployed = false
     }
 


### PR DESCRIPTION
When we created the testsuite pipeline, we store it in manager_prs, which is wrong.
This PR creates new folders for manager and uyuni testsuites, where we can include our pipelines for QA/QAM testsuites.