### PR TITLE
Change 4.1 and Head to use SLES15SP2 for the KVM minion

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -164,7 +164,7 @@ module "cucumber_testsuite" {
       image = "sles15sp2"
     }
     min-kvm = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       provider_settings = {
         mac = "AA:B2:93:00:00:83"
       }

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -166,7 +166,7 @@ module "cucumber_testsuite" {
       image = "sles15sp2"
     }
     min-kvm = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       provider_settings = {
         mac = "52:54:00:00:00:29"
       }

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -169,7 +169,7 @@ module "cucumber_testsuite" {
       image = "sles15sp2"
     }
     min-kvm = {
-      image = "sles15sp1"
+      image = "sles15sp2"
       provider_settings = {
         mac = "AA:B2:93:00:00:29"
       }


### PR DESCRIPTION
Reason: because I can't test Leap 15.2 and KVM minion on Uyuni (we don't inject salt packages there, and Leap 15.2 doesn't have the correct salt 3000 yet, that wil come after 4.0.7 release).

So at least this way we can validate KVM on SLES15SP2.