### PR TITLE
Change timeout to 10 hours and absolute

### DIFF
--- a/jenkins_pipelines/environments/manager-3.2-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-3.2-cucumber-NUE
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-3.2-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-3.2-cucumber-PRV
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-3.2-reference-PRV
+++ b/jenkins_pipelines/environments/manager-3.2-reference-PRV
@@ -21,7 +21,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.0-reference-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-reference-NUE
@@ -21,7 +21,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.0-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-reference-PRV
@@ -21,7 +21,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-reference-PRV
@@ -21,7 +21,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-Head-cucumber-NUE
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-reference-NUE
@@ -21,7 +21,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-cucumber
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
@@ -23,7 +23,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 60, unit: 'MINUTES') {
+    timeout(activity: false, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
For some reason this is not working exactly as it should (sometimes the builds get terminated even with activity in the last 60 minutes), and no time to debug it now before going on holidays. Since I need results ASAP, I am going to switch it to a 10 hours absolute timeout with a this PR.

```
208[0m[0m
[2020-07-22T20:10:40.262Z] [32mAnd I follow "[32m[1mSoftware Channels[0m[0m[32m" in the [32m[1mcontent area[0m[0m[32m[90m                        # features/step_definitions/navigation_steps.rb:208[0m[0m
[2020-07-22T20:10:40.262Z] [32mAnd I wait until I do not see "[32m[1mLoading...[0m[0m[32m" text[90m                             # features/step_definitions/navigation_steps.rb:34[0m[0m
[2020-07-22T20:10:40.262Z] [32mAnd I check radio button "[32m[1mTest-Channel-x86_64[0m[0m[32m"[90m                              # features/step_definitions/common_steps.rb:137[0m[0m
[2020-07-22T20:10:40.262Z] [32mAnd I wait until I do not see "[32m[1mLoading...[0m[0m[32m" text[90m                             # features/step_definitions/navigation_steps.rb:34[0m[0m
[2020-07-22T20:10:40.262Z] [32mAnd I click on "[32m[1mNext[0m[0m[32m"[90m                                                       # features/step_definitions/navigation_steps.rb:161[0m[0m
[2020-07-22T20:10:40.262Z] [32mThen I should see a "[32m[1mConfirm Software Channel Change[0m[0m[32m" text[90m                  # features/step_definitions/navigation_steps.rb:509[0m[0m
[2020-07-22T20:10:40.262Z] [32mWhen I click on "[32m[1mConfirm[0m[0m[32m"[90m                                                   # features/step_definitions/navigation_steps.rb:161[0m[0m
[2020-07-22T20:10:40.262Z] [32mThen I should see a "[32m[1mChanging the channels has been scheduled.[0m[0m[32m" text[90m        # features/step_definitions/navigation_steps.rb:509[0m[0m
Cancelling nested steps due to timeout
[2020-07-22T20:11:02.770Z] [32mAnd I wait until event "[32m[1mSubscribe channels scheduled by admin[0m[0m[32m" is completed[90m # features/step_definitions/common_steps.rb:75[0m[0mSending interrupt signal to process
[2020-07-22T20:11:06.997Z] /home/jenkins/jenkins-build/workspace/manager-4.0-cucumber-NUE@tmp/durable-30766a87/script.sh: line 1: 10946 Terminated              ./terracumber-cli --outputdir /home/jenkins/jenkins-build/workspace/manager-4.0-cucumber-NUE/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf --gitfolder /home/jenkins/jenkins-build/workspace/manager-4.0-cucumber-NUE/results/sumaform --logfile /home/jenkins/jenkins-build/workspace/manager-4.0-cucumber-NUE/results/24/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:init_clients'
[2020-07-22T20:11:07.006Z] script returned exit code 143
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Get results)
[Pipeline] sh
``` 
```
[2020-07-22T20:11:39.571Z] [32mGiven a postgresql database is running[90m                                                     # features/step_definitions/smdba_steps.rb:4[0m[0m
[2020-07-22T20:11:39.571Z] [36mDatabase is running[0m
[2020-07-22T20:11:39.571Z] [32mWhen I issue command "[32m[1msmdba space-overview[0m[0m[32m"[90m                                                # features/step_definitions/smdba_steps.rb:66[0m[0m
[2020-07-22T20:11:39.571Z] [32mThen tablespace "[32m[1msusemanager[0m[0m[32m" should be listed[90m                                             # features/step_definitions/smdba_steps.rb:70[0m[0m
Body did not finish within grace period; terminating with extreme prejudice
[Pipeline] echo
[2020-07-22T20:12:02.788Z] ERROR: rake cucumber:finishing failed
[Pipeline] sh
[2020-07-22T20:12:03.098Z] + ./terracumber-cli --outputdir /home/jenkins/jenkins-build/workspace/manager-4.0-cucumber-NUE/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf --gitfolder /home/jenkins/jenkins-build/workspace/manager-4.0-cucumber-NUE/results/sumaform --logfile /home/jenkins/jenkins-build/workspace/manager-4.0-cucumber-NUE/results/24/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake utils:generate_test_report'
```
https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-cucumber-NUE/24/consoleFull
https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-cucumber-NUE/23/consoleFull
https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-cucumber-PRV/35/console
https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-cucumber-PRV/34/console

I cant find a good reason for it, unless some of the substeps does not complete is not finishing.