### PR TITLE
add dev tool channel for sles15sp2 on manager 4.1

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
-  
+
   images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
 
   use_avahi = false
@@ -117,6 +117,10 @@ module "cucumber_testsuite" {
     srv = {
       provider_settings = {
         mac = "52:54:00:00:00:31"
+      }
+      additional_repos = {
+        devtools_product = "http://minima-mirror.prv.suse.net/SUSE/Products/SLE-Module-Development-Tools/15-SP2/x86_64/product/",
+        devtools_update  = "http://minima-mirror.prv.suse.net/SUSE/Updates/SLE-Module-Development-Tools/15-SP2/x86_64/update/"
       }
     }
     pxy = {
@@ -179,7 +183,7 @@ module "cucumber_testsuite" {
     additional_network = "192.168.41.0/24"
   }
 }
-  
+
 output "configuration" {
   value = module.cucumber_testsuite.configuration
 }


### PR DESCRIPTION
We had some conflicts between those developer tools channels
and our suse manager channels.
Adding those channels allow us to verify is all questions are solved.

Signed-off-by: Ricardo Mateus <rmateus@suse.com>