### PR TITLE
3.2: Changing sles12sp4 to official image

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "sles12sp3", "sles12sp4", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles12sp3", "sles12sp4o", "ubuntu1804o"]
 
   use_avahi    = false
   name_prefix  = "suma-32-"
@@ -113,13 +113,13 @@ module "cucumber_testsuite" {
       }
     }
     server = {
-      image = "sles12sp4"
+      image = "sles12sp4o"
       provider_settings = {
         mac = "AA:B2:93:00:00:66"
       }
     }
     proxy = {
-      image = "sles12sp4"
+      image = "sles12sp4o"
       provider_settings = {
         mac = "AA:B2:93:00:00:72"
       }

--- a/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
@@ -93,7 +93,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
   
-  images = ["centos7o", "opensuse150o", "sles12sp3", "sles12sp4", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles12sp3", "sles12sp4o", "ubuntu1804o"]
 
   use_avahi = false
   name_prefix = "suma-32-"
@@ -115,13 +115,13 @@ module "cucumber_testsuite" {
       }
     }
     server = {
-      image = "sles12sp4"
+      image = "sles12sp4o"
       provider_settings = {
         mac = "52:54:00:01:37:28"
       }
     }
     proxy = {
-      image = "sles12sp4"
+      image = "sles12sp4o"
       provider_settings = {
         mac = "52:54:00:1d:af:5a"
       }


### PR DESCRIPTION
Fixing https://ci.suse.de/view/Manager/view/Manager-3.2/job/manager-3.2-cucumber-NUE/370/console:
```
10:49:25  Error: Can't retrieve base volume with name 'suma-32-sles12sp4o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'suma-32-sles12sp4o'')
10:49:25  
10:49:25    on /home/jenkins/jenkins-build/workspace/manager-3.2-cucumber-NUE@2/results/sumaform/backend_modules/libvirt/host/main.tf line 41, in resource "libvirt_volume" "main_disk":
10:49:25    41: resource "libvirt_volume" "main_disk" {
10:49:25  
10:49:25  
10:49:25  
10:49:25  Error: Can't retrieve base volume with name 'suma-32-sles12sp4o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'suma-32-sles12sp4o'')
10:49:25  
10:49:25    on /home/jenkins/jenkins-build/workspace/manager-3.2-cucumber-NUE@2/results/sumaform/backend_modules/libvirt/host/main.tf line 41, in resource "libvirt_volume" "main_disk":
10:49:25    41: resource "libvirt_volume" "main_disk" {
10:49:25  
10:49:25  
10:49:25  
10:49:25  Error: Can't retrieve base volume with name 'suma-32-sles12sp4o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'suma-32-sles12sp4o'')
10:49:25  
10:49:25    on /home/jenkins/jenkins-build/workspace/manager-3.2-cucumber-NUE@2/results/sumaform/backend_modules/libvirt/host/main.tf line 41, in resource "libvirt_volume" "main_disk":
10:49:25    41: resource "libvirt_volume" "main_disk" {
10:49:25  
10:49:25  
10:49:25  
10:49:25  Error: Can't retrieve base volume with name 'suma-32-sles12sp4o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'suma-32-sles12sp4o'')
10:49:25  
10:49:25    on /home/jenkins/jenkins-build/workspace/manager-3.2-cucumber-NUE@2/results/sumaform/backend_modules/libvirt/host/main.tf line 41, in resource "libvirt_volume" "main_disk":
10:49:25    41: resource "libvirt_volume" "main_disk" {
```