### PR TITLE
Add a 60 minutes timeout for the testsuites

### DIFF
--- a/jenkins_pipelines/environments/manager-3.2-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-3.2-cucumber-NUE
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-3.2-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-3.2-cucumber-PRV
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-3.2-reference-PRV
+++ b/jenkins_pipelines/environments/manager-3.2-reference-PRV
@@ -21,6 +21,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-4.0-reference-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-reference-NUE
@@ -21,6 +21,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-4.0-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-reference-PRV
@@ -21,6 +21,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-4.1-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-reference-PRV
@@ -21,6 +21,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-Head-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-Head-cucumber-NUE
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-Head-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-reference-NUE
@@ -21,6 +21,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/manager-TEST-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-cucumber
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }

--- a/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
@@ -23,6 +23,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
-    pipeline.run(params)
+    timeout(activity: true, time: 60, unit: 'MINUTES') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
 }


### PR DESCRIPTION
The `activity` parameter is used so the timeout applies to "time without activity on the logs":

https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#timeout-enforce-time-limit

We could adjust it individually for each job if needed.

If you think more than 60 minutes are needed (or less), please do let me know.

I tested https://github.com/juliogonzalez/jenkins-pipeline-parameters (changing the value for `time` at `product3.2`) at my private Jenkins, and worked fine.