### PR TITLE
Emergency fix: CentOS back to custom image

### DIFF
--- a/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
@@ -11,7 +11,7 @@ node('sumaform-cucumber') {
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
-            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/calancha/sumaform#backend-choice)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
             // Temporary: should move to uyuni-project

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
@@ -9,10 +9,9 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
             string(name: 'cucumber_ref', defaultValue: 'Manager-4.0', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf', description: 'Path to the tf file to be used'),
-            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/calancha/sumaform.git', description: 'Sumaform Git Repository'),
-            // Temporary: should move to uyuni-project
-            string(name: 'sumaform_ref', defaultValue: 'revert-use-official', description: 'Sumaform Git reference (branch, tag...)'),
-            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/calancha/sumaform#backend-choice)'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
             // Temporary: should move to uyuni-project

--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -82,7 +82,7 @@ module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
   product_version = "4.0-nightly"
-  
+
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
   git_password = var.GIT_PASSWORD
@@ -92,13 +92,13 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  # temporary: custom CentOS image due to broken Salt
+  images = ["centos7", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-40-"
   domain       = "mgr.suse.de"
   from_email   = "root@suse.de"
-
 
   portus_uri = "portus.mgr.suse.de:5000/cucutest"
   portus_username = "cucutest"
@@ -150,6 +150,7 @@ module "cucumber_testsuite" {
       }
     }
     redhat-minion = {
+      image = "centos7"
       provider_settings = {
         mac = "AA:B2:93:00:00:44"
         // Openscap cannot run with less than 1.25 GB of RAM
@@ -172,9 +173,9 @@ module "cucumber_testsuite" {
     }
   }
   provider_settings = {
-    pool               = "ssd"
-    network_name       = null
-    bridge             = "br0"
+    pool = "ssd"
+    network_name = null
+    bridge = "br0"
     additional_network = "192.168.40.0/24"
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -92,13 +92,14 @@ module "cucumber_testsuite" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
-  
-  images = ["centos7", "opensuse150", "sles15sp1", "sles15sp2o", "ubuntu1804"]
 
-  use_avahi = false
-  name_prefix = "suma-40-"
-  domain = "prv.suse.net"
-  from_email = "root@suse.de"
+  # temporary: custom CentOS image due to broken Salt
+  images = ["centos7", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+
+  use_avahi    = false
+  name_prefix  = "suma-40-"
+  domain       = "prv.suse.net"
+  from_email   = "root@suse.de"
 
   portus_uri = "portus.mgr.suse.de:5000/cucutest"
   portus_username = "cucutest"
@@ -125,14 +126,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:02"
       }
     }
     suse-minion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:03"
@@ -145,13 +146,14 @@ module "cucumber_testsuite" {
       }
     }
     suse-sshminion = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "52:54:00:00:00:04"
       }
     }
     redhat-minion = {
+      image = "centos7"
       provider_settings = {
         mac = "52:54:00:00:00:05"
         // Openscap cannot run with less than 1.25 GB of RAM
@@ -167,7 +169,7 @@ module "cucumber_testsuite" {
       image = "sles15sp2o"
     }
     kvm-host = {
-      image = "sles15sp1"
+      image = "sles15sp1o"
       provider_settings = {
         mac = "52:54:00:00:00:09"
       }
@@ -180,7 +182,7 @@ module "cucumber_testsuite" {
     additional_network = "192.168.40.0/24"
   }
 }
-  
+
 output "configuration" {
   value = module.cucumber_testsuite.configuration
 }


### PR DESCRIPTION
Salt seems to be broken on CentOS 7 official image
```
2020-09-12 05:13:31,609 [salt.utils.data  :1029][ERROR   ][1773] Invalid input for repack_dictlist: element tzdata is not a string/dict/numeric value
2020-09-12 05:13:31,610 [salt.state       :323 ][ERROR   ][1773] Invalidly formatted 'pkgs' parameter. See minion log.
2020-09-12 05:13:32,120 [salt.utils.data  :1029][ERROR   ][1773] Invalid input for repack_dictlist: element andromeda-dummy is not a string/dict/numeric value
2020-09-12 05:13:32,121 [salt.state       :323 ][ERROR   ][1773] Invalidly formatted 'pkgs' parameter. See minion log.
```

Reverting to Custom image

