### PR TITLE
Upgrade Ruby2.1 to Ruby2.5

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -28,7 +28,7 @@ pipeline {
         // the actual test is the git repo (inside spacewalk)
         test = "susemanager-utils/testing/automation/backend-unittest-pgsql.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
     }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
@@ -20,7 +20,7 @@ pipeline {
 
     environment {
         repository = "SUSE/spacewalk"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         gitarro_changelog_test = "-r ${repository}" +
                 " -c changelog_test -d \"test if changelog was updated\" " +

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -18,7 +18,7 @@ pipeline {
 
     environment {
       repository = 'SUSE/spacewalk'
-      gitarro_cmd = 'gitarro.ruby2.1'
+      gitarro_cmd = 'gitarro.ruby2.5'
       gitarro_local = 'ruby gitarro.rb'
       check = " -r ${repository} -t placeholder --check --changed_since 172800"
     }

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         javacheckstyle_test = "-r SUSE/spacewalk" +
                 " -c java_lint_checkstyle -d \"java-checkstyle\" " +

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -29,7 +29,7 @@ pipeline {
         // the actual test is the git repo
         test = "susemanager-utils/testing/automation/java-unittests-pgsql.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         jslint_test = "-r SUSE/spacewalk" +
                 " -c javascript_lint -d \"javascript-lint\" " +

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
@@ -25,7 +25,7 @@ pipeline {
         filter = 'testsuite/'
         test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/rubocop.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro/gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_oracle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_oracle
@@ -26,7 +26,7 @@ pipeline {
         filter = "schema/spacewalk"
         git_fs = "${env.WORKSPACE}"
         test = "susemanager-utils/testing/automation/schema-migration-test-oracle.sh"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         // oracle test
         runtest_oracle = "-r ${repository}" +

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -26,7 +26,7 @@ pipeline {
         filter = "schema/spacewalk"
         git_fs = "${env.WORKSPACE}"
         test = "susemanager-utils/testing/automation/schema-migration-test-pgsql.sh" 
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
     // postgresql
         runtest_pg = "-r ${repository}" +

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -26,7 +26,7 @@ pipeline {
         filter = "schema/spacewalk"
         git_fs = "${env.WORKSPACE}"
         test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/sql_schema_filename.py"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "-r ${repository}" +
                 " -c ${context} -d \"${description}\" " +

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
@@ -28,7 +28,7 @@ pipeline {
         // the actual test is the git repo
         test = "susemanager-utils/testing/automation/susemanager-unittest.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -29,7 +29,7 @@ pipeline {
         // the actual test is the git repo (inside spacewalk)
         test = "susemanager-utils/testing/automation/backend-unittest-pgsql.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
@@ -18,7 +18,7 @@ pipeline {
 
     environment {
       repository = "uyuni-project/uyuni"
-      gitarro_cmd = 'gitarro.ruby2.1'
+      gitarro_cmd = 'gitarro.ruby2.5'
       gitarro_local = 'ruby gitarro.rb'
       check = " -r ${repository} -t placeholder --check --changed_since 172800"
     }

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         javacheckstyle_test = "-r uyuni-project/uyuni" +
                 " -c java_lint_checkstyle -d \"java-checkstyle\" " +

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -29,7 +29,7 @@ pipeline {
         // the actual test is the git repo
         test = "susemanager-utils/testing/automation/java-unittests-pgsql.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_javascript_lint
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         jslint_test = "-r uyuni-project/uyuni" +
                 " -c javascript_lint -d \"javascript-lint\" " +

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
@@ -25,7 +25,7 @@ pipeline {
         filter = 'testsuite/'
         test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/rubocop.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro/gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -26,7 +26,7 @@ pipeline {
         filter = "schema/spacewalk"
         git_fs = "${env.WORKSPACE}"
         test = "susemanager-utils/testing/automation/schema-migration-test-pgsql.sh"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
     // postgresql
         runtest_pg = "-r ${repository}" +

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -27,7 +27,7 @@ pipeline {
         git_fs = "${env.WORKSPACE}"
         test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/sql_schema_filename.py"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -29,7 +29,7 @@ pipeline {
         // the actual test is the git repo (inside spacewalk)
         test = "susemanager-utils/testing/automation/spacecmd-unittest.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
@@ -28,7 +28,7 @@ pipeline {
         // the actual test is the git repo
         test = "susemanager-utils/testing/automation/susemanager-unittest.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
-        gitarro_cmd = 'gitarro.ruby2.1'
+        gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'
         runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
 

--- a/jenkins_pipelines/uyuni_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/uyuni_prs/tests_files/rubocop.sh
@@ -2,4 +2,4 @@
 
 echo "running rubocop on step files"
 cd testsuite
-rubocop.ruby2.1 features/*
+rubocop.ruby2.5 features/*


### PR DESCRIPTION
Our sumadockers will now use ruby2.5 for gitarro and rubocop. https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/172
So we need to update our pipelines according it.