### PR TITLE
Add openSUSE Leap 15.2 to Uyuni Master

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "opensuse151", "sles15sp1", "sles15sp2", "ubuntu1804"]
+  images = ["centos7", "opensuse150", "opensuse151", "opensuse152o", "sles15sp1", "sles15sp2", "ubuntu1804"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"


### PR DESCRIPTION
So we can move Server and Proxy to use Leap 15.2

That part is done at https://github.com/uyuni-project/sumaform/pull/723