### PR TITLE
Migrating QAM from sumaform-test-runner to terracumber

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-qam-setup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-qam-setup.groovy
@@ -1,0 +1,80 @@
+def run(params) {
+    timestamps {
+        deployed = false
+        env.resultdir = "${WORKSPACE}/results"
+        env.resultdirbuild = "${resultdir}/${BUILD_NUMBER}"
+        // The junit plugin doesn't affect full paths
+        junit_resultdir = "results/${BUILD_NUMBER}/results_junit"
+        env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform"
+        try {
+            stage('Clone terracumber, susemanager-ci and sumaform') {
+                // Create a directory for  to place the directory with the build results (if it does not exist)
+                sh "mkdir -p ${resultdir}"
+                git url: params.terracumber_gitrepo, branch: params.terracumber_ref
+                dir("susemanager-ci") {
+                    checkout scm
+                }
+                // Clone sumaform
+                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
+            }
+            stage('Deploy') {
+                if(params.must_deploy) {
+                    // Provision the environment
+                    if (params.terraform_init) {
+                        env.TERRAFORM_INIT = '--init'
+                    } else {
+                        env.TERRAFORM_INIT = ''
+                    }
+                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
+                    deployed = true
+                }
+            }
+            stage('Run Core features') {
+                if(params.must_run_core) {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:qam_core'"
+                }
+            }
+            stage('Sync. products and channels') {
+                if(params.must_sync) {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:qam_reposync'"
+                }
+            }
+        }
+        finally {
+            stage('Get results') {
+                def error = 0
+                if (deployed) {
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake cucumber:finishing failed")
+                        error = 1
+                    }
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake utils:generate_test_repor failed")
+                        error = 1
+                    }
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+                    publishHTML( target: [
+                                allowMissing: true,
+                                alwaysLinkToLastBuild: false,
+                                keepAll: true,
+                                reportDir: "${resultdirbuild}/cucumber_report/",
+                                reportFiles: 'cucumber_report.html',
+                                reportName: "Setup QAM Environment"]
+                    )
+                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+                }
+                // Send email
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                // Clean up old results
+                sh "./clean-old-results -r ${resultdir}"
+                sh "exit ${error}"
+            }
+        }
+    }
+}
+
+return this

--- a/jenkins_pipelines/environments/common/pipeline-qam.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-qam.groovy
@@ -1,0 +1,98 @@
+def run(params) {
+    timestamps {
+        deployed = false
+        env.resultdir = "${WORKSPACE}/results"
+        env.resultdirbuild = "${resultdir}/${BUILD_NUMBER}"
+        // The junit plugin doesn't affect full paths
+        junit_resultdir = "results/${BUILD_NUMBER}/results_junit"
+        env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform"
+        try {
+            stage('Clone terracumber, susemanager-ci and sumaform') {
+                // Create a directory for  to place the directory with the build results (if it does not exist)
+                sh "mkdir -p ${resultdir}"
+                git url: params.terracumber_gitrepo, branch: params.terracumber_ref
+                dir("susemanager-ci") {
+                    checkout scm
+                }
+                // Clone sumaform
+                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
+            }
+
+
+            stage('Add MUs') {
+                if(params.must_add_channels) {
+                    echo 'Add custom channels and MU repositories'
+                    res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:qam_add_custom_repositories'", returnStatus: true)
+                    echo "Custom channels and MU repositories status code: ${res_mu_repos}"
+                }
+            }
+            
+            stage('Add Activation Keys') {
+                if(params.must_add_keys) {
+                    echo 'Add Activation Keys'
+                    res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:qam_add_activation_keys'", returnStatus: true)
+                    echo "Add Activation Keys status code: ${res_add_keys}"
+                }
+            }
+
+            stage('Bootstrap Proxy') {
+                if(params.must_boot_proxy) {
+                    echo 'Proxy register as minion with gui'
+                    res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:qam_init_proxy'", returnStatus: true)
+                    echo "Init Proxy status code: ${res_init_proxy}"
+                }
+            }
+            
+            stage('Bootstrap clients') {
+                if(params.must_boot_clients) {
+                    echo 'Bootstrap clients'
+                    res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:qam_init_clients'", returnStatus: true)
+                    echo "Init clients status code: ${res_init_clients}"
+                }
+            }
+
+            stage('Run Smoke Tests') {
+                if(params.must_run_tests) {
+                        echo 'Run Smoke tests'
+                        res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:qam_smoke_tests'", returnStatus: true)
+                        echo "Smoke tests status code: ${res_smoke_tests}"
+                }
+            }
+        }
+        }
+        finally {
+            stage('Get results') {
+                def error = 0
+                try {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing'"
+                } catch(Exception ex) {
+                    println("ERROR: rake cucumber:finishing failed")
+                    error = 1
+                }
+                try {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+                } catch(Exception ex) {
+                    println("ERROR: rake utils:generate_test_repor failed")
+                    error = 1
+                }
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+                publishHTML( target: [
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: false,
+                            keepAll: true,
+                            reportDir: "${resultdirbuild}/cucumber_report/",
+                            reportFiles: 'cucumber_report.html',
+                            reportName: "TestSuite Report"]
+                )
+                junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+            }
+            // Send email
+            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+            // Clean up old results
+            sh "./clean-old-results -r ${resultdir}"
+            sh "exit ${error}"
+        }
+    }
+}
+
+return this

