### PR TITLE
Improve the doc, including new stuff about terracumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # susemanager-ci
 
-CI Automation for SUSE Manager.
+CI Automation for [SUSE Manager](https://www.suse.com/products/suse-manager/) and [Uyuni](https://www.uyuni-project.org/)
 
-## Jenkins pipelines 
+# Contents
 
-This dir contain the Jenkins pipeline we use for Jenkins.
+- [jenkins_pipelines](jenkins_pipelines): Jenkins pipeline definitions
+- [terracumber_config](terracumber_config): Configuration files for terracumber, used by some of the Jenkins pipelines
 
-For details have look [here](jenkins_pipelines/README.md)
+## Jenkins pipeline definitions
+
+This directory contain the Jenkins pipeline we use for Jenkins.
+
+For details have look at [jenkins_pipelines/README.md](jenkins_pipelines/README.md)
+
+## Configuration files for terracumber
+
+This directory contains the configuration files for terracumber that are used by the testsuite and reference enviroment pipelines.
+
+For details have a look at [terracumber_config/README.md](terracumber_config/README.md)
+

--- a/jenkins_pipelines/README.md
+++ b/jenkins_pipelines/README.md
@@ -1,23 +1,22 @@
-# Pipelines for SUSE-Manager
+# Contents
 
-- [Manager testsuite pipelines for QA/QAM](manager_testsuite)
-- [Uyuni testsuite pipelines for QA/QAM](uyuni_testsuite)
-- [Manager PR Checks](manager_prs)
-- [Uyuni PR Checks](uyuni_prs)
-- [POC Cucumber Testsuite per PR](cucumber_per_prs)
+- [environments](environments/): Testsuite (cucumber) and reference environments
+- [manager_testsuite](manager_testsuite/): Manager testsuite pipelines for QA/QAM (deprecated)
+- [uyuni_testsuite](uyuni_testsuite/): Uyuni testsuite pipelines for QA/QAM (deprecated)
+- [manager_prs](manager_prs/): Manager PR Checks
+- [uyuni_prs](uyuni_prs/): Uyuni PR Checks
 
+## Testsuite (cucumber) and reference environments
 
-### Manager GitHub pull-request unit/tests
+The directory contains jobs definitions for all of our testsuite and reference environment jobs.
 
-This directory contains all pipelines that are executed for testing prs for spacewalk.
+Check [environments/README.md](environments/README.md) for more details.
 
-This pipelines use the same patterns, which is to use the gitarro tools for github PRS.
-1) Use gitarro https://github.com/openSUSE/gitarro
+## Manager and Uyuni testsuite pipelines for QA/QAM (deprecated)
 
-### Manager and Uyuni testsuite pipelines for QA/QAM
+**WARNING:** This is deprecrated and only exists until QAM jobs can be migrated to the new pipelines with terracumber at [environments](environments/) folder.
 
-This dir contains pipelines related to QA and QAM testsuites for suse-manager.
-
+This directory contains pipelines related to QA and QAM testsuites for suse-manager.
 
 ### How to make a pipeline from scratch 
 
@@ -31,3 +30,10 @@ https://jenkins.io/doc/book/pipeline/getting-started/#defining-a-pipeline-in-scm
 1) Configure Jenkins to clone from your custom PR Branch. ( in this way you can tests the pipeline before it get merged in master)  
 2) When the PR is merged, update your Job Pipeline to use the **master** branch
 3) Create a directory if you are creating pipelines for a special topic. Otherwise add it in the proper namespaces.
+
+## Manager PR Checks/Uyuni PR Checks
+
+This directory contains all pipelines that are executed for testing prs for spacewalk.
+
+This pipelines use the same patterns, which is to use the gitarro tools for github PRS.
+1) Use gitarro https://github.com/openSUSE/gitarro

--- a/jenkins_pipelines/environments/README.md
+++ b/jenkins_pipelines/environments/README.md
@@ -1,0 +1,32 @@
+# Contents
+
+This directory contains the Jenkinsfiles used by each one of our cucumber or reference Jenkins jobs.
+
+We use [Scripted Pipelines](https://www.jenkins.io/doc/book/pipeline/syntax/#scripted-pipeline) in this folder and **note** [Declarative Pipelines](https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline).
+
+The reason is that while Declarative Pipelines are easier, they are not enough flexible for what we need, and they don't really allow to easy reuse code.
+
+# Files
+
+Each file defines the parameters (and default values), cron configuration and old build removal for each job. Then the correct code from `commons` folder is called.
+
+If you want to run a build for a Job changing a parameter value only once, you can do it from Jenkins.
+
+If you want to make that change permanent for several builds (or forever), then you need to edit the Job's file here. Just change the default value.
+
+For `manager-Test*-cucumber` jobs, squads can also decide to add more parameters, but it's strongly recommended that we keep the same parameters for all jobs, so maintenance is easier.
+
+**NOTE:** The old pipelines at [../manager_testsuite](../manager_testsuite) and [../uyuni_testsuite](../uyuni_testsuite) are now deprecated and should not be maintained. They are only there until migration of the QA jobs is possible.
+
+# "common" folder
+
+Contains the real deal. The code to run the steps such as a git cloning, terracumber provisioning, cucumber testsuite steps, etc.
+
+Currently there are two groovy files:
+
+- [common/pipeline.groovy](common/pipeline.groovy) is used on jobs that run a cucumber testsuite.
+- [pipeline-reference.groovy](pipeline-reference.groovy) is used on jobs that provisiong reference environments (they don't use cucumber at all)
+
+At some point we should consider a refactor of the two files, to unify code that is used at both "pipelines".
+
+Needless to say, new groovy files can be defined if your needs are different.

--- a/terracumber_config/README.md
+++ b/terracumber_config/README.md
@@ -1,0 +1,8 @@
+# Contents
+
+This directory contains the  files used by terracumber to create an environment and run cucumber (except for reference environments).
+
+- [tf_files](tf_files/): contains the terraform files describing the bascis environment, and variables
+- [mail_templates](mail_templates/): contains the mail templates that are used for sending email. Each terraform file from the previous folder makes reference to two templates: one for cucumber results, the other when the environment fails to be created.
+
+For more information refer to the terracumber documentation.


### PR DESCRIPTION
Small rewrite to:
- Add information about new scripted pipelines used for testsuite and reference environments (also using terraform).
- Add links, to easy navigation
- Add more information about the contents of each folder
- Mark the old testsuite/reference pipelines as deprecated.

Other than the diff, you can also review the doc itself at https://github.com/juliogonzalez/susemanager-ci/tree/improve-doc