### PR TITLE
Use sle15sp2 as a build host a retail terminal initial VM

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -137,7 +137,7 @@ module "cucumber_testsuite" {
       }
     }
     min-build = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       provider_settings = {
         mac = "AA:B2:93:00:00:84"
       }
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
     }
     min-pxeboot = {
       present = true
-      image = "sles15sp1"
+      image = "sles15sp2"
     }
     min-kvm = {
       image = "sles15sp1"

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -139,7 +139,7 @@ module "cucumber_testsuite" {
       }
     }
     min-build = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       provider_settings = {
         mac = "52:54:00:00:00:30"
       }
@@ -163,7 +163,7 @@ module "cucumber_testsuite" {
     }
     min-pxeboot = {
       present = true
-      image = "sles15sp1"
+      image = "sles15sp2"
     }
     min-kvm = {
       image = "sles15sp1"

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -137,7 +137,7 @@ module "cucumber_testsuite" {
       }
     }
     min-build = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       name = "min-build"
       provider_settings = {
         mac = "AA:B2:93:00:00:58"
@@ -166,7 +166,7 @@ module "cucumber_testsuite" {
     }
     min-pxeboot = {
       present = true
-      image = "sles15sp1"
+      image = "sles15sp2"
     }
     min-kvm = {
       image = "sles15sp1"

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -151,7 +151,7 @@ module "cucumber_testsuite" {
       additional_packages = ["python2-salt"]
     }
     min-build = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       name = "min-build"
       provider_settings = {
         mac = "AA:B2:93:00:01:09"
@@ -194,7 +194,7 @@ module "cucumber_testsuite" {
     }
     min-pxeboot = {
       present = true
-      image = "sles15sp1"
+      image = "sles15sp2"
       additional_repos = {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"
       }

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "opensuse151", "sles15sp1", "ubuntu1804"]
+  images = ["centos7", "opensuse150", "opensuse151", "sles15sp1", "sles15sp2", "ubuntu1804"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"
@@ -136,7 +136,7 @@ module "cucumber_testsuite" {
       }
     }
     min-build = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       provider_settings = {
         mac = "AA:B2:93:00:00:09"
       }
@@ -164,7 +164,7 @@ module "cucumber_testsuite" {
     }
     min-pxeboot = {
       present = true
-      image = "sles15sp1"
+      image = "sles15sp2"
     }
     min-kvm = {
       image = "opensuse151"


### PR DESCRIPTION
We recently switched to SLES15SP2 as a retail terminal. This PR aligns OS used for the build host and initial OS for pxeboot VM.