### PR TITLE
Set global timeout to 12 hours for 4.0 @ PRV

### DIFF
--- a/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
@@ -24,7 +24,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: false, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
Last several runs took > 10 h (default limit)