### PR TITLE
Add xen minion to 4.0+ test suites and kvm refhead minion

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -175,6 +175,12 @@ module "cucumber_testsuite" {
         mac = "AA:B2:93:00:00:48"
       }
     }
+    xen-host = {
+      image = "sles15sp1o"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:49"
+      }
+    }
   }
   provider_settings = {
     pool = "ssd"

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -178,6 +178,12 @@ module "cucumber_testsuite" {
         mac = "aa:b2:92:00:00:09"
       }
     }
+    xen-host = {
+      image = "sles15sp1o"
+      provider_settings = {
+        mac = "aa:b2:92:00:01:10"
+      }
+    }
   }
   provider_settings = {
     pool = "ssd"

--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -174,6 +174,12 @@ module "cucumber_testsuite" {
         mac = "AA:B2:93:00:00:83"
       }
     }
+    xen-host = {
+      image = "sles15sp2o"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:84"
+      }
+    }
   }
   provider_settings = {
     pool = "ssd"

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -177,6 +177,12 @@ module "cucumber_testsuite" {
         mac = "aa:b2:92:00:00:29"
       }
     }
+    xen-host = {
+      image = "sles15sp2o"
+      provider_settings = {
+        mac = "aa:b2:92:00:01:30"
+      }
+    }
   }
   provider_settings = {
     pool = "ssd"

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -177,6 +177,12 @@ module "cucumber_testsuite" {
         mac = "AA:B2:93:00:00:29"
       }
     }
+    xen-host = {
+      image = "sles15sp2o"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:30"
+      }
+    }
   }
   provider_settings = {
     pool = "ssd"

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -179,3 +179,16 @@ module "debian-minion" {
     mac = "AA:B2:93:00:00:37"
   }
 }
+
+module "kvm-minion" {
+  source               = "./modules/virthost"
+  base_configuration   = module.base.configuration
+  product_version      = "head"
+  name                 = "min-kvm"
+  image                = "sles15sp2o"
+  server_configuration = module.server.configuration
+
+  provider_settings = {
+    mac = "AA:B2:93:00:01:40"
+  }
+}

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -176,6 +176,12 @@ module "cucumber_testsuite" {
         mac = "AA:B2:93:00:00:07"
       }
     }
+    xen-host = {
+      image = "opensuse152o"
+      provider_settings = {
+        mac = "AA:B2:93:00:01:08"
+      }
+    }
   }
   provider_settings = {
     pool               = "ssd"


### PR DESCRIPTION
Now run the Xen cucumber tests. Also add a KVM minion on refhead to allow everyone to play with the virtualization features