### PR TITLE
Jenkinsfile with terracumber

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-reference.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference.groovy
@@ -1,0 +1,42 @@
+def run(params) {
+    timestamps {
+        deployed = false
+        env.resultdir = "${WORKSPACE}/results"
+        env.resultdirbuild = "${resultdir}/${BUILD_NUMBER}"
+        env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform"
+        try {
+            stage('Clone terracumber, susemanager-ci and sumaform') {
+                // Create a directory for  to place the directory with the build results (if it does not exist)
+                sh "mkdir -p ${resultdir}"
+                git url: params.terracumber_gitrepo, branch: params.terracumber_ref
+                dir("susemanager-ci") {
+                    checkout scm
+                }
+                // Clone sumaform
+                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
+            }
+            stage('Deploy') {
+                // Provision the environment
+                if (params.terraform_bin_init) {
+                    env.TERRAFORM_INIT = '--init'
+                } else {
+                    env.TERRAFORM_INIT = ''
+                }
+                sh "set +x; source /home/jenkins/.credentials set -x; TERRAFORM=${params.terraform_bin} TERRAFORM_PLUGINS=${params.terraform_bin_plugins} ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
+                deployed = true
+            }
+        }
+        finally {
+            stage('Get results') {
+                if (!deployed) {
+                  // Send email
+                  sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                }
+                // Clean up old results
+                sh "./clean-old-results -r ${resultdir}"
+            }
+        }
+    }
+}
+
+return this

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -1,0 +1,84 @@
+def run(params) {
+    timestamps {
+        deployed = false
+        env.resultdir = "${WORKSPACE}/results"
+        env.resultdirbuild = "${resultdir}/${BUILD_NUMBER}"
+        // The junit plugin doesn't affect full paths
+        junit_resultdir = "results/${BUILD_NUMBER}/results_junit"
+        env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform"
+        try {
+            stage('Clone terracumber, susemanager-ci and sumaform') {
+                // Create a directory for  to place the directory with the build results (if it does not exist)
+                sh "mkdir -p ${resultdir}"
+                git url: params.terracumber_gitrepo, branch: params.terracumber_ref
+                dir("susemanager-ci") {
+                    checkout scm
+                }
+                // Clone sumaform
+                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
+            }
+            stage('Deploy') {
+                // Provision the environment
+                if (params.terraform_bin_init) {
+                    env.TERRAFORM_INIT = '--init'
+                } else {
+                    env.TERRAFORM_INIT = ''
+                }
+                sh "set +x; source /home/jenkins/.credentials set -x; TERRAFORM=${params.terraform_bin} TERRAFORM_PLUGINS=${params.terraform_bin_plugins} ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
+                deployed = true
+            }
+            stage('Sanity Check') {
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:sanity_check'"
+            }
+            
+            stage('Core - Setup') {
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:core'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reposync'"
+            }
+            stage('Core - Initialize clients') {
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:init_clients'"
+            }
+            stage('Secondary features') {
+                def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
+                def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:secondary_parallelizable'", returnStatus:true
+                sh "exit \$(( ${statusCode1}|${statusCode2} ))"
+            }
+        }
+        finally {
+            stage('Get results') {
+                def error = 0
+                if (deployed) {
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake cucumber:finishing failed")
+                        error = 1
+                    }
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake utils:generate_test_repor failed")
+                        error = 1
+                    }
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+                    publishHTML( target: [
+                                allowMissing: true,
+                                alwaysLinkToLastBuild: false,
+                                keepAll: true,
+                                reportDir: "${resultdirbuild}/cucumber_report/",
+                                reportFiles: 'cucumber_report.html',
+                                reportName: "TestSuite Report"]
+                    )
+                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+                }
+                // Send email
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                // Clean up old results
+                sh "./clean-old-results -r ${resultdir}"
+                sh "exit ${error}"
+            }
+        }
+    }
+}
+
+return this

