### PR TITLE
Use image sles15sp2 for min-build and proxy

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -139,7 +139,7 @@ module "cucumber_testsuite" {
       }
     }
     min-build = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       provider_settings = {
         mac = "52:54:00:00:00:20"
       }
@@ -163,7 +163,7 @@ module "cucumber_testsuite" {
     }
     min-pxeboot = {
       present = true
-      image = "sles15sp1"
+      image = "sles15sp2"
     }
     min-kvm = {
       image = "sles15sp1"

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix = "suma-ref40-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = ["centos7", "sles15sp1", "ubuntu1804"]
+  images      = ["centos7", "sles15sp1", "sles15sp2", "ubuntu1804"]
 
   provider_settings = {
     pool         = "ssd"
@@ -142,7 +142,7 @@ module "min-build" {
   base_configuration      = module.base.configuration
   product_version         = "4.0-nightly"
   name                    = "min-build"
-  image                   = "sles15sp1"
+  image                   = "sles15sp2"
   server_configuration    = module.srv.configuration
 
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix       = "suma-ref40-"
   use_avahi         = false
   domain            = "prv.suse.net"
-  images            = ["centos7", "sles15sp1", "ubuntu1804"]
+  images            = ["centos7", "sles15sp1", "sles15sp2", "ubuntu1804"]
   mirror            = "minima-mirror.prv.suse.net"
   use_mirror_images = true
 
@@ -144,7 +144,7 @@ module "min-build" {
   base_configuration      = module.base.configuration
   product_version         = "4.0-nightly"
   name                    = "min-build"
-  image                   = "sles15sp1"
+  image                   = "sles15sp2"
   server_configuration    = module.srv.configuration
 
   provider_settings = {


### PR DESCRIPTION
Use image sles15sp2 for both, min-build and pxeboot VM's at the 4.0 branch.

This completes 'use sle15sp2 as a build host a retail terminal initial vm'
(5640b5cc7d0150f96f5e383a2ae346fd8a2b9469)