### PR TITLE
QA: Support run a testsuite filtering tests by scope

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -39,8 +39,8 @@ def run(params) {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:init_clients'"
             }
             stage('Secondary features') {
-                def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
-                def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus:true
+                def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; export PROFILE=${params.functional_scope}; cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
+                def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; export PROFILE=${params.functional_scope}; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus:true
                 sh "exit \$(( ${statusCode1}|${statusCode2} ))"
             }
         }

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-NUE
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-cucumber-PRV
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-Head-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-Head-cucumber-NUE
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-cucumber
@@ -19,7 +19,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-cucumber
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-cucumber
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-TEST-cucumber
+++ b/jenkins_pipelines/environments/manager-TEST-cucumber
@@ -18,7 +18,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 

--- a/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
@@ -19,7 +19,8 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: false, description: 'Call terraform init (needed if modules are added or changes)'),
-            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            choice(name: 'functional_scope', choices: ['default', 'smdba', 'spacecmd', 'spacewalk_utils', 'visualization', 'notification_message', 'virtual_host_manager',  'subscription_matching', 'formulas', 'sp_migration', 'cve_audit', 'onboarding', 'content_lifecycle_management', 'res', 'recurring_actions', 'maintenance_windows', 'cluster_management', 'building_container_images', 'kubernetes_integration', 'openscap', 'ubuntu', 'action_chains', 'salt_ssh', 'tomcat', 'changing_software_channels', 'monitoring', 'salt', 'cobbler', 'sumatoolbox', 'virtualization', 'hub', 'retail', 'configuration_channels', 'content_staging', 'proxy', 'traditional_client', 'xmlrpc', 'power_management'], description: 'Choose a functional scope and your job will only run tests of that scope')
         ])
     ])
 


### PR DESCRIPTION
Second part of https://github.com/SUSE/spacewalk/issues/12831

By using the environment variable PROFILE, we provide via Jenkins choice parameter, a Cucumber profile to our Rake task.
This will allow us to run a test suite running only a certain profile, which normally matches a certain group.

Note that this is the first approach. If people embrace it, we can re-visit and we might change it from a choice parameter to checkboxes, so we can select more than one profile. But that will also require a change in our product code.