### PR TITLE
Use official image for SLE 15 SP1

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-qam.tf
@@ -85,7 +85,7 @@ provider "libvirt" {
 
 provider "libvirt" {
   alias = "giediprime"
-  uri = "qemu+tcp://giediprime.mgr.suse.net/system"
+  uri = "qemu+tcp://giediprime.mgr.prv.suse.net/system"
 }
 
 
@@ -97,7 +97,7 @@ module "base" {
   name_prefix = "suma-qam-40-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15o", "sles15sp1", "opensuse152o" ]
+  images      = [ "sles15o", "sles15sp1o", "opensuse152o" ]
 
   mirror = "minima-mirror-qam.mgr.prv.suse.net"
   use_mirror_images = true
@@ -149,7 +149,7 @@ module "base3" {
   name_prefix = "suma-qam-40-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o",  "ubuntu1804o", "ubuntu1604o", "ubuntu2004o", "centos8o" ]
+  images      = [ "sles15sp1o", "ubuntu1804o", "ubuntu1604o", "ubuntu2004o", "centos8o" ]
 
   mirror = "minima-mirror-qam.mgr.prv.suse.net"
   use_mirror_images = true
@@ -169,7 +169,7 @@ module "server" {
   base_configuration = module.base.configuration
   product_version    = "4.0-released"
   name               = "srv"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
   provider_settings = {
     mac                = "aa:b2:92:f6:5d:e8"
     memory             = 40960
@@ -196,7 +196,7 @@ module "server" {
   ssh_key_path                   = "./salt/controller/id_rsa.pub"
   from_email                     = "root@suse.de"
 
-  //srv_additional_repos
+  //server_additional_repos
 
 }
 
@@ -205,7 +205,7 @@ module "proxy" {
   base_configuration = module.base.configuration
   product_version    = "4.0-released"
   name               = "pxy"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
   provider_settings = {
     mac                = "aa:b2:92:f2:4d:7a"
     memory             = 4096
@@ -738,7 +738,7 @@ module "controller" {
   provider_settings = {
     mac                = "aa:b2:92:b2:cf:9b"
     memory             = 16384
-    vcpu               = 6
+    vcpu               = 10
   }
   swap_file_size = null
 

--- a/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
@@ -1,4 +1,4 @@
-  // Mandatory variables for terracumber
+// Mandatory variables for terracumber
 variable "URL_PREFIX" {
   type = "string"
   default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-qam-setup-cucumber"
@@ -97,7 +97,7 @@ module "base" {
   name_prefix = "suma-qam-41-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = ["sles15sp2o", "opensuse152o" ]
+  images      = [ "sles15sp2o", "opensuse152o" ]
 
   mirror = "minima-mirror-qam.mgr.prv.suse.net"
   use_mirror_images = true
@@ -149,7 +149,7 @@ module "base3" {
   name_prefix = "suma-qam-41-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "centos8o" ]
+  images      = [ "sles15sp1o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "centos8o" ]
 
   mirror = "minima-mirror-qam.mgr.prv.suse.net"
   use_mirror_images = true
@@ -305,7 +305,7 @@ module "sles15sp1-client" {
   base_configuration = module.base3.configuration
   product_version    = "4.1-released"
   name               = "cli-sles15sp1"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
   provider_settings = {
     mac                = "aa:b2:92:7a:84:9e"
     memory             = 4096
@@ -448,7 +448,7 @@ module "sles15sp1-minion" {
   base_configuration = module.base3.configuration
   product_version    = "4.1-released"
   name               = "min-sles15sp1"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
   provider_settings = {
     mac                = "aa:b2:92:ca:f7:a9"
     memory             = 4096
@@ -668,7 +668,7 @@ module "sles15sp1-sshminion" {
   base_configuration = module.base3.configuration
   product_version    = "4.1-released"
   name               = "minssh-sles15sp1"
-  image              = "sles15sp1"
+  image              = "sles15sp1o"
   provider_settings = {
     mac                = "aa:b2:92:ee:ad:30"
     memory             = 4096


### PR DESCRIPTION
This PR changes `sles15sp1` into `sles15sp1o` for QAM.

It also fixes a number of typos and resynchronizes 4.0's `main.tf` with 4.1's one.