--- a/jenkins_pipelines/environments/manager-3.2-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-3.2-cucumber-NUE
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'Manager-3.2', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-3.2-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-3.2-cucumber-PRV
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'Manager-3.2', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-3.2-reference-PRV
+++ b/jenkins_pipelines/environments/manager-3.2-reference-PRV
@@ -1,0 +1,26 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H 3 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'Manager-4.0', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'Manager-4.0', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.0-reference-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-reference-NUE
@@ -1,0 +1,26 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H 2 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.0-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-reference-PRV
@@ -1,0 +1,26 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H 2 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-Head-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-Head-cucumber-NUE
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-projects/uyuni.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Head-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-Head-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-reference-NUE
@@ -1,0 +1,26 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H 1 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'Manager-4.0', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-TEST-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-cucumber
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+    disableConcurrentBuilds(),
+    parameters([
+        string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
+        string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+        string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-NUE.tf', description: 'Path to the tf file to be used'),
+        string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+        string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+        choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+        choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+        choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+        string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+        string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+        booleanParam(name: 'terraform_bin_init', defaultValue: false, description: 'Call terraform_bin init (needed if modules are added or changes)')
+    ])
+])
+
+node('sumaform-cucumber') {
+    cron('H H/4 * * *')
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+    pipeline.run(params)
+}

--- a/terracumber_config/mail_templates/mail-template-jenkins-env-fail.txt
+++ b/terracumber_config/mail_templates/mail-template-jenkins-env-fail.txt
@@ -1,0 +1,8 @@
+#################################################################
+# SUMMARY
+#################################################################
+Build:   $urlprefix/$timestamp
+Console: $urlprefix/$timestamp/console
+Results: $urlprefix/$timestamp/execution/node/4/ws/results/$timestamp
+
+Environment failed to be created, so no spacewalk-debug tarball or cucumber results are available.

--- a/terracumber_config/mail_templates/mail-template-jenkins-refenv-fail.txt
+++ b/terracumber_config/mail_templates/mail-template-jenkins-refenv-fail.txt
@@ -1,0 +1,10 @@
+#################################################################
+# SUMMARY
+#################################################################
+Build:   $urlprefix/$timestamp
+Console: $urlprefix/$timestamp/console
+Results: $urlprefix/$timestamp/execution/node/4/ws/results/$timestamp
+
+Environment failed to be created. Some or all instances are maybe not available.
+
+Please check the console output or the results.

--- a/terracumber_config/mail_templates/mail-template-jenkins.txt
+++ b/terracumber_config/mail_templates/mail-template-jenkins.txt
@@ -1,0 +1,19 @@
+#################################################################
+# SUMMARY
+#################################################################
+Build:   $urlprefix/$timestamp
+Console: $urlprefix/$timestamp/console
+Results: $urlprefix/$timestamp/execution/node/4/ws/results/$timestamp
+Report:  $urlprefix/$timestamp/execution/node/4/ws/results/$timestamp/cucumber_report/cucumber_report.html
+Logs:    $urlprefix/$timestamp/execution/node/4/ws/results/$timestamp/spacewalk-debug.tar.bz2
+
+#################################################################
+# SCENARIOS
+#################################################################
+Total:   $tests
+Passed:  $passed
+Failed:  $failures
+Errors:  $errors
+Skipped: $skipped
+
+$failures_log

--- a/terracumber_config/mail_templates/mail-template-local-env-fail.txt
+++ b/terracumber_config/mail_templates/mail-template-local-env-fail.txt
@@ -1,0 +1,6 @@
+#################################################################
+# SUMMARY
+#################################################################
+Results: $urlprefix-$timestamp
+
+Environment failed to be created, so no spacewalk-debug tarball or cucumber results are available.

--- a/terracumber_config/mail_templates/mail-template-local-refenv-fail.txt
+++ b/terracumber_config/mail_templates/mail-template-local-refenv-fail.txt
@@ -1,0 +1,8 @@
+#################################################################
+# SUMMARY
+#################################################################
+Results: $urlprefix-$timestamp
+
+Environment failed to be created. Some or all instances are maybe not available.
+
+Please check the console output or the results.

