### PR TITLE
Use official images in all CI

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles12sp3", "sles12sp4o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-32-"

--- a/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
@@ -93,7 +93,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
   
-  images = ["centos7", "opensuse150", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles12sp3", "sles12sp4o", "ubuntu1804o"]
 
   use_avahi = false
   name_prefix = "suma-32-"

--- a/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix       = "suma-ref32-"
   use_avahi         = false
   domain            = "prv.suse.net"
-  images            = ["centos7", "sles12sp4", "ubuntu1804"]
+  images            = ["centos7o", "sles12sp4o", "ubuntu1804o"]
   mirror            = "minima-mirror.prv.suse.net"
   use_mirror_images = true
 
@@ -118,7 +118,6 @@ module "suse-client" {
   base_configuration = module.base.configuration
   product_version    = "3.2-nightly"
   name               = "cli-sles12"
-  image              = "sles12sp4"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -133,7 +132,6 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "3.2-nightly"
   name               = "min-sles12"
-  image              = "sles12sp4"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -148,7 +146,6 @@ module "build-host" {
   base_configuration      = module.base.configuration
   product_version         = "3.2-nightly"
   name                    = "min-build"
-  image                   = "sles12sp4"
   server_configuration    = module.server.configuration
 
   provider_settings = {
@@ -162,7 +159,6 @@ module "redhat-minion" {
   base_configuration = module.base.configuration
   product_version    = "3.2-nightly"
   name               = "min-centos7"
-  image              = "centos7"
 
   server_configuration = module.server.configuration
 
@@ -176,7 +172,6 @@ module "debian-minion" {
   base_configuration = module.base.configuration
   product_version    = "3.2-nightly"
   name               = "min-ubuntu1804"
-  image              = "ubuntu1804"
 
   server_configuration = module.server.configuration
 

--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-40-"
@@ -123,14 +123,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:41"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:42"
@@ -143,7 +143,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:43"
@@ -163,7 +163,6 @@ module "cucumber_testsuite" {
       image = "sles15sp2o"
     }
     kvm-host = {
-      image = "sles15sp1"
       provider_settings = {
         mac = "AA:B2:93:00:00:48"
       }

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -93,7 +93,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
   
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi = false
   name_prefix = "suma-40-"
@@ -125,14 +125,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:02"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:03"
@@ -145,7 +145,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:04"
@@ -165,7 +165,6 @@ module "cucumber_testsuite" {
       image = "sles15sp2o"
     }
     kvm-host = {
-      image = "sles15sp1"
       provider_settings = {
         mac = "52:54:00:00:00:09"
       }

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix = "suma-ref40-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = ["centos7", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images      = ["centos7o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   provider_settings = {
     pool         = "ssd"
@@ -112,7 +112,7 @@ module "suse-client" {
   base_configuration = module.base.configuration
   product_version    = "4.0-nightly"
   name               = "cli-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -127,7 +127,7 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.0-nightly"
   name               = "min-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -154,7 +154,7 @@ module "suse-sshminion" {
   source                  = "./modules/sshminion"
   base_configuration      = module.base.configuration
   name                    = "minssh-sles15"
-  image                   = "sles15sp1"
+  image                   = "sles15sp1o"
 
   use_os_released_updates = true
 
@@ -168,7 +168,6 @@ module "redhat-minion" {
   base_configuration   = module.base.configuration
   product_version      = "4.0-nightly"
   name                 = "min-centos7"
-  image                = "centos7"
   server_configuration = module.server.configuration
 
   provider_settings = {
@@ -181,7 +180,6 @@ module "debian-minion" {
   base_configuration   = module.base.configuration
   product_version      = "4.0-nightly"
   name                 = "min-ubuntu1804"
-  image                = "ubuntu1804"
   server_configuration = module.server.configuration
 
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix       = "suma-ref40-"
   use_avahi         = false
   domain            = "prv.suse.net"
-  images            = ["centos7", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images            = ["centos7o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
   mirror            = "minima-mirror.prv.suse.net"
   use_mirror_images = true
 
@@ -114,7 +114,7 @@ module "suse-client" {
   base_configuration = module.base.configuration
   product_version    = "4.0-nightly"
   name               = "cli-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -129,7 +129,7 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.0-nightly"
   name               = "min-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -157,7 +157,6 @@ module "redhat-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.0-nightly"
   name               = "min-centos7"
-  image              = "centos7"
 
   server_configuration   = module.server.configuration
   auto_connect_to_master = false
@@ -172,7 +171,6 @@ module "debian-minion" {
   base_configuration   = module.base.configuration
   product_version      = "4.0-nightly"
   name                 = "min-ubuntu1804"
-  image                = "ubuntu1804"
   server_configuration = module.server.configuration
 
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-41-"
@@ -116,6 +116,10 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "AA:B2:93:00:00:75"
       }
+      additional_repos = {
+        devtools_product = "http://minima-mirror.prv.suse.net/SUSE/Products/SLE-Module-Development-Tools/15-SP2/x86_64/product/",
+        devtools_update  = "http://minima-mirror.prv.suse.net/SUSE/Updates/SLE-Module-Development-Tools/15-SP2/x86_64/update/"
+      }
     }
     proxy = {
       provider_settings = {
@@ -123,14 +127,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:76"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:77"
@@ -143,7 +147,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:78"

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -93,7 +93,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi = false
   name_prefix = "suma-41-"
@@ -129,14 +129,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:22"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:23"
@@ -149,7 +149,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:24"

--- a/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix       = "suma-ref41-"
   use_avahi         = false
   domain            = "prv.suse.net"
-  images            = ["centos7", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images            = ["centos7o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
   mirror            = "minima-mirror.prv.suse.net"
   use_mirror_images = true
 
@@ -118,7 +118,7 @@ module "suse-client" {
   base_configuration = module.base.configuration
   product_version    = "4.1-nightly"
   name               = "cli-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -133,7 +133,7 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.1-nightly"
   name               = "min-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -148,7 +148,7 @@ module "build-host" {
   base_configuration      = module.base.configuration
   product_version         = "4.1-nightly"
   name                    = "min-build"
-  image                   = "sles15sp1"
+  image                   = "sles15sp1o"
   server_configuration    = module.server.configuration
 
   provider_settings = {
@@ -161,7 +161,6 @@ module "redhat-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.1-nightly"
   name               = "min-centos7"
-  image              = "centos7"
 
   server_configuration   = module.server.configuration
   auto_connect_to_master = false
@@ -176,7 +175,6 @@ module "debian-minion" {
   base_configuration   = module.base.configuration
   product_version      = "4.1-nightly"
   name                 = "min-ubuntu1804"
-  image                = "ubuntu1804"
   server_configuration = module.server.configuration
 
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-head-"
@@ -123,14 +123,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:21"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:22"
@@ -144,7 +144,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:23"

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix = "suma-refhead-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = ["centos7", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images      = ["centos7o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
   provider_settings = {
     pool         = "ssd"
     network_name = null
@@ -112,7 +112,7 @@ module "suse-client" {
   base_configuration = module.base.configuration
   product_version    = "head"
   name               = "cli-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -127,7 +127,7 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "head"
   name               = "min-sles15"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -142,7 +142,7 @@ module "build-host" {
   base_configuration      = module.base.configuration
   product_version         = "head"
   name                    = "min-build"
-  image                   = "sles15sp1"
+  image                   = "sles15sp1o"
   server_configuration    = module.server.configuration
 
   provider_settings = {
@@ -155,7 +155,6 @@ module "redhat-minion" {
   base_configuration   = module.base.configuration
   product_version      = "head"
   name                 = "min-centos7"
-  image                = "centos7"
   server_configuration = module.server.configuration
 
   provider_settings = {
@@ -172,7 +171,6 @@ module "debian-minion" {
   base_configuration   = module.base.configuration
   product_version      = "head"
   name                 = "min-ubuntu1804"
-  image                = "ubuntu1804"
   server_configuration = module.server.configuration
 
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "opensuse151", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-testhexagon-"
@@ -128,27 +128,27 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:B1"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:B3"
       }
     }
     build-host = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       provider_settings = {
         mac = "AA:B2:93:00:00:B7"
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:B5"

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-"
@@ -129,14 +129,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:61"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:62"
@@ -150,7 +150,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:64"
@@ -174,7 +174,7 @@ module "cucumber_testsuite" {
       image = "sles15sp2o"
     }
     kvm-host = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       provider_settings = {
         mac = "AA:B2:93:00:00:69"
       }

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-testnaica-"
@@ -129,7 +129,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:01:01"
@@ -140,7 +140,7 @@ module "cucumber_testsuite" {
       additional_packages = ["python2-salt"]
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:01:02"
@@ -162,7 +162,7 @@ module "cucumber_testsuite" {
       additional_packages = ["python2-salt"]
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:01:04"
@@ -200,7 +200,6 @@ module "cucumber_testsuite" {
       additional_packages = ["python2-salt"]
     }
     kvm-host = {
-      image = "sles15sp1"
       provider_settings = {
         mac = "AA:B2:93:00:01:08"
       }

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "opensuse151", "sles15sp1", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "sles15sp1o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-testorion-"
@@ -120,27 +120,27 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:A1"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:A3"
       }
     }
     build-host = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       provider_settings = {
         mac = "AA:B2:93:00:00:A7"
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:A5"

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7", "opensuse150", "opensuse151", "opensuse152o", "sles15sp1", "sles15sp2o", "ubuntu1804"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"
@@ -122,14 +122,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:01"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:02"
@@ -142,7 +142,7 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "AA:B2:93:00:00:03"


### PR DESCRIPTION
Update all main.tf to download and use official images by default.

We have merged https://github.com/uyuni-project/sumaform/pull/741 to
use official images by default in sumaform.   Now we need to update the main.tf
so that the default images are available.

- SUSEManager-4.1-NUE.tf:
Add the additional repos in the server