### PR TITLE
Enable Ubuntu 20.04

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -93,7 +93,7 @@ module "cucumber_testsuite" {
   cc_password = var.SCC_PASSWORD
 
   # temporary: custom CentOS image due to broken Salt
-  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-40-"
@@ -160,6 +160,7 @@ module "cucumber_testsuite" {
       }
     }
     debian-minion = {
+      image = "ubuntu2004o"
       provider_settings = {
         mac = "AA:B2:93:00:00:47"
       }

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -94,7 +94,7 @@ module "cucumber_testsuite" {
   cc_password = var.SCC_PASSWORD
 
   # temporary: custom CentOS image due to broken Salt
-  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-40-"
@@ -163,6 +163,7 @@ module "cucumber_testsuite" {
       }
     }
     debian-minion = {
+      image = "ubuntu2004o"
       provider_settings = {
         mac = "aa:b2:92:00:00:08"
       }

--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-41-"
@@ -159,6 +159,7 @@ module "cucumber_testsuite" {
       }
     }
     debian-minion = {
+      image = "ubuntu2004o"
       provider_settings = {
         mac = "AA:B2:93:00:00:82"
       }

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -93,7 +93,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi = false
   name_prefix = "suma-41-"
@@ -162,6 +162,7 @@ module "cucumber_testsuite" {
       }
     }
     debian-minion = {
+      image = "ubuntu2004o"
       provider_settings = {
         mac = "aa:b2:92:00:00:28"
       }

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-head-"
@@ -162,6 +162,7 @@ module "cucumber_testsuite" {
       }
     }
     debian-minion = {
+      image = "ubuntu2004o"
       provider_settings = {
         mac = "AA:B2:93:00:00:28"
       }

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -92,7 +92,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu1804o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
       }
     }
     debian-minion = {
-      image = "ubuntu1804o"
+      image = "ubuntu2004o"
       provider_settings = {
         mac = "AA:B2:93:00:00:08"
       }


### PR DESCRIPTION
Enable Ubuntu 20.04 on 4.0, 4.1, Head, and Uyuni.

Reference and test machines are left alone for the time being.

See also uyuni-project/uyuni#2753 for the test suite part.