--- a/terracumber_config/mail_templates/mail-template-local.txt
+++ b/terracumber_config/mail_templates/mail-template-local.txt
@@ -1,0 +1,17 @@
+#################################################################
+# SUMMARY
+#################################################################
+Results: $urlprefix-$timestamp
+Report:  $urlprefix-$timestamp/cucumber_report/cucumber_report.html
+Logs:    $urlprefix-$timestamp/spacewalk-debug.tar.bz2
+ 
+#################################################################
+# SCENARIOS
+#################################################################
+Total:   $tests
+Passed:  $passed
+Failed:  $failures
+Errors:  $errors
+Skipped: $skipped
+
+$failures_log

--- a/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
@@ -1,0 +1,166 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-3.2/job/manager-3.2-cucumber-NUE"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-3.2"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results 3.2-NUE $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results 3.2-NUE: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "3.2-nightly"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "sles12sp3", "sles12sp4", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "suma-32-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:71"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:66"
+      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:72"
+      }
+    }
+    cli-sles12sp4 = {
+      name = "cli-sles12"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:67"
+      }
+    }
+    min-sles12sp4 = {
+      name = "min-sles12"
+      provider_settings = {
+        mac = "AA:B2:93:00:21:68"
+      }
+    }
+    minssh-sles12sp4 = {
+      name = "minssh-sles12"
+      provider_settings = {
+        mac = "AA:B2:93:00:21:69"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:70"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:7A"
+      }
+    }
+    min-pxeboot = {
+      present = true
+    }
+  }
+  provider_settings = {
+    pool               = "ssd"
+    bridge             = "br0"
+    additional_network = "192.168.32.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
@@ -1,0 +1,168 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-3.2/job/manager-3.2-cucumber-PRV"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-3.2"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results 3.2-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results 3.2-PRV: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://metropolis.prv.suse.net/system"
+}
+
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "3.2-nightly"
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  
+  images = ["centos7", "opensuse150", "sles12sp3", "sles12sp4", "ubuntu1804"]
+
+  use_avahi = false
+  name_prefix = "suma-32-"
+  domain = "prv.suse.net"
+  from_email = "root@suse.de"
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  mirror = "minima-mirror.prv.suse.net"
+  use_mirror_images = true
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "52:54:00:02:f0:55"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "52:54:00:01:37:28"
+      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "52:54:00:1d:af:5a"
+      }
+    }
+    cli-sles12sp4 = {
+      name = "cli-sles12"
+      provider_settings = {
+        mac = "52:54:00:55:bf:9b"
+      }
+    }
+    min-sles12sp4 = {
+      name = "min-sles12"
+      provider_settings = {
+        mac = "52:54:00:e7:1e:fa"
+      }
+    }
+    minssh-sles12sp4 = {
+      name = "minssh-sles12"
+      provider_settings = {
+        mac = "52:54:00:99:c9:f5"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "52:54:00:4f:17:48"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "52:54:00:4f:17:49"
+      }
+    }
+    min-pxeboot = {
+      present = true
+    }
+  }
+  provider_settings = {
+      pool = "ssd"
+      bridge = "br0"
+      additional_network = "192.168.32.0/24"
+  }
+}
+  
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
@@ -1,0 +1,172 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-3.2/job/manager-3.2-reference-PRV"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-3.2"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+// Not really used in this pipeline, as we do not send emails on success (no cucumber results)
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results REF3.2-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results REF3.2-PRV: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://metropolis.prv.suse.net/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  
+  name_prefix       = "suma-ref32-"
+  use_avahi         = false
+  domain            = "prv.suse.net"
+  images            = ["centos7", "sles12sp4", "ubuntu1804"]
+  mirror            = "minima-mirror.prv.suse.net"
+  use_mirror_images = true
+
+  provider_settings = {
+    pool         = "ssd"
+    network_name = null
+    bridge       = "br0"
+  }
+}
+
+module "srv" {
+  source                  = "./modules/server"
+  base_configuration      = module.base.configuration
+  product_version         = "3.2-nightly"
+  name                    = "srv"
+  monitored               = true
+  use_os_released_updates = true
+  disable_download_tokens = false
+  from_email              = "root@suse.de"
+  channels = [
+    "sles12-sp4-pool-x86_64",
+    "sles12-sp4-updates-x86_64",
+    "sle-module-containers12-pool-x86_64-sp4",
+    "sle-module-containers12-updates-x86_64-sp4"]
+
+  provider_settings = {
+    mac    = "52:54:00:c6:48:b9"
+    memory = 8192
+  }
+}
+
+module "cli-sles12" {
+  source             = "./modules/client"
+  base_configuration = module.base.configuration
+  product_version    = "3.2-nightly"
+  name               = "cli-sles12"
+  image              = "sles12sp4"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "52:54:00:93:17:5f"
+  }
+}
+
+module "min-sles12" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "3.2-nightly"
+  name               = "min-sles12"
+  image              = "sles12sp4"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "52:54:00:a0:d0:ce"
+  }
+}
+
+module "min-centos7" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "3.2-nightly"
+  name               = "min-centos7"
+  image              = "centos7"
+
+  server_configuration = module.srv.configuration
+
+  provider_settings = {
+    mac = "52:54:00:33:1a:ad"
+  }
+}
+
+module "min-ubuntu1804" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "3.2-nightly"
+  name               = "min-ubuntu1804"
+  image              = "ubuntu1804"
+
+  server_configuration = module.srv.configuration
+
+  provider_settings = {
+    mac = "52:54:00:e0:ed:07"
+  }
+}

