### PR TITLE
Reverting: same problem on centos 7 custom

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -93,7 +93,7 @@ module "cucumber_testsuite" {
   cc_password = var.SCC_PASSWORD
 
   # temporary: custom CentOS image due to broken Salt
-  images = ["centos7", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-40-"
@@ -150,7 +150,7 @@ module "cucumber_testsuite" {
       }
     }
     redhat-minion = {
-      image = "centos7"
+      image = "centos7o"
       provider_settings = {
         mac = "AA:B2:93:00:00:44"
         // Openscap cannot run with less than 1.25 GB of RAM

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -94,7 +94,7 @@ module "cucumber_testsuite" {
   cc_password = var.SCC_PASSWORD
 
   # temporary: custom CentOS image due to broken Salt
-  images = ["centos7", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-40-"
@@ -153,7 +153,7 @@ module "cucumber_testsuite" {
       }
     }
     redhat-minion = {
-      image = "centos7"
+      image = "centos7o"
       provider_settings = {
         mac = "52:54:00:00:00:05"
         // Openscap cannot run with less than 1.25 GB of RAM


### PR DESCRIPTION
Revert the emergency fix #120. 

As a side effect, this makes 4.0 fully use official images.