### PR TITLE
Set global timeout to 12 hours for head NUE

### DIFF
--- a/jenkins_pipelines/environments/manager-Head-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-Head-cucumber-NUE
@@ -24,7 +24,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: false, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
The last several runs took > 10 h (default limit), thus they were automatically aborted.