### PR TITLE
Move sanity check to a separate stage

### DIFF
--- a/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_sequential_testsuite
+++ b/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_sequential_testsuite
@@ -57,6 +57,12 @@ pipeline {
             }
         }
 
+        stage('Sanity Check') {
+            steps {
+                sh "RAKE_NAMESPACE=cucumber RAKE_TASK=sanity_check TERRAFORM=${params.terraform} TERRAFORM_PLUGINS=${params.terraform_plugins} bash jenkins-test-runner.sh ${params.sumaform_env}"
+            }
+        }
+        
         stage('Core - Setup') {
             steps {
                 script { env.deployed = true }

--- a/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_testsuite
+++ b/jenkins_pipelines/manager_testsuite/Jenkinsfile_qa_testsuite
@@ -56,6 +56,12 @@ pipeline {
             }
         }
 
+        stage('Sanity Check') {
+            steps {
+                sh "RAKE_NAMESPACE=cucumber RAKE_TASK=sanity_check TERRAFORM=${params.terraform} TERRAFORM_PLUGINS=${params.terraform_plugins} bash jenkins-test-runner.sh ${params.sumaform_env}"
+            }
+        }
+
         stage('Core - Setup') {
             steps {
                 sh "RAKE_NAMESPACE=cucumber RAKE_TASK=core TERRAFORM=${params.terraform} TERRAFORM_PLUGINS=${params.terraform_plugins} bash jenkins-test-runner.sh ${params.sumaform_env}"

--- a/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_sequential_testsuite
+++ b/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_sequential_testsuite
@@ -55,6 +55,12 @@ pipeline {
             }
         }
 
+        stage('Sanity Check') {
+            steps {
+                sh "RAKE_NAMESPACE=cucumber RAKE_TASK=sanity_check TERRAFORM=${params.terraform} TERRAFORM_PLUGINS=${params.terraform_plugins} bash jenkins-test-runner.sh ${params.sumaform_env}"
+            }
+        }
+        
         stage('Core - Setup') {
             steps {
                 script { env.deployed = true }

--- a/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_testsuite
+++ b/jenkins_pipelines/uyuni_testsuite/Jenkinsfile_qa_testsuite
@@ -54,6 +54,12 @@ pipeline {
             }
         }
 
+        stage('Sanity Check') {
+            steps {
+                sh "RAKE_NAMESPACE=cucumber RAKE_TASK=sanity_check TERRAFORM=${params.terraform} TERRAFORM_PLUGINS=${params.terraform_plugins} bash jenkins-test-runner.sh ${params.sumaform_env}"
+            }
+        }
+        
         stage('Core - Setup') {
             steps {
                 sh "RAKE_NAMESPACE=cucumber RAKE_TASK=core TERRAFORM=${params.terraform} TERRAFORM_PLUGINS=${params.terraform_plugins} bash jenkins-test-runner.sh ${params.sumaform_env}"


### PR DESCRIPTION
Card: SUSE/spacewalk#10347

We want to have the sanity checks in a different stage of the testsuite, so if the sanity checks fails, the rest of the test suite is aborted.

Related PRs:

- Manager-3.2 SUSE/spacewalk#11101
- Manager-4.0 SUSE/spacewalk#11099
- Uyuni https://github.com/uyuni-project/uyuni/pull/2073