### PR TITLE
Remove Development Tools repositories for 4.1

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -116,10 +116,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "AA:B2:93:00:00:75"
       }
-      additional_repos = {
-        devtools_product = "http://minima-mirror.prv.suse.net/SUSE/Products/SLE-Module-Development-Tools/15-SP2/x86_64/product/",
-        devtools_update  = "http://minima-mirror.prv.suse.net/SUSE/Updates/SLE-Module-Development-Tools/15-SP2/x86_64/update/"
-      }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -118,10 +118,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "52:54:00:00:00:31"
       }
-      additional_repos = {
-        devtools_product = "http://minima-mirror.prv.suse.net/SUSE/Products/SLE-Module-Development-Tools/15-SP2/x86_64/product/",
-        devtools_update  = "http://minima-mirror.prv.suse.net/SUSE/Updates/SLE-Module-Development-Tools/15-SP2/x86_64/update/"
-      }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
@@ -107,10 +107,6 @@ module "server" {
     mac    = "52:54:00:00:00:32"
     memory = 8192
   }
-  additional_repos = {
-    devtools_product = "http://minima-mirror.prv.suse.net/SUSE/Products/SLE-Module-Development-Tools/15-SP2/x86_64/product/",
-    devtools_update  = "http://minima-mirror.prv.suse.net/SUSE/Updates/SLE-Module-Development-Tools/15-SP2/x86_64/update/"
-  }
 }
 
 module "suse-client" {


### PR DESCRIPTION
Rollback:

- https://github.com/SUSE/susemanager-ci/pull/97
- https://github.com/SUSE/susemanager-ci/pull/101
- Part of https://github.com/SUSE/susemanager-ci/pull/106

Not needed anymore, as 4.1.1 is released and the packages we needed from there are already part of the "released" channels.