### PR TITLE
Renaming modules matching images used

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -122,21 +122,21 @@ module "cucumber_testsuite" {
         mac = "AA:B2:93:00:00:46"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:41"
       }
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:42"
       }
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -124,21 +124,21 @@ module "cucumber_testsuite" {
         mac = "52:54:00:00:00:07"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:02"
       }
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:03"
       }
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -122,21 +122,21 @@ module "cucumber_testsuite" {
         mac = "AA:B2:93:00:00:26"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:21"
       }
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:22"
       }
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -127,21 +127,21 @@ module "cucumber_testsuite" {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Hexagon/SLE_15_SP2/"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:B1"
       }
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:B3"
       }
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -131,7 +131,7 @@ module "cucumber_testsuite" {
         //Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_15_SP2/"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
@@ -142,7 +142,7 @@ module "cucumber_testsuite" {
       }
       additional_packages = ["python2-salt"]
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
@@ -153,7 +153,7 @@ module "cucumber_testsuite" {
       }
       additional_packages = ["python2-salt"]
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -128,7 +128,7 @@ module "cucumber_testsuite" {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Naica/SLE_15_SP2/"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
@@ -139,7 +139,7 @@ module "cucumber_testsuite" {
       }
       additional_packages = ["python2-salt"]
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
@@ -150,7 +150,7 @@ module "cucumber_testsuite" {
       }
       additional_packages = ["python2-salt"]
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -119,21 +119,21 @@ module "cucumber_testsuite" {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Orion/openSUSE_Leap_15.1/"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:A1"
       }
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:A3"
       }
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -121,21 +121,21 @@ module "cucumber_testsuite" {
         mac = "AA:B2:93:00:00:06"
       }
     }
-    cli-sles12sp4 = {
+    cli-sles15sp1 = {
       image = "sles15sp1"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:01"
       }
     }
-    min-sles12sp4 = {
+    min-sles15sp1 = {
       image = "sles15sp1"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:02"
       }
     }
-    minssh-sles12sp4 = {
+    minssh-sles15sp1 = {
       image = "sles15sp1"
       name = "minssh-sles15"
       provider_settings = {


### PR DESCRIPTION
This PR fix the name of the module matching the image used, it's harmless, as in fact we are not using it anywhere.

Still, the attribute "name" must be updated, from sles15 to sles15sp1, but that will imply changes in the testsuite code too.