### PR TITLE
Let openscap run with more RAM on Centos minion on 4.0 and 4.1

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -152,6 +152,8 @@ module "cucumber_testsuite" {
     redhat-minion = {
       provider_settings = {
         mac = "AA:B2:93:00:00:44"
+        // Openscap cannot run with less than 1.25 GB of RAM
+        memory = 1280
       }
     }
     debian-minion = {

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -154,6 +154,8 @@ module "cucumber_testsuite" {
     redhat-minion = {
       provider_settings = {
         mac = "52:54:00:00:00:05"
+        // Openscap cannot run with less than 1.25 GB of RAM
+        memory = 1280
       }
     }
     debian-minion = {

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
@@ -173,6 +173,8 @@ module "redhat-minion" {
 
   provider_settings = {
     mac = "AA:B2:93:00:00:54"
+    // Openscap cannot run with less than 1.25 GB of RAM
+    memory = 1280
   }
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
@@ -164,6 +164,8 @@ module "redhat-minion" {
 
   provider_settings = {
     mac = "52:54:00:00:00:14"
+    // Openscap cannot run with less than 1.25 GB of RAM
+    memory = 1280
   }
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -152,6 +152,8 @@ module "cucumber_testsuite" {
     redhat-minion = {
       provider_settings = {
         mac = "AA:B2:93:00:00:79"
+        // Openscap cannot run with less than 1.25 GB of RAM
+        memory = 1280
       }
     }
     debian-minion = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -154,6 +154,8 @@ module "cucumber_testsuite" {
     redhat-minion = {
       provider_settings = {
         mac = "52:54:00:00:00:25"
+        // Openscap cannot run with less than 1.25 GB of RAM
+        memory = 1280
       }
     }
     debian-minion = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
@@ -164,6 +164,9 @@ module "redhat-minion" {
 
   provider_settings = {
     mac = "52:54:00:00:00:36"
+    // Openscap cannot run with less than 1.25 GB of RAM
+    memory = 1280
+    vcpu = 2
   }
 }
 

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -154,7 +154,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "AA:B2:93:00:00:24"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
-        // Still researching, but it will do it for now
+        // Also, openscap cannot run with less than 1.25 GB of RAM
         memory = 2048
         vcpu = 2
       }

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -161,7 +161,7 @@ module "redhat-minion" {
   provider_settings = {
     mac = "AA:B2:93:00:00:34"
     // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
-    // Still researching, but it will do it for now
+    // Also, openscap cannot run with less than 1.25 GB of RAM
     memory = 2048
     vcpu = 2
   }

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -153,7 +153,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "AA:B2:93:00:00:04"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
-        // Still researching, but it will do it for now
+        // Also, openscap cannot run with less than 1.25 GB of RAM
         memory = 2048
         vcpu = 2
       }


### PR DESCRIPTION
With only one GB on CentOS for 4.0 and 4.1:
```
[root@suma-40-min-centos7 ~]# oscap xccdf eval --profile standard /usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml >/dev/null
WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
WARNING: Skipping https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml file which is referenced from XCCDF content
W: oscap:         Can't connect: 12, Cannot allocate memory.
E: oscap:         Connect: retry limit (0) reached.
W: oscap:       Can't connect: 12, Cannot allocate memory.
E: oscap:       Connect: retry limit (0) reached.
W: oscap:       Can't connect: 12, Cannot allocate memory.
E: oscap:       Connect: retry limit (0) reached.
W: oscap:       Can't connect: 12, Cannot allocate memory.
E: oscap:       Connect: retry limit (0) reached.
```
etc