### PR TITLE
Temporary revert "Use synchronous workspace cleaning"

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -40,7 +40,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -78,7 +78,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
@@ -40,7 +40,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -84,7 +84,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -33,7 +33,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -93,7 +93,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -34,7 +34,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -70,7 +70,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -41,7 +41,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -79,7 +79,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
@@ -34,7 +34,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -69,7 +69,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
@@ -36,7 +36,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -73,7 +73,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_oracle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_oracle
@@ -44,7 +44,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -79,7 +79,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -44,7 +44,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -81,7 +81,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -42,7 +42,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -76,7 +76,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
@@ -40,7 +40,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -78,7 +78,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_sequencial_testsuite
+++ b/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_sequencial_testsuite
@@ -91,7 +91,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_testsuite
+++ b/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_testsuite
@@ -91,7 +91,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_testsuite/Jenkinsfile_qam_setup
+++ b/jenkins_pipelines/manager_testsuite/Jenkinsfile_qam_setup
@@ -78,7 +78,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/manager_testsuite/Jenkinsfile_qam_testsuite
+++ b/jenkins_pipelines/manager_testsuite/Jenkinsfile_qam_testsuite
@@ -78,7 +78,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -41,7 +41,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -80,7 +80,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_changelog_test
@@ -40,7 +40,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -84,7 +84,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
@@ -33,7 +33,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -91,7 +91,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -34,7 +34,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -69,7 +69,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -41,7 +41,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -77,7 +77,7 @@ pipeline {
 
     post {
         success {
-            cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+            cleanWs()
         }
     }
 }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
@@ -34,7 +34,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -69,7 +69,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
@@ -36,7 +36,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -73,7 +73,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -44,7 +44,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -80,7 +80,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -38,7 +38,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -72,7 +72,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -41,7 +41,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -80,7 +80,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
@@ -40,7 +40,7 @@ pipeline {
         stage('Clean Up Workspace') {
             steps {
                 echo 'Clean up previous workspace'
-                cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                cleanWs()
                 echo 'Check out SCM'
                 checkout scm
                 script {
@@ -78,7 +78,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_sequencial_testsuite
+++ b/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_sequencial_testsuite
@@ -89,7 +89,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }

--- a/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_testsuite
+++ b/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_testsuite
@@ -89,7 +89,7 @@ pipeline {
             script {
                 if (params.cleanWorkspace == true) {
                     echo 'Clean up current workspace, when job success.'
-                    cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+                    cleanWs()
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 315da00be5f40bf9048536141b49d4eb108e759d.

Reason: we need everyone rebasing their branches so they get https://github.com/uyuni-project/uyuni/pull/1555 and their tests are able to clean the leaked files.

Until that happens, sometimes synchronous workspace cleaning crashes while trying to cleanup a previous workspace.