### PR TITLE
Increased memory for Centos 7 VM because of OpenSCAP test

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-NUE.tf
@@ -143,6 +143,7 @@ module "cucumber_testsuite" {
     min-centos7 = {
       provider_settings = {
         mac = "AA:B2:93:00:00:70"
+        memory = 3072        
       }
     }
     min-ubuntu1804 = {

--- a/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
@@ -145,6 +145,7 @@ module "cucumber_testsuite" {
     min-centos7 = {
       provider_settings = {
         mac = "52:54:00:4f:17:48"
+        memory = 3072        
       }
     }
     min-ubuntu1804 = {

--- a/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
@@ -154,6 +154,7 @@ module "min-centos7" {
 
   provider_settings = {
     mac = "52:54:00:33:1a:ad"
+    memory = 3072    
   }
 }
 


### PR DESCRIPTION
OpenSCAP audit needs temporarily considerable amount of resources (all processes are able to consume 2.6 GiB of memory).

We need to increase memory size for this purpose.