### PR TITLE
3.2 Provo on selektah and new network

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
@@ -75,7 +75,7 @@ variable "GIT_PASSWORD" {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://metropolis.prv.suse.net/system"
+  uri = "qemu+tcp://selektah.mgr.prv.suse.net/system"
 }
 
 
@@ -97,7 +97,7 @@ module "cucumber_testsuite" {
 
   use_avahi = false
   name_prefix = "suma-32-"
-  domain = "prv.suse.net"
+  domain = "mgr.prv.suse.net"
   from_email = "root@suse.de"
 
   no_auth_registry = "minima-mirror.mgr.prv.suse.net"
@@ -170,7 +170,7 @@ module "cucumber_testsuite" {
   }
   provider_settings = {
       pool = "ssd"
-      bridge = "br0"
+      bridge = "br1"
       additional_network = "192.168.32.0/24"
   }
 }


### PR DESCRIPTION
* try to have less VMs on metropolis
* stop 3.2 nue to discharge ramrod
* measure performance on reinstalled selektah
* use new network mgr.prv.suse.net