### PR TITLE
Mount the files that we mirror

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
@@ -795,12 +795,16 @@ module "controller" {
 resource "null_resource" "server_extra_nfs_mounts" {
   provisioner "remote-exec" {
     inline = [
-      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES6/x86_64  /mirror/repo/$RCE/RES6/x86_64  nfs   defaults  0 0' >> /etc/fstab",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES6/x86_64         /mirror/repo/$RCE/RES6/x86_64         nfs  defaults  0 0' >> /etc/fstab",
       "mount '/mirror/repo/$RCE/RES6/x86_64'",
-      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7/x86_64  /mirror/repo/$RCE/RES7/x86_64  nfs   defaults  0 0' >> /etc/fstab",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7/x86_64         /mirror/repo/$RCE/RES7/x86_64         nfs  defaults  0 0' >> /etc/fstab",
       "mount '/mirror/repo/$RCE/RES7/x86_64'",
-      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES8/x86_64  /mirror/repo/$RCE/RES8/x86_64  nfs   defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES8/x86_64'"
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES/8/x86_64     /mirror/SUSE/Updates/RES/8/x86_64     nfs  defaults  0 0' >> /etc/fstab",
+      "mount '/mirror/SUSE/updates/RES/8/x86_64'",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-CB/8/x86_64  /mirror/SUSE/Updates/RES-CB/8/x86_64  nfs  defaults  0 0' >> /etc/fstab",
+      "mount '/mirror/SUSE/updates/RES-CB/8/x86_64'",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-AS/8/x86_64  /mirror/SUSE/Updates/RES-AS/8/x86_64  nfs  defaults  0 0' >> /etc/fstab",
+      "mount '/mirror/SUSE/updates/RES-AS/8/x86_64'"
     ]
     connection {
       type     = "ssh"

--- a/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
@@ -845,12 +845,16 @@ module "controller" {
 resource "null_resource" "server_extra_nfs_mounts" {
   provisioner "remote-exec" {
     inline = [
-      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES6/x86_64  /mirror/repo/$RCE/RES6/x86_64  nfs   defaults  0 0' >> /etc/fstab",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES6/x86_64         /mirror/repo/$RCE/RES6/x86_64         nfs  defaults  0 0' >> /etc/fstab",
       "mount '/mirror/repo/$RCE/RES6/x86_64'",
-      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7/x86_64  /mirror/repo/$RCE/RES7/x86_64  nfs   defaults  0 0' >> /etc/fstab",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7/x86_64         /mirror/repo/$RCE/RES7/x86_64         nfs  defaults  0 0' >> /etc/fstab",
       "mount '/mirror/repo/$RCE/RES7/x86_64'",
-      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES8/x86_64  /mirror/repo/$RCE/RES8/x86_64  nfs   defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES8/x86_64'"
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES/8/x86_64     /mirror/SUSE/Updates/RES/8/x86_64     nfs  defaults  0 0' >> /etc/fstab",
+      "mount '/mirror/SUSE/updates/RES/8/x86_64'",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-CB/8/x86_64  /mirror/SUSE/Updates/RES-CB/8/x86_64  nfs  defaults  0 0' >> /etc/fstab",
+      "mount '/mirror/SUSE/updates/RES-CB/8/x86_64'",
+      "echo 'minima-mirror-qam2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-AS/8/x86_64  /mirror/SUSE/Updates/RES-AS/8/x86_64  nfs  defaults  0 0' >> /etc/fstab",
+      "mount '/mirror/SUSE/updates/RES-AS/8/x86_64'"
     ]
     connection {
       type     = "ssh"


### PR DESCRIPTION
We moved from ibs to scc for RES, now we need to adapt NFS accordingly.

This is the client part, see https://gitlab.suse.de/qa-css/css-infrastructure/-/merge_requests/57 for the server part.