--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -1,0 +1,177 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-cucumber-NUE"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.0"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results 4.0-NUE $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results 4.0-NUE: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "4.0-nightly"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "sles15sp1", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "suma-40-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:45"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:40"
+      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:46"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:41"
+      }
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:42"
+      }
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:43"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:44"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:47"
+      }
+    }
+    min-pxeboot = {
+      present = true
+      image = "sles15sp1"
+    }
+    min-kvm = {
+      image = "sles15sp1"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:48"
+      }
+    }
+  }
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -1,0 +1,179 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-cucumber-PRV"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.0"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results 4.0-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results 4.0-PRV: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://metropolis.prv.suse.net/system"
+}
+
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "4.0-nightly"
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  
+  images = ["centos7", "opensuse150", "sles15sp1", "ubuntu1804"]
+
+  use_avahi = false
+  name_prefix = "suma-40-"
+  domain = "prv.suse.net"
+  from_email = "root@suse.de"
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  mirror = "minima-mirror.prv.suse.net"
+  use_mirror_images = true
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "52:54:00:00:00:06"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "52:54:00:00:00:01"
+      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "52:54:00:00:00:07"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "52:54:00:00:00:02"
+      }
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "52:54:00:00:00:03"
+      }
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "52:54:00:00:00:04"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "52:54:00:00:00:05"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "52:54:00:00:00:08"
+      }
+    }
+    min-pxeboot = {
+      present = true
+      image = "sles15sp1"
+    }
+    min-kvm = {
+      image = "sles15sp1"
+      provider_settings = {
+        mac = "52:54:00:00:00:09"
+      }
+    }
+  }
+  provider_settings = {
+    pool = "ssd"
+    network_name = null
+    bridge = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+  
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
@@ -1,0 +1,178 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-reference-NUE"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.0"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+// Not really used in this pipeline, as we do not send emails on success (no cucumber results)
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results REF4.0-NUE $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results REF4.0-NUE: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  name_prefix = "suma-ref40-"
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+  images      = ["centos7", "sles15sp1", "ubuntu1804"]
+
+  provider_settings = {
+    pool         = "ssd"
+    network_name = null
+    bridge       = "br0"
+  }
+}
+
+module "srv" {
+  source                  = "./modules/server"
+  base_configuration      = module.base.configuration
+  product_version         = "4.0-nightly"
+  name                    = "srv"
+  monitored               = true
+  use_os_released_updates = true
+  disable_download_tokens = false
+  from_email              = "root@suse.de"
+  channels                = ["sle-product-sles15-pool-x86_64", "sle-product-sles15-updates-x86_64", "sle-module-basesystem15-pool-x86_64", "sle-module-basesystem15-updates-x86_64", "sle-module-containers15-pool-x86_64", "sle-module-containers15-updates-x86_64"]
+
+  provider_settings = {
+    mac    = "AA:B2:93:00:00:50"
+    memory = 8192
+  }
+}
+
+module "cli-sles15" {
+  source             = "./modules/client"
+  base_configuration = module.base.configuration
+  product_version    = "4.0-nightly"
+  name               = "cli-sles15"
+  image              = "sles15sp1"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:51"
+  }
+}
+
+module "min-sles15" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "4.0-nightly"
+  name               = "min-sles15"
+  image              = "sles15sp1"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:52"
+  }
+}
+
+module "minssh-sles15" {
+  source                  = "./modules/sshminion"
+  base_configuration      = module.base.configuration
+  name                    = "minssh-sles15"
+  image                   = "sles15sp1"
+
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:53"
+  }
+}
+
+module "min-centos7" {
+  source               = "./modules/minion"
+  base_configuration   = module.base.configuration
+  product_version      = "4.0-nightly"
+  name                 = "min-centos7"
+  image                = "centos7"
+  server_configuration = module.srv.configuration
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:54"
+  }
+}
+
+module "min-ubuntu1804" {
+  source               = "./modules/minion"
+  base_configuration   = module.base.configuration
+  product_version      = "4.0-nightly"
+  name                 = "min-ubuntu1804"
+  image                = "ubuntu1804"
+  server_configuration = module.srv.configuration
+
+  provider_settings = {
+    mac    = "AA:B2:93:00:00:57"
+    memory = 1024
+  }
+}

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
@@ -1,0 +1,168 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-reference-PRV"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.0"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+// Not really used in this pipeline, as we do not send emails on success (no cucumber results)
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results REF4.0-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results REF4.0-PRV: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://metropolis.prv.suse.net/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  name_prefix       = "suma-ref40-"
+  use_avahi         = false
+  domain            = "prv.suse.net"
+  images            = ["centos7", "sles15sp1", "ubuntu1804"]
+  mirror            = "minima-mirror.prv.suse.net"
+  use_mirror_images = true
+
+  provider_settings = {
+    pool         = "ssd"
+    network_name = null
+    bridge       = "br0"
+  }
+}
+
+module "srv" {
+  source                  = "./modules/server"
+  base_configuration      = module.base.configuration
+  product_version         = "4.0-nightly"
+  name                    = "srv"
+  monitored               = true
+  use_os_released_updates = true
+  disable_download_tokens = false
+  from_email              = "root@suse.de"
+  channels                = ["sle-product-sles15-pool-x86_64", "sle-product-sles15-updates-x86_64", "sle-module-basesystem15-pool-x86_64", "sle-module-basesystem15-updates-x86_64", "sle-module-containers15-pool-x86_64", "sle-module-containers15-updates-x86_64"]
+
+  provider_settings = {
+    mac    = "52:54:00:00:00:10"
+    memory = 8192
+  }
+}
+
+module "cli-sles15" {
+  source             = "./modules/client"
+  base_configuration = module.base.configuration
+  product_version    = "4.0-nightly"
+  name               = "cli-sles15"
+  image              = "sles15sp1"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "52:54:00:00:00:11"
+  }
+}
+
+module "min-sles15" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "4.0-nightly"
+  name               = "min-sles15"
+  image              = "sles15sp1"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "52:54:00:00:00:12"
+  }
+}
+
+module "min-centos7" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "4.0-nightly"
+  name               = "min-centos7"
+  image              = "centos7"
+
+  server_configuration   = module.srv.configuration
+  auto_connect_to_master = false
+
+  provider_settings = {
+    mac = "52:54:00:00:00:14"
+  }
+}
+
+module "min-ubuntu1804" {
+  source               = "./modules/minion"
+  base_configuration   = module.base.configuration
+  product_version      = "4.0-nightly"
+  name                 = "min-ubuntu1804"
+  image                = "ubuntu1804"
+  server_configuration = module.srv.configuration
+
+  provider_settings = {
+    mac = "52:54:00:00:00:17"
+  }
+}

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -1,0 +1,177 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-cucumber-NUE"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results Head $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results Head: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "head"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "suma-40-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:25"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:20"
+      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:26"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:21"
+      }
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:22"
+      }
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:23"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:24"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:28"
+      }
+    }
+    min-pxeboot = {
+      present = true
+      image = "sles15sp1"
+    }
+    min-kvm = {
+      image = "sles15sp1"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:29"
+      }
+    }
+  }
+  provider_settings = {
+    pool = "ssd"
+    network_name = null
+    bridge = "br0"
+    additional_network = "192.168.41.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -1,0 +1,163 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-reference-NUE"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "master"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+// Not really used in this pipeline, as we do not send emails on success (no cucumber results)
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results RefHead-NUE $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results RefHead-NUE: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://cokerunner.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  name_prefix = "suma-refhead-"
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+  images      = ["centos7", "sles15sp1", "sles15sp2", "ubuntu1804"]
+  provider_settings = {
+    pool         = "ssd"
+    network_name = null
+    bridge       = "br2"
+  }
+}
+
+module "srv" {
+  source             = "./modules/server"
+  base_configuration = module.base.configuration
+  product_version    = "head"
+  name               = "srv"
+
+  use_os_released_updates = true
+  disable_download_tokens = false
+  from_email              = "root@suse.de"
+  channels                = ["sle-product-sles15-sp1-pool-x86_64", "sle-product-sles15-sp1-updates-x86_64", "sle-module-basesystem15-sp1-pool-x86_64", "sle-module-basesystem15-sp1-updates-x86_64", "sle-module-containers15-sp1-pool-x86_64", "sle-module-containers15-sp1-updates-x86_64", "sle-manager-tools15-pool-x86_64-sp1", "sle-manager-tools15-updates-x86_64-sp1", "sle-manager-tools15-beta-pool-x86_64-sp1", "sle-manager-tools15-beta-updates-x86_64-sp1"]
+
+  provider_settings = {
+    mac    = "AA:B2:93:00:00:30"
+    memory = 8192
+  }
+}
+
+module "cli-sles15" {
+  source             = "./modules/client"
+  base_configuration = module.base.configuration
+  product_version    = "head"
+  name               = "cli-sles15"
+  image              = "sles15sp1"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:31"
+  }
+}
+
+module "min-sles15" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "head"
+  name               = "min-sles15"
+  image              = "sles15sp1"
+
+  server_configuration    = module.srv.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:32"
+  }
+}
+
+module "min-centos7" {
+  source               = "./modules/minion"
+  base_configuration   = module.base.configuration
+  product_version      = "head"
+  name                 = "min-centos7"
+  image                = "centos7"
+  server_configuration = module.srv.configuration
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:34"
+  }
+}
+
+module "min-ubuntu1804" {
+  source               = "./modules/minion"
+  base_configuration   = module.base.configuration
+  product_version      = "head"
+  name                 = "min-ubuntu1804"
+  image                = "ubuntu1804"
+  server_configuration = module.srv.configuration
+
+  provider_settings = {
+    mac = "AA:B2:93:00:00:37"
+  }
+}

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -1,0 +1,158 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-Hexagon-cucumber"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.0"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results TEST-HEXAGON $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results TEST-HEXAGON: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://cthulu.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "4.0-nightly"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "suma-testhexagon-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:B4"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:B0"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Hexagon/SLE_15_SP1/"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:B1"
+      }
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:B3"
+      }
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:B5"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:B2"
+      }
+    }
+  }
+  provider_settings = {
+    pool         = "ssd"
+    network_name = null
+    bridge       = "br0"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -1,0 +1,212 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-cucumber"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.0"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results TEST $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results TEST: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://cthulu.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "4.0-nightly"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "suma-test-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac    = "AA:B2:93:00:00:63"
+      }
+//      branch = "fix-login"
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:60"
+      }
+//      additional_repos = {
+//        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_15_SP2/"
+//        Server_repo = "http://dist.nue.suse.com/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Server-Applications-POOL-x86_64-Media1/"
+//        Base_repo = "http://dist.nue.suse.com/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Basesystem-POOL-x86_64-Media1/"
+//        Web_repo = "http://dist.nue.suse.com/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Web-Scripting-POOL-x86_64-Media1/"
+//      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:86"
+      }
+      additional_repos = {
+        //Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_15_SP2/"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:61"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:62"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:64"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:65"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:68"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04/"
+      }
+    }
+    min-pxeboot = {
+      present = true
+      image = "sles15sp1"
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    min-kvm = {
+      image = "sles15sp1"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:69"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+  }
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br0"
+    additional_network = "192.168.140.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -1,0 +1,209 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-Naica-cucumber"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/uyuni-project/uyuni.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results TEST-NAICA $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results TEST-NAICA: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://cthulu.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "head"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "suma-testnaica-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac    = "AA:B2:93:00:01:03"
+      }
+//      branch = "fix-login"
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:01:00"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Naica/SLE_15_SP2/"
+      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "AA:B2:93:00:01:06"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Naica/SLE_15_SP2/"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:01"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:02"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:04"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:01:05"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:01:07"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04/"
+      }
+    }
+    min-pxeboot = {
+      present = true
+      image = "sles15sp1"
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+    min-kvm = {
+      image = "sles15sp1"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:08"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
+      }
+      additional_packages = ["python2-salt"]
+    }
+  }
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br0"
+    additional_network = "192.168.142.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -1,0 +1,163 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-Orion-cucumber"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='Uyuni' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/uyuni-project/uyuni.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results TEST-ORION $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results TEST-ORION: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://cthulu.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "uyuni-master"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "opensuse151", "sles15sp1", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "suma-testorion-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  portus_uri = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:A4"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:A0"
+      }
+      additional_repos = {
+        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Orion/openSUSE_Leap_15.1/"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:A1"
+      }
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:A3"
+      }
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:A5"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:A2"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:A6"
+      }
+    }
+  }
+  provider_settings = {
+    pool         = "ssd"
+    network_name = null
+    bridge       = "br0"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -1,0 +1,176 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-cucumber-NUE"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='Uyuni' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/uyuni-project/uyuni.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results Uyuni-Master $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results Uyuni-Master: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "uyuni-master"
+  
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse150", "opensuse151", "sles15sp1", "ubuntu1804"]
+
+  use_avahi    = false
+  name_prefix  = "uyuni-master-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  portus_uri      = "portus.mgr.suse.de:5000/cucutest"
+  portus_username = "cucutest"
+  portus_password = "cucusecret"
+
+  server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    ctl = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:05"
+      }
+    }
+    srv = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:00"
+      }
+    }
+    pxy = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:06"
+      }
+    }
+    cli-sles12sp4 = {
+      image = "sles15sp1"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:01"
+      }
+    }
+    min-sles12sp4 = {
+      image = "sles15sp1"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:02"
+      }
+    }
+    minssh-sles12sp4 = {
+      image = "sles15sp1"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:03"
+      }
+    }
+    min-centos7 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:04"
+      }
+    }
+    min-ubuntu1804 = {
+      provider_settings = {
+        mac = "AA:B2:93:00:00:08"
+      }
+    }
+    min-pxeboot = {
+      present = true
+      image = "sles15sp1"
+    }
+    min-kvm = {
+      image = "opensuse151"
+      provider_settings = {
+        mac = "AA:B2:93:00:00:07"
+      }
+    }
+  }
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br0"
+    additional_network = "192.168.141.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}


### PR DESCRIPTION
Tested with 3.2 (full and refenv), Test-Naica and Uyuni-Master.

This change, besides using sumaform, allows pipelines with separate parameters for each environment.

The target is removing `manager_testsuite` and `uyuni_testsuite` after everything is migrated.