--- a/jenkins_pipelines/environments/manager-4.0-qam-cucumber
+++ b/jenkins_pipelines/environments/manager-4.0-qam-cucumber
@@ -1,0 +1,33 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30')),
+        disableConcurrentBuilds(),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-4.0', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-qam.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'must_add_channels', defaultValue: true, description: 'Add custom channels and MU repositories'),
+            booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
+            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
+            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
+            choice(name: 'rake_namespace', choices: ['parallel', 'cucumber'], description: 'Choose parallel or cucumber')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-qam.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.0-qam-setup-cucumber
+++ b/jenkins_pipelines/environments/manager-4.0-qam-setup-cucumber
@@ -1,0 +1,31 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30')),
+        disableConcurrentBuilds(),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-4.0', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-qam.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
+            booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
+            booleanParam(name: 'must_sync', defaultValue: true, description: 'Sync. products and channels'),
+            choice(name: 'rake_namespace', choices: ['cucumber'], description: 'Choose parallel or cucumber')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-qam-setup.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.1-qam-cucumber
+++ b/jenkins_pipelines/environments/manager-4.1-qam-cucumber
@@ -1,0 +1,33 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30')),
+        disableConcurrentBuilds(),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-4.1', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.1-qam.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'must_add_channels', defaultValue: true, description: 'Add custom channels and MU repositories'),
+            booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
+            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
+            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
+            choice(name: 'rake_namespace', choices: ['parallel', 'cucumber'], description: 'Choose parallel or cucumber')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-qam.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.1-qam-setup-cucumber
+++ b/jenkins_pipelines/environments/manager-4.1-qam-setup-cucumber
@@ -1,0 +1,31 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30')),
+        disableConcurrentBuilds(),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-4.1', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.1-qam.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
+            booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
+            booleanParam(name: 'must_sync', defaultValue: true, description: 'Sync. products and channels'),
+            choice(name: 'rake_namespace', choices: ['cucumber'], description: 'Choose parallel or cucumber')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-qam-setup.groovy"
+    pipeline.run(params)
+}

--- a/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
@@ -681,5 +681,7 @@ module "ctl" {
 }
 
 output "configuration" {
-  value = module.ctl.configuration
+  value = {
+    ctl = module.ctl.configuration
+  }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
@@ -1,0 +1,685 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-qam-setup-cucumber"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.0"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results 4.0 QAM $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results 4.0 QAM: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://classic176.qa.prv.suse.net/system"
+}
+
+provider "libvirt" {
+  alias = "classic179"
+  uri = "qemu+tcp://classic179.qa.prv.suse.net/system"
+}
+
+provider "libvirt" {
+  alias = "classic181"
+  uri = "qemu+tcp://classic181.qa.prv.suse.net/system"
+}
+
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "qam-pip-40-"
+  use_avahi   = false
+  domain      = "qa.prv.suse.net"
+  images      = ["sles15", "sles15sp1", "opensuse150"]
+
+  mirror = "minima-mirror.qa.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite          = true
+
+  provider_settings = {
+    pool        = "default"
+    bridge      = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+
+module "base2" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "qam-pip-40-"
+  use_avahi   = false
+  domain      = "qa.prv.suse.net"
+  images      = ["sles11sp4", "sles12sp4", "sles15", "sles15sp1"]
+
+  mirror = "minima-mirror.qa.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite          = true
+
+  provider_settings = {
+    pool        = "default"
+    bridge      = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+
+module "base3" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "qam-pip-40-"
+  use_avahi   = false
+  domain      = "qa.prv.suse.net"
+  images      = ["sles15sp1",  "ubuntu1804"]
+
+  mirror = "minima-mirror.qa.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite          = true
+
+  provider_settings = {
+    pool        = "default"
+    bridge      = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+
+
+module "srv" {
+  source             = "./modules/server"
+  base_configuration = module.base.configuration
+  product_version    = "4.0-nightly"
+  name               = "srv"
+  provider_settings = {
+    mac                = "52:54:00:F6:5D:E8"
+    memory             = 40960
+    vcpu               = 6
+    data_pool            = "default"
+  }
+
+  repository_disk_size = 750
+
+  auto_accept                    = false
+  monitored                      = true
+  disable_firewall               = false
+  allow_postgres_connections     = false
+  skip_changelog_import          = false
+  browser_side_less              = false
+  create_first_user              = false
+  mgr_sync_autologin             = false
+  create_sample_channel          = false
+  create_sample_activation_key   = false
+  create_sample_bootstrap_script = false
+  publish_private_ssl_key        = false
+  use_os_released_updates        = true
+  disable_download_tokens        = false
+  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  from_email                     = "root@suse.de"
+
+  //srv_additional_repos
+
+}
+
+module "pxy" {
+  source             = "./modules/proxy"
+  base_configuration = module.base.configuration
+  product_version    = "4.0-nightly"
+  name               = "pxy"
+  provider_settings = {
+    mac                = "52:54:00:F2:4D:7A"
+    memory             = 4096
+  }
+  server_configuration = {
+    hostname = "qam-pip-40-srv.qa.prv.suse.net"
+    username = "admin"
+    password = "admin"
+  }
+  auto_register             = false
+  auto_connect_to_master    = false
+  download_private_ssl_key  = false
+  auto_configure            = false
+  generate_bootstrap_script = false
+  publish_private_ssl_key   = false
+  use_os_released_updates   = true
+  ssh_key_path              = "./salt/controller/id_rsa.pub"
+
+}
+
+module "cli-sles12sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/client"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles12sp4"
+  image              = "sles12sp4"
+  provider_settings = {
+    mac                = "52:54:00:0E:F8:ED"
+    memory             = 2048
+  }
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "cli-sles11sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/client"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles11sp4"
+  image              = "sles11sp4"
+  provider_settings = {
+    mac                = "52:54:00:66:70:7B"
+    memory             = 2048
+  }
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "cli-sles15" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/client"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles15"
+  image              = "sles15"
+  provider_settings = {
+    mac                = "52:54:00:06:F2:85"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "cli-sles15sp1" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/client"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles15sp1"
+  image              = "sles15sp1"
+  provider_settings = {
+    mac                = "52:54:00:BA:1D:11"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+//module "cli-centos7" {
+//  source             = "./modules/client"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name               = "cli-centos7"
+//  image              = "centos7"
+//  provider_settings = {
+//    mac                = "52:54:00:72:41:8A"
+//  }
+//  memory             = 2048
+//
+//  server_configuration = {
+//    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+//  }
+//  auto_register = false
+//  use_os_released_updates = false
+//  ssh_key_path  = "./salt/controller/id_rsa.pub"
+//}
+
+//module "cli-centos6" {
+//  source = "./modules/client"
+//  base_configuration = module.base.configuration
+//  product_version = "4.0-released"
+//  name = "cli-centos6"
+//  image = "centos6"
+//  mac = "52:54:00:BA:ED:61"
+//  memory             = 2048
+//  use_os_released_updates = false
+//  server_configuration =  { hostname = "qam-pip-40-pxy.qa.prv.suse.net" }
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "min-sles12sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles12sp4"
+  image              = "sles12sp4"
+  provider_settings = {
+    mac                = "52:54:00:B2:49:5C"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "min-sles11sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles11sp4"
+  image              = "sles11sp4"
+  provider_settings = {
+    mac                = "52:54:00:02:C8:20"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "min-sles15" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles15"
+  image              = "sles15"
+  provider_settings = {
+    mac                = "52:54:00:DA:C7:79"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "min-sles15sp1" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles15sp1"
+  image              = "sles15sp1"
+  provider_settings = {
+    mac                = "52:54:00:72:E5:BE"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+//module "min-centos7" {
+//  source             = "./modules/minion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name               = "min-centos7"
+//  image              = "centos7"
+//  provider_settings = {
+//    mac                = "52:54:00:92:F9:D6"
+//  }
+//  memory             = 2048
+//  server_configuration = {
+//    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+//  }
+//  auto_connect_to_master = false
+//  use_os_released_updates = false
+//  ssh_key_path           = "./salt/controller/id_rsa.pub"
+//}
+
+//module "min-centos6" {
+//  source = "./modules/minion"
+//  base_configuration = module.base.configuration
+//  product_version = "4.0-released"
+//  name = "min-centos6"
+//  image = "centos6"
+//  mac = "52:54:00:7A:13:48"
+//  memory             = 2048
+//  server_configuration =  { hostname = "qam-pip-40-pxy.qa.prv.suse.net" }
+//  auto_connect_to_master = false
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "min-ubuntu1804" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "min-ubuntu1804"
+  image              = "ubuntu1804"
+  provider_settings = {
+    mac                = "52:54:00:D2:5E:EC"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master = false
+  use_os_released_updates = false
+  ssh_key_path           = "./salt/controller/id_rsa.pub"
+}
+
+//module "min-ubuntu1604" {
+//  source = "./modules/minion"
+//  base_configuration = module.base.configuration
+//  product_version = "4.0-released"
+//  name = "min-ubuntu1604"
+//  image = "ubuntu1604"
+//  mac = "52:54:00:12:33:D8"
+//  memory             = 2048
+//  server_configuration =  { hostname =  "qam-pip-40-pxy.qa.prv.suse.net" }
+//  auto_connect_to_master = false
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "minssh-sles12sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  provider_settings = {
+    mac                = "52:54:00:DA:AD:B0"
+    memory             = 2048
+  }
+  name               = "minssh-sles12sp4"
+  image              = "sles12sp4"
+
+  use_os_released_updates = false
+  ssh_key_path = "./salt/controller/id_rsa.pub"
+  gpg_keys     = ["default/gpg_keys/galaxy.key"]
+}
+
+module "minssh-sles11sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-sles11sp4"
+  image              = "sles11sp4"
+  provider_settings = {
+    mac                = "52:54:00:3A:0D:F9"
+    memory             = 2048
+  }
+
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "minssh-sles15" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-sles15"
+  image              = "sles15"
+  provider_settings = {
+    mac                = "52:54:00:62:D7:5D"
+    memory             = 2048
+  }
+
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "minssh-sles15sp1" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-sles15sp1"
+  image              = "sles15sp1"
+  provider_settings = {
+    mac                = "52:54:00:26:7C:DE"
+    memory             = 2048
+  }
+
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+//module "minssh-centos7" {
+//  source             = "./modules/sshminion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name               = "minssh-centos7"
+//  image              = "centos7"
+//  provider_settings = {
+//    mac                = "52:54:00:EA:AA:42"
+//  memory             = 2048
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+//module "minssh-centos6" {
+//  source = "./modules/sshminion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name = "minssh-centos6"
+//  image = "centos6"
+//  memory             = 2048
+//  mac = "52:54:00:96:6B:AC"
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "minssh-ubuntu1804" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-ubuntu1804"
+  image              = "ubuntu1804"
+  provider_settings = {
+    mac                = "52:54:00:8E:00:5A"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path       = "./salt/controller/id_rsa.pub"
+}
+
+//module "minssh-ubuntu1604" {
+//  source = "./modules/sshminion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name = "minssh-ubuntu1604"
+//  image = "ubuntu1604"
+//  mac = "52:54:00:CE:FE:C8"
+//  memory             = 2048
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+// }
+
+
+module "ctl" {
+  source             = "./modules/controller"
+  base_configuration = module.base.configuration
+  name               = "ctl"
+  provider_settings = {
+    mac                = "52:54:00:B2:CF:9B"
+    memory             = 16384
+    vcpu               = 6
+  }
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+  
+  server_configuration = module.srv.configuration
+  proxy_configuration  = module.pxy.configuration
+
+  //  centos6_minion_configuration = module.min-centos6.configuration
+  //  centos6_sshminion_configuration = module.minssh-centos6.configuration
+  //  centos6_client_configuration = module.cli-centos6.configuration
+
+  //  centos7_minion_configuration    = module.min-centos7.configuration
+  //  centos7_sshminion_configuration = module.minssh-centos7.configuration
+  //  centos7_client_configuration    = module.cli-centos7.configuration
+
+  sle11sp4_minion_configuration    = module.min-sles11sp4.configuration
+  sle11sp4_sshminion_configuration = module.minssh-sles11sp4.configuration
+  sle11sp4_client_configuration    = module.cli-sles11sp4.configuration
+
+  sle12sp4_minion_configuration    = module.min-sles12sp4.configuration
+  sle12sp4_sshminion_configuration = module.minssh-sles12sp4.configuration
+  sle12sp4_client_configuration    = module.cli-sles12sp4.configuration
+
+  minion_configuration    = module.min-sles12sp4.configuration
+  sshminion_configuration = module.minssh-sles12sp4.configuration
+  client_configuration    = module.cli-sles12sp4.configuration
+
+  sle15_minion_configuration    = module.min-sles15.configuration
+  sle15_sshminion_configuration = module.minssh-sles15.configuration
+  sle15_client_configuration    = module.cli-sles15.configuration
+
+  sle15sp1_minion_configuration    = module.min-sles15sp1.configuration
+  sle15sp1_sshminion_configuration = module.minssh-sles15sp1.configuration
+  sle15sp1_client_configuration    = module.cli-sles15sp1.configuration
+
+  //  ubuntu1604_minion_configuration = module.min-ubuntu1604.configuration
+  //  ubuntu1604_sshminion_configuration = module.minssh-ubuntu1604.configuration
+
+  ubuntu1804_minion_configuration = module.min-ubuntu1804.configuration
+  ubuntu1804_sshminion_configuration = module.minssh-ubuntu1804.configuration
+}
+
+output "configuration" {
+  value = module.ctl.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
@@ -681,5 +681,7 @@ module "ctl" {
 }
 
 output "configuration" {
-  value = module.ctl.configuration
+  value = {
+    ctl = module.ctl.configuration
+  }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
@@ -1,0 +1,685 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = "string"
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-qam-setup-cucumber"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = "string"
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = "string"
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = "string"
+  default = "Manager-4.1"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = "string"
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = "string"
+  default = "Results 4.1 QAM $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = "string"
+  default = "Results 4.1 QAM: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = "string"
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = "string"
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = "string"
+}
+
+variable "SCC_PASSWORD" {
+  type = "string"
+}
+
+variable "GIT_USER" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = "string"
+  default = null // Not needed for master, as it is public
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://classic176.qa.prv.suse.net/system"
+}
+
+provider "libvirt" {
+  alias = "classic179"
+  uri = "qemu+tcp://classic179.qa.prv.suse.net/system"
+}
+
+provider "libvirt" {
+  alias = "classic181"
+  uri = "qemu+tcp://classic181.qa.prv.suse.net/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "qam-pip-40-"
+  use_avahi   = false
+  domain      = "qa.prv.suse.net"
+  images      = ["sles15", "sles15sp1", "sles15sp2", "opensuse150"]
+
+  mirror = "minima-mirror.qa.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite          = true
+
+  provider_settings = {
+    pool        = "default"
+    bridge      = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+
+module "base2" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "qam-pip-40-"
+  use_avahi   = false
+  domain      = "qa.prv.suse.net"
+  images      = ["sles11sp4", "sles12sp4", "sles15", "sles15sp1"]
+
+  mirror = "minima-mirror.qa.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite          = true
+
+  provider_settings = {
+    pool        = "default"
+    bridge      = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+
+module "base3" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "qam-pip-40-"
+  use_avahi   = false
+  domain      = "qa.prv.suse.net"
+  images      = ["sles15sp1", "ubuntu1804"]
+
+  mirror = "minima-mirror.qa.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite          = true
+
+  provider_settings = {
+    pool        = "default"
+    bridge      = "br0"
+    additional_network = "192.168.40.0/24"
+  }
+}
+
+module "srv" {
+  source             = "./modules/server"
+  base_configuration = module.base.configuration
+  product_version    = "head"
+  name               = "srv"
+  provider_settings = {
+    mac                = "52:54:00:F6:5D:E8"
+    memory             = 40960
+    vcpu               = 6
+    data_pool            = "default"
+  }
+
+  repository_disk_size = 750
+
+  auto_accept                    = false
+  monitored                      = true
+  disable_firewall               = false
+  allow_postgres_connections     = false
+  skip_changelog_import          = false
+  browser_side_less              = false
+  create_first_user              = false
+  mgr_sync_autologin             = false
+  create_sample_channel          = false
+  create_sample_activation_key   = false
+  create_sample_bootstrap_script = false
+  publish_private_ssl_key        = false
+  use_os_released_updates        = true
+  disable_download_tokens        = false
+  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  from_email                     = "root@suse.de"
+
+  //srv_additional_repos
+
+}
+
+module "pxy" {
+  source             = "./modules/proxy"
+  base_configuration = module.base.configuration
+  product_version    = "head"
+  name               = "pxy"
+  provider_settings = {
+    mac                = "52:54:00:F2:4D:7A"
+    memory             = 4096
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-srv.qa.prv.suse.net"
+    username = "admin"
+    password = "admin"
+  }
+  auto_register             = false
+  auto_connect_to_master    = false
+  download_private_ssl_key  = false
+  auto_configure            = false
+  generate_bootstrap_script = false
+  publish_private_ssl_key   = false
+  use_os_released_updates   = true
+  ssh_key_path              = "./salt/controller/id_rsa.pub"
+
+}
+
+module "cli-sles12sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/client"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles12sp4"
+  image              = "sles12sp4"
+  provider_settings = {
+    mac                = "52:54:00:0E:F8:ED"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "cli-sles11sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/client"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles11sp4"
+  image              = "sles11sp4"
+  provider_settings = {
+    mac                = "52:54:00:66:70:7B"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "cli-sles15" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/client"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles15"
+  image              = "sles15"
+  provider_settings = {
+    mac                = "52:54:00:06:F2:85"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "cli-sles15sp1" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/client"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "cli-sles15sp1"
+  image              = "sles15sp1"
+  provider_settings = {
+    mac                = "52:54:00:BA:1D:11"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_register           = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+//module "cli-centos7" {
+//  source             = "./modules/client"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name               = "cli-centos7"
+//  image              = "centos7"
+//  provider_settings = {
+//    mac                = "52:54:00:72:41:8A"
+//  }
+//  memory             = 2048
+//
+//  server_configuration = {
+//    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+//  }
+//  auto_register = false
+//  use_os_released_updates = false
+//  ssh_key_path  = "./salt/controller/id_rsa.pub"
+//}
+
+//module "cli-centos6" {
+//  source = "./modules/client"
+//  base_configuration = module.base.configuration
+//  product_version = "4.0-released"
+//  name = "cli-centos6"
+//  image = "centos6"
+//  mac = "52:54:00:BA:ED:61"
+//  memory             = 2048
+//  use_os_released_updates = false
+//  server_configuration =  { hostname = "qam-pip-40-pxy.qa.prv.suse.net" }
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "min-sles12sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles12sp4"
+  image              = "sles12sp4"
+  provider_settings = {
+    mac                = "52:54:00:B2:49:5C"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "min-sles11sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles11sp4"
+  image              = "sles11sp4"
+  provider_settings = {
+    mac                = "52:54:00:02:C8:20"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "min-sles15" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles15"
+  image              = "sles15"
+  provider_settings = {
+    mac                = "52:54:00:DA:C7:79"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "min-sles15sp1" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "min-sles15sp1"
+  image              = "sles15sp1"
+  provider_settings = {
+    mac                = "52:54:00:72:E5:BE"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+//module "min-centos7" {
+//  source             = "./modules/minion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name               = "min-centos7"
+//  image              = "centos7"
+//  provider_settings = {
+//    mac                = "52:54:00:92:F9:D6"
+//  memory             = 2048
+//  server_configuration = {
+//    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+//  }
+//  auto_connect_to_master = false
+//  use_os_released_updates = false
+//  ssh_key_path           = "./salt/controller/id_rsa.pub"
+//}
+
+//module "min-centos6" {
+//  source = "./modules/minion"
+//  base_configuration = module.base.configuration
+//  product_version = "4.0-released"
+//  name = "min-centos6"
+//  image = "centos6"
+//  mac = "52:54:00:7A:13:48"
+//  memory             = 2048
+//  server_configuration =  { hostname = "qam-pip-40-pxy.qa.prv.suse.net" }
+//  auto_connect_to_master = false
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "min-ubuntu1804" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "min-ubuntu1804"
+  image              = "ubuntu1804"
+  provider_settings = {
+    mac                = "52:54:00:D2:5E:EC"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "qam-pip-40-pxy.qa.prv.suse.net"
+  }
+  auto_connect_to_master = false
+  use_os_released_updates = false
+  ssh_key_path           = "./salt/controller/id_rsa.pub"
+}
+
+//module "min-ubuntu1604" {
+//  source = "./modules/minion"
+//  base_configuration = module.base.configuration
+//  product_version = "4.0-released"
+//  name = "min-ubuntu1604"
+//  image = "ubuntu1604"
+//  mac = "52:54:00:12:33:D8"
+//  memory             = 2048
+//  server_configuration =  { hostname =  "qam-pip-40-pxy.qa.prv.suse.net" }
+//  auto_connect_to_master = false
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "minssh-sles12sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  provider_settings = {
+    mac                = "52:54:00:DA:AD:B0"
+    memory             = 2048
+  }
+  name               = "minssh-sles12sp4"
+  image              = "sles12sp4"
+
+  use_os_released_updates = false
+  ssh_key_path = "./salt/controller/id_rsa.pub"
+  gpg_keys     = ["default/gpg_keys/galaxy.key"]
+}
+
+module "minssh-sles11sp4" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-sles11sp4"
+  image              = "sles11sp4"
+  provider_settings = {
+    mac                = "52:54:00:3A:0D:F9"
+    memory             = 2048
+  }
+
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "minssh-sles15" {
+  providers = {
+    libvirt = libvirt.classic179
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base2.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-sles15"
+  image              = "sles15"
+  provider_settings = {
+    mac                = "52:54:00:62:D7:5D"
+    memory             = 2048
+  }
+
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "minssh-sles15sp1" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-sles15sp1"
+  image              = "sles15sp1"
+  provider_settings = {
+    mac                = "52:54:00:26:7C:DE"
+    memory             = 2048
+  }
+
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+//module "minssh-centos7" {
+//  source             = "./modules/sshminion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name               = "minssh-centos7"
+//  image              = "centos7"
+//  provider_settings = {
+//    mac                = "52:54:00:EA:AA:42"
+//  memory             = 2048
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+//module "minssh-centos6" {
+//  source = "./modules/sshminion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name = "minssh-centos6"
+//  image = "centos6"
+//  memory             = 2048
+//  mac = "52:54:00:96:6B:AC"
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+//}
+
+module "minssh-ubuntu1804" {
+  providers = {
+    libvirt = libvirt.classic181
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base3.configuration
+  product_version    = "4.0-released"
+  name               = "minssh-ubuntu1804"
+  image              = "ubuntu1804"
+  provider_settings = {
+    mac                = "52:54:00:8E:00:5A"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path       = "./salt/controller/id_rsa.pub"
+}
+
+//module "minssh-ubuntu1604" {
+//  source = "./modules/sshminion"
+//  base_configuration = module.base.configuration
+//  product_version    = "4.0-released"
+//  name = "minssh-ubuntu1604"
+//  image = "ubuntu1604"
+//  mac = "52:54:00:CE:FE:C8"
+//  memory             = 2048
+//  use_os_released_updates = false
+//  ssh_key_path = "./salt/controller/id_rsa.pub"
+// }
+
+
+module "ctl" {
+  source             = "./modules/controller"
+  base_configuration = module.base.configuration
+  name               = "ctl"
+  provider_settings = {
+    mac                = "52:54:00:B2:CF:9B"
+    memory             = 16384
+    vcpu               = 6
+  }
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  server_configuration = module.srv.configuration
+  proxy_configuration  = module.pxy.configuration
+
+  //  centos6_minion_configuration = module.min-centos6.configuration
+  //  centos6_sshminion_configuration = module.minssh-centos6.configuration
+  //  centos6_client_configuration = module.cli-centos6.configuration
+
+  //  centos7_minion_configuration    = module.min-centos7.configuration
+  //  centos7_sshminion_configuration = module.minssh-centos7.configuration
+  //  centos7_client_configuration    = module.cli-centos7.configuration
+
+  sle11sp4_minion_configuration    = module.min-sles11sp4.configuration
+  sle11sp4_sshminion_configuration = module.minssh-sles11sp4.configuration
+  sle11sp4_client_configuration    = module.cli-sles11sp4.configuration
+
+  sle12sp4_minion_configuration    = module.min-sles12sp4.configuration
+  sle12sp4_sshminion_configuration = module.minssh-sles12sp4.configuration
+  sle12sp4_client_configuration    = module.cli-sles12sp4.configuration
+
+  minion_configuration    = module.min-sles12sp4.configuration
+  sshminion_configuration = module.minssh-sles12sp4.configuration
+  client_configuration    = module.cli-sles12sp4.configuration
+
+  sle15_minion_configuration    = module.min-sles15.configuration
+  sle15_sshminion_configuration = module.minssh-sles15.configuration
+  sle15_client_configuration    = module.cli-sles15.configuration
+
+  sle15sp1_minion_configuration    = module.min-sles15sp1.configuration
+  sle15sp1_sshminion_configuration = module.minssh-sles15sp1.configuration
+  sle15sp1_client_configuration    = module.cli-sles15sp1.configuration
+
+  //  ubuntu1604_minion_configuration = module.min-ubuntu1604.configuration
+  //  ubuntu1604_sshminion_configuration = module.minssh-ubuntu1604.configuration
+
+  ubuntu1804_minion_configuration = module.min-ubuntu1804.configuration
+  ubuntu1804_sshminion_configuration = module.minssh-ubuntu1804.configuration
+}
+
+output "configuration" {
+  value = module.ctl.configuration
+}


### PR DESCRIPTION
This PR migrate 4.0 and 4.1 QAM Test Environments from sumaform-test-runner to Terracumber.
We need it, so we can use the latest sumaform version, and see if using it we can fix the issues happening on deployment time for QAM 4.1.

See the related Cards:
https://github.com/SUSE/spacewalk/issues/11902
https://github.com/SUSE/spacewalk/issues/11901