### PR TITLE
Avoid false duplicate MAC addresses

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-PRV.tf
@@ -112,57 +112,57 @@ module "cucumber_testsuite" {
   host_settings = {
     controller = {
       provider_settings = {
-        mac = "52:54:00:02:f0:55"
+        mac = "aa:b2:92:02:f0:55"
       }
     }
     server = {
       image = "sles12sp4o"
       provider_settings = {
-        mac = "52:54:00:01:37:28"
+        mac = "aa:b2:92:01:37:28"
       }
     }
     proxy = {
       image = "sles12sp4o"
       provider_settings = {
-        mac = "52:54:00:1d:af:5a"
+        mac = "aa:b2:92:1d:af:5a"
       }
     }
     suse-client = {
       name = "cli-sles12"
       image = "sles12sp3"
       provider_settings = {
-        mac = "52:54:00:55:bf:9b"
+        mac = "aa:b2:92:55:bf:9b"
       }
     }
     suse-minion = {
       name = "min-sles12"
       image = "sles12sp3"
       provider_settings = {
-        mac = "52:54:00:e7:1e:fa"
+        mac = "aa:b2:92:e7:1e:fa"
       }
     }
     build-host = {
       image = "sles12sp3"
       provider_settings = {
-        mac = "52:54:00:00:00:18"
+        mac = "aa:b2:92:00:00:18"
       }
     }
     suse-sshminion = {
       name = "minssh-sles12"
       image = "sles12sp3"
       provider_settings = {
-        mac = "52:54:00:99:c9:f5"
+        mac = "aa:b2:92:99:c9:f5"
       }
     }
     redhat-minion = {
       provider_settings = {
-        mac = "52:54:00:4f:17:48"
+        mac = "aa:b2:92:4f:17:48"
         memory = 3072        
       }
     }
     debian-minion = {
       provider_settings = {
-        mac = "52:54:00:4f:17:49"
+        mac = "aa:b2:92:4f:17:49"
       }
     }
     pxeboot-minion = {

--- a/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-3.2-refenv-PRV.tf
@@ -110,7 +110,7 @@ module "server" {
     "sle-module-containers12-updates-x86_64-sp4"]
 
   provider_settings = {
-    mac    = "52:54:00:c6:48:b9"
+    mac    = "aa:b2:92:c6:48:b9"
     memory = 8192
   }
 }
@@ -126,7 +126,7 @@ module "suse-client" {
   use_os_released_updates = true
 
   provider_settings = {
-    mac = "52:54:00:93:17:5f"
+    mac = "aa:b2:92:93:17:5f"
   }
 }
 
@@ -141,7 +141,7 @@ module "suse-minion" {
   use_os_released_updates = true
 
   provider_settings = {
-    mac = "52:54:00:a0:d0:ce"
+    mac = "aa:b2:92:a0:d0:ce"
   }
 }
 
@@ -154,7 +154,7 @@ module "build-host" {
   server_configuration    = module.server.configuration
 
   provider_settings = {
-    mac = "52:54:00:00:00:19"
+    mac = "aa:b2:92:00:00:19"
   }
 }
 
@@ -169,7 +169,7 @@ module "redhat-minion" {
   server_configuration = module.server.configuration
 
   provider_settings = {
-    mac = "52:54:00:33:1a:ad"
+    mac = "aa:b2:92:33:1a:ad"
     memory = 3072    
   }
 }
@@ -184,6 +184,6 @@ module "debian-minion" {
   server_configuration = module.server.configuration
 
   provider_settings = {
-    mac = "52:54:00:e0:ed:07"
+    mac = "aa:b2:92:e0:ed:07"
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -114,57 +114,57 @@ module "cucumber_testsuite" {
   host_settings = {
     controller = {
       provider_settings = {
-        mac = "52:54:00:00:00:06"
+        mac = "aa:b2:92:00:00:06"
       }
     }
     server = {
       provider_settings = {
-        mac = "52:54:00:00:00:01"
+        mac = "aa:b2:92:00:00:01"
       }
     }
     proxy = {
       provider_settings = {
-        mac = "52:54:00:00:00:07"
+        mac = "aa:b2:92:00:00:07"
       }
     }
     suse-client = {
       image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
-        mac = "52:54:00:00:00:02"
+        mac = "aa:b2:92:00:00:02"
       }
     }
     suse-minion = {
       image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
-        mac = "52:54:00:00:00:03"
+        mac = "aa:b2:92:00:00:03"
       }
     }
     build-host = {
       image = "sles15sp2o"
       provider_settings = {
-        mac = "52:54:00:00:00:20"
+        mac = "aa:b2:92:00:00:20"
       }
     }
     suse-sshminion = {
       image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
-        mac = "52:54:00:00:00:04"
+        mac = "aa:b2:92:00:00:04"
       }
     }
     redhat-minion = {
       image = "centos7o"
       provider_settings = {
-        mac = "52:54:00:00:00:05"
+        mac = "aa:b2:92:00:00:05"
         // Openscap cannot run with less than 1.25 GB of RAM
         memory = 1280
       }
     }
     debian-minion = {
       provider_settings = {
-        mac = "52:54:00:00:00:08"
+        mac = "aa:b2:92:00:00:08"
       }
     }
     pxeboot-minion = {
@@ -173,7 +173,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp1o"
       provider_settings = {
-        mac = "52:54:00:00:00:09"
+        mac = "aa:b2:92:00:00:09"
       }
     }
   }

--- a/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
@@ -171,7 +171,7 @@ module "server" {
   name               = "srv"
   image              = "sles15sp1"
   provider_settings = {
-    mac                = "52:54:00:F6:5D:E8"
+    mac                = "aa:b2:92:f6:5d:e8"
     memory             = 40960
     vcpu               = 6
     data_pool            = "default"
@@ -207,7 +207,7 @@ module "proxy" {
   name               = "pxy"
   image              = "sles15sp1"
   provider_settings = {
-    mac                = "52:54:00:F2:4D:7A"
+    mac                = "aa:b2:92:f2:4d:7a"
     memory             = 4096
   }
   server_configuration = {
@@ -236,7 +236,7 @@ module "sles12sp4-client" {
   name               = "cli-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
-    mac                = "52:54:00:0E:F8:ED"
+    mac                = "aa:b2:92:0e:f8:ed"
     memory             = 4096
   }
   server_configuration = {
@@ -257,7 +257,7 @@ module "sles11sp4-client" {
   name               = "cli-sles11sp4"
   image              = "sles11sp4"
   provider_settings = {
-    mac                = "52:54:00:66:70:7B"
+    mac                = "aa:b2:92:66:70:7b"
     memory             = 4096
   }
   server_configuration = {
@@ -278,7 +278,7 @@ module "sles15-client" {
   name               = "cli-sles15"
   image              = "sles15o"
   provider_settings = {
-    mac                = "52:54:00:06:F2:85"
+    mac                = "aa:b2:92:06:f2:85"
     memory             = 4096
   }
   server_configuration = {
@@ -299,7 +299,7 @@ module "sles15sp1-client" {
   name               = "cli-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
-    mac                = "52:54:00:BA:1D:11"
+    mac                = "aa:b2:92:ba:1d:11"
     memory             = 4096
   }
   server_configuration = {
@@ -320,7 +320,7 @@ module "centos7-client" {
   name               = "cli-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "52:54:00:72:41:8A"
+    mac                = "aa:b2:92:72:41:8a"
     memory             = 4096
   }
   server_configuration = {
@@ -341,7 +341,7 @@ module "centos6-client" {
   name               = "cli-centos6"
   image              = "centos6o"
   provider_settings = {
-    mac                = "52:54:00:BA:ED:61"
+    mac                = "aa:b2:92:ba:ed:61"
     memory             = 4096
   }
   auto_register           = false
@@ -360,7 +360,7 @@ module "sles12sp4-minion" {
   name               = "min-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
-    mac                = "52:54:00:B2:49:5C"
+    mac                = "aa:b2:92:b2:49:5c"
     memory             = 4096
   }
 
@@ -382,7 +382,7 @@ module "sles11sp4-minion" {
   name               = "min-sles11sp4"
   image              = "sles11sp4"
   provider_settings = {
-    mac                = "52:54:00:02:C8:20"
+    mac                = "aa:b2:92:02:c8:20"
     memory             = 4096
   }
 
@@ -404,7 +404,7 @@ module "sles15-minion" {
   name               = "min-sles15"
   image              = "sles15o"
   provider_settings = {
-    mac                = "52:54:00:DA:C7:79"
+    mac                = "aa:b2:92:da:c7:79"
     memory             = 4096
   }
   server_configuration = {
@@ -425,7 +425,7 @@ module "sles15sp1-minion" {
   name               = "min-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
-    mac                = "52:54:00:72:E5:BE"
+    mac                = "aa:b2:92:72:e5:be"
     memory             = 4096
   }
 
@@ -447,7 +447,7 @@ module "centos8-minion" {
   name               = "min-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "52:54:00:99:CF:C8"
+    mac                = "aa:b2:92:99:cf:c8"
     memory             = 4096
   }
   server_configuration = {
@@ -468,7 +468,7 @@ module "centos7-minion" {
   name               = "min-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "52:54:00:92:F9:D6"
+    mac                = "aa:b2:92:92:f9:d6"
     memory             = 4096
   }
   server_configuration = {
@@ -490,7 +490,7 @@ module "centos6-minion" {
   name               = "min-centos6"
   image              = "centos6o"
   provider_settings = {
-    mac                = "52:54:00:7A:13:48"
+    mac                = "aa:b2:92:7a:13:48"
     memory             = 4096
   }
   server_configuration =  { hostname = "suma-qam-40-pxy.mgr.prv.suse.net" }
@@ -509,7 +509,7 @@ module "ubuntu2004-minion" {
   name               = "min-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "52:54:00:2A:47:D8"
+    mac                = "aa:b2:92:2a:47:d8"
     memory             = 4096
   }
   server_configuration = {
@@ -530,7 +530,7 @@ module "ubuntu1804-minion" {
   name               = "min-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "52:54:00:D2:5E:EC"
+    mac                = "aa:b2:92:d2:5e:ec"
     memory             = 4096
   }
   server_configuration = {
@@ -551,7 +551,7 @@ module "ubuntu1604-minion" {
   name               = "min-ubuntu1604"
   image              = "ubuntu1604o"
   provider_settings = {
-    mac                = "52:54:00:12:33:D8"
+    mac                = "aa:b2:92:12:33:d8"
     memory             = 4096
   }
   server_configuration =  { hostname =  "suma-qam-40-pxy.mgr.prv.suse.net" }
@@ -570,7 +570,7 @@ module "sles12sp4-sshminion" {
   name               = "minssh-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
-    mac                = "52:54:00:DA:AD:B0"
+    mac                = "aa:b2:92:da:ad:b0"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -588,7 +588,7 @@ module "sles11sp4-sshminion" {
   name               = "minssh-sles11sp4"
   image              = "sles11sp4"
   provider_settings = {
-    mac                = "52:54:00:3A:0D:F9"
+    mac                = "aa:b2:92:3a:0d:f9"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -605,7 +605,7 @@ module "sles15-sshminion" {
   name               = "minssh-sles15"
   image              = "sles15o"
   provider_settings = {
-    mac                = "52:54:00:62:D7:5D"
+    mac                = "aa:b2:92:62:d7:5d"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -622,7 +622,7 @@ module "sles15sp1-sshminion" {
   name               = "minssh-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
-    mac                = "52:54:00:26:7C:DE"
+    mac                = "aa:b2:92:26:7c:de"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -639,7 +639,7 @@ module "centos8-sshminion" {
   name               = "minssh-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "52:54:00:AE:F1:6C"
+    mac                = "aa:b2:92:ae:f1:6c"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -656,7 +656,7 @@ module "centos7-sshminion" {
   name               = "minssh-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "52:54:00:EA:AA:42"
+    mac                = "aa:b2:92:ea:aa:42"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -673,7 +673,7 @@ module "centos6-sshminion" {
   name               = "minssh-centos6"
   image              = "centos6o"
   provider_settings = {
-    mac                = "52:54:00:96:6B:AC"
+    mac                = "aa:b2:92:96:6b:ac"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -690,7 +690,7 @@ module "ubuntu2004-sshminion" {
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "52:54:00:2A:47:D8"
+    mac                = "aa:b2:92:0e:28:39"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -707,7 +707,7 @@ module "ubuntu1804-sshminion" {
   name               = "minssh-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "52:54:00:8E:00:5A"
+    mac                = "aa:b2:92:8e:00:5a"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -724,7 +724,7 @@ module "ubuntu1604-sshminion" {
   name               = "minssh-ubuntu1604"
   image              = "ubuntu1604o"
   provider_settings = {
-    mac                = "52:54:00:CE:FE:C8"
+    mac                = "aa:b2:92:ce:fe:c8"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -736,7 +736,7 @@ module "controller" {
   base_configuration = module.base.configuration
   name               = "ctl"
   provider_settings = {
-    mac                = "52:54:00:B2:CF:9B"
+    mac                = "aa:b2:92:b2:cf:9b"
     memory             = 16384
     vcpu               = 6
   }

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
@@ -104,7 +104,7 @@ module "server" {
   channels                = ["sle-product-sles15-pool-x86_64", "sle-product-sles15-updates-x86_64", "sle-module-basesystem15-pool-x86_64", "sle-module-basesystem15-updates-x86_64", "sle-module-containers15-pool-x86_64", "sle-module-containers15-updates-x86_64"]
 
   provider_settings = {
-    mac    = "52:54:00:00:00:10"
+    mac    = "aa:b2:92:00:00:10"
     memory = 8192
   }
 }
@@ -120,7 +120,7 @@ module "suse-client" {
   use_os_released_updates = true
 
   provider_settings = {
-    mac = "52:54:00:00:00:11"
+    mac = "aa:b2:92:00:00:11"
   }
 }
 
@@ -135,7 +135,7 @@ module "suse-minion" {
   use_os_released_updates = true
 
   provider_settings = {
-    mac = "52:54:00:00:00:12"
+    mac = "aa:b2:92:00:00:12"
   }
 }
 
@@ -148,7 +148,7 @@ module "build-host" {
   server_configuration    = module.server.configuration
 
   provider_settings = {
-    mac = "52:54:00:00:00:21"
+    mac = "aa:b2:92:00:00:21"
   }
 }
 
@@ -163,7 +163,7 @@ module "redhat-minion" {
   auto_connect_to_master = false
 
   provider_settings = {
-    mac = "52:54:00:00:00:14"
+    mac = "aa:b2:92:00:00:14"
     // Openscap cannot run with less than 1.25 GB of RAM
     memory = 1280
   }
@@ -178,6 +178,6 @@ module "debian-minion" {
   server_configuration = module.server.configuration
 
   provider_settings = {
-    mac = "52:54:00:00:00:17"
+    mac = "aa:b2:92:00:00:17"
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -113,57 +113,57 @@ module "cucumber_testsuite" {
   host_settings = {
     controller = {
       provider_settings = {
-        mac = "52:54:00:00:00:26"
+        mac = "aa:b2:92:00:00:26"
       }
     }
     server = {
       provider_settings = {
-        mac = "52:54:00:00:00:31"
+        mac = "aa:b2:92:00:00:31"
       }
     }
     proxy = {
       provider_settings = {
-        mac = "52:54:00:00:00:27"
+        mac = "aa:b2:92:00:00:27"
       }
     }
     suse-client = {
       image = "sles15sp1o"
       name = "cli-sles15"
       provider_settings = {
-        mac = "52:54:00:00:00:22"
+        mac = "aa:b2:92:00:00:22"
       }
     }
     suse-minion = {
       image = "sles15sp1o"
       name = "min-sles15"
       provider_settings = {
-        mac = "52:54:00:00:00:23"
+        mac = "aa:b2:92:00:00:23"
       }
     }
     build-host = {
       image = "sles15sp2o"
       provider_settings = {
-        mac = "52:54:00:00:00:30"
+        mac = "aa:b2:92:00:00:30"
       }
     }
     suse-sshminion = {
       image = "sles15sp1o"
       name = "minssh-sles15"
       provider_settings = {
-        mac = "52:54:00:00:00:24"
+        mac = "aa:b2:92:00:00:24"
       }
     }
     redhat-minion = {
       image = "centos7o"
       provider_settings = {
-        mac = "52:54:00:00:00:25"
+        mac = "aa:b2:92:00:00:25"
         // Openscap cannot run with less than 1.25 GB of RAM
         memory = 1280
       }
     }
     debian-minion = {
       provider_settings = {
-        mac = "52:54:00:00:00:28"
+        mac = "aa:b2:92:00:00:28"
       }
     }
     pxeboot-minion = {
@@ -172,7 +172,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp2o"
       provider_settings = {
-        mac = "52:54:00:00:00:29"
+        mac = "aa:b2:92:00:00:29"
       }
     }
   }

--- a/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
@@ -170,7 +170,7 @@ module "server" {
   product_version    = "4.1-released"
   name               = "srv"
   provider_settings = {
-    mac                = "52:54:00:46:86:8A"
+    mac                = "aa:b2:92:46:86:8a"
     memory             = 40960
     vcpu               = 10
     data_pool            = "default"
@@ -205,7 +205,7 @@ module "proxy" {
   product_version    = "4.1-released"
   name               = "pxy"
   provider_settings = {
-    mac                = "52:54:00:FA:0A:A5"
+    mac                = "aa:b2:92:fa:0a:a5"
     memory             = 4096
   }
   server_configuration = {
@@ -236,7 +236,7 @@ module "sles12sp4-client" {
   name               = "cli-sles12sp4"
   image              = "sles12sp4"
   provider_settings = {
-    mac                = "52:54:00:DE:8B:4B"
+    mac                = "aa:b2:92:de:8b:4b"
     memory             = 4096
   }
   server_configuration = {
@@ -259,7 +259,7 @@ module "sles11sp4-client" {
   name               = "cli-sles11sp4"
   image              = "sles11sp4"
   provider_settings = {
-    mac                = "52:54:00:CE:B2:F6"
+    mac                = "aa:b2:92:ce:b2:f6"
     memory             = 4096
   }
   server_configuration = {
@@ -283,7 +283,7 @@ module "sles15-client" {
   name               = "cli-sles15"
   image              = "sles15"
   provider_settings = {
-    mac                = "52:54:00:56:49:43"
+    mac                = "aa:b2:92:56:49:43"
     memory             = 4096
   }
   server_configuration = {
@@ -307,7 +307,7 @@ module "sles15sp1-client" {
   name               = "cli-sles15sp1"
   image              = "sles15sp1"
   provider_settings = {
-    mac                = "52:54:00:7A:84:9E"
+    mac                = "aa:b2:92:7a:84:9e"
     memory             = 4096
   }
   server_configuration = {
@@ -331,7 +331,7 @@ module "centos7-client" {
   name               = "cli-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "52:54:00:8E:E6:5B"
+    mac                = "aa:b2:92:8e:e6:5b"
     memory             = 4096
   }
   server_configuration = {
@@ -355,7 +355,7 @@ module "centos6-client" {
   name               = "cli-centos6"
   image              = "centos6o"
   provider_settings = {
-    mac                = "52:54:00:EE:2D:80"
+    mac                = "aa:b2:92:ee:2d:80"
     memory             = 4096
   }
   auto_register = false
@@ -377,7 +377,7 @@ module "sles12sp4-minion" {
   name               = "min-sles12sp4"
   image              = "sles12sp4"
   provider_settings = {
-    mac                = "52:54:00:9A:94:C9"
+    mac                = "aa:b2:92:9a:94:c9"
     memory             = 4096
   }
   server_configuration = {
@@ -401,7 +401,7 @@ module "sles11sp4-minion" {
   name               = "min-sles11sp4"
   image              = "sles11sp4"
   provider_settings = {
-    mac                = "52:54:00:6A:52:82"
+    mac                = "aa:b2:92:6a:52:82"
     memory             = 4096
   }
   server_configuration = {
@@ -425,7 +425,7 @@ module "sles15-minion" {
   name               = "min-sles15"
   image              = "sles15"
   provider_settings = {
-    mac                = "52:54:00:82:63:59"
+    mac                = "aa:b2:92:82:63:59"
     memory             = 4096
   }
 
@@ -450,7 +450,7 @@ module "sles15sp1-minion" {
   name               = "min-sles15sp1"
   image              = "sles15sp1"
   provider_settings = {
-    mac                = "52:54:00:CA:F7:A9"
+    mac                = "aa:b2:92:ca:f7:a9"
     memory             = 4096
   }
 
@@ -475,7 +475,7 @@ module "centos8-minion" {
   name               = "min-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "52:54:00:11:EA:1D"
+    mac                = "aa:b2:92:11:ea:1d"
     memory             = 4096
   }
   server_configuration = {
@@ -499,7 +499,7 @@ module "centos7-minion" {
   name               = "min-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "52:54:00:56:1E:C9"
+    mac                = "aa:b2:92:56:1e:c9"
     memory             = 4096
   }
   server_configuration = {
@@ -523,7 +523,7 @@ module "centos6-minion" {
   name               = "min-centos6"
   image              = "centos6o"
   provider_settings = {
-    mac                = "52:54:00:76:EF:77"
+    mac                = "aa:b2:92:76:ef:77"
     memory             = 4096
   }
   server_configuration =  { hostname = "suma-qam-41-pxy.mgr.prv.suse.net" }
@@ -546,7 +546,7 @@ module "ubuntu2004-minion" {
   name               = "min-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "52:54:00:15:A7:50"
+    mac                = "aa:b2:92:15:a7:50"
     memory             = 4096
   }
   server_configuration = {
@@ -571,7 +571,7 @@ module "ubuntu1804-minion" {
   name               = "min-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "52:54:00:7E:7D:ED"
+    mac                = "aa:b2:92:7e:7d:ed"
     memory             = 4096
   }
   server_configuration = {
@@ -595,7 +595,7 @@ module "ubuntu1604-minion" {
   name               = "min-ubuntu1604"
   image              = "ubuntu1604o"
   provider_settings = {
-    mac                = "52:54:00:DA:F0:A0"
+    mac                = "aa:b2:92:da:f0:a0"
     memory             = 4096
   }
   server_configuration =  { hostname =  "suma-qam-41-pxy.mgr.prv.suse.net" }
@@ -617,7 +617,7 @@ module "sles12sp4-sshminion" {
   name               = "minssh-sles12sp4"
   image              = "sles12sp4"
   provider_settings = {
-    mac                = "52:54:00:9A:51:7B"
+    mac                = "aa:b2:92:9a:51:7b"
     memory             = 4096
   }
 
@@ -636,7 +636,7 @@ module "sles11sp4-sshminion" {
   name               = "minssh-sles11sp4"
   image              = "sles11sp4"
   provider_settings = {
-    mac                = "52:54:00:56:0F:F7"
+    mac                = "aa:b2:92:56:0f:f7"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -653,7 +653,7 @@ module "sles15-sshminion" {
   name               = "minssh-sles15"
   image              = "sles15"
   provider_settings = {
-    mac                = "52:54:00:8A:F9:39"
+    mac                = "aa:b2:92:8a:f9:39"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -670,7 +670,7 @@ module "sles15sp1-sshminion" {
   name               = "minssh-sles15sp1"
   image              = "sles15sp1"
   provider_settings = {
-    mac                = "52:54:00:EE:AD:30"
+    mac                = "aa:b2:92:ee:ad:30"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -687,7 +687,7 @@ module "centos8-sshminion" {
   name               = "minssh-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "52:54:00:05:67:B3"
+    mac                = "aa:b2:92:05:67:b3"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -704,7 +704,7 @@ module "centos7-sshminion" {
   name               = "minssh-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "52:54:00:32:A9:28"
+    mac                = "aa:b2:92:32:a9:28"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -721,7 +721,7 @@ module "centos6-sshminion" {
   name               = "minssh-centos6"
   image              = "centos6o"
   provider_settings = {
-    mac                = "52:54:00:D6:E1:67"
+    mac                = "aa:b2:92:d6:e1:67"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -739,7 +739,7 @@ module "ubuntu2004-sshminion" {
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "52:54:00:E9:7F:D7"
+    mac                = "aa:b2:92:e9:7f:d7"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -757,7 +757,7 @@ module "ubuntu1804-sshminion" {
   name               = "minssh-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "52:54:00:EE:EC:95"
+    mac                = "aa:b2:92:ee:ec:95"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -774,7 +774,7 @@ module "ubuntu1604-sshminion" {
   name               = "minssh-ubuntu1604"
   image              = "ubuntu1604o"
   provider_settings = {
-    mac                = "52:54:00:96:3B:E1"
+    mac                = "aa:b2:92:96:3b:e1"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -786,7 +786,7 @@ module "controller" {
   base_configuration = module.base.configuration
   name               = "ctl"
   provider_settings = {
-    mac                = "52:54:00:BA:9D:AD"
+    mac                = "aa:b2:92:ba:9d:ad"
     memory             = 16384
     vcpu               = 8
   }

--- a/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
@@ -104,7 +104,7 @@ module "server" {
   channels                = ["sle-product-sles15-sp1-pool-x86_64", "sle-product-sles15-sp1-updates-x86_64", "sle-module-basesystem15-sp1-pool-x86_64", "sle-module-basesystem15-sp1-updates-x86_64", "sle-module-containers15-sp1-pool-x86_64", "sle-module-containers15-sp1-updates-x86_64", "sle-manager-tools15-pool-x86_64-sp1", "sle-manager-tools15-updates-x86_64-sp1"]
 
   provider_settings = {
-    mac    = "52:54:00:00:00:32"
+    mac    = "aa:b2:92:00:00:32"
     memory = 8192
   }
 }
@@ -120,7 +120,7 @@ module "suse-client" {
   use_os_released_updates = true
 
   provider_settings = {
-    mac = "52:54:00:00:00:33"
+    mac = "aa:b2:92:00:00:33"
   }
 }
 
@@ -135,7 +135,7 @@ module "suse-minion" {
   use_os_released_updates = true
 
   provider_settings = {
-    mac = "52:54:00:00:00:34"
+    mac = "aa:b2:92:00:00:34"
   }
 }
 
@@ -148,7 +148,7 @@ module "build-host" {
   server_configuration    = module.server.configuration
 
   provider_settings = {
-    mac = "52:54:00:00:00:40"
+    mac = "aa:b2:92:00:00:40"
   }
 }
 
@@ -163,7 +163,7 @@ module "redhat-minion" {
   auto_connect_to_master = false
 
   provider_settings = {
-    mac = "52:54:00:00:00:36"
+    mac = "aa:b2:92:00:00:36"
     // Openscap cannot run with less than 1.25 GB of RAM
     memory = 1280
     vcpu = 2
@@ -179,6 +179,6 @@ module "debian-minion" {
   server_configuration = module.server.configuration
 
   provider_settings = {
-    mac = "52:54:00:00:00:39"
+    mac = "aa:b2:92:00:00:39"
   }
 }


### PR DESCRIPTION
This PR prevents MAC address duplicates with private network by using a different prefix (`aa:b2:92` instead of `52:54:00`).

It also fixes one copy/paste error in QAM test suite (`ubuntu2004-sshminion` using `52:54:00:2A:47:D8` instead of `52:54:00:0E:28:39`).

See also https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/203
