### PR TITLE
QAM: Adding VMs necessary for retail tests

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-qam.tf
@@ -132,7 +132,6 @@ module "base_old_sle" {
   provider_settings = {
     pool        = "default"
     bridge      = "br1"
-    additional_network = "192.168.41.0/24"
   }
 }
 
@@ -183,7 +182,6 @@ module "base_newsle_ubuntu" {
   provider_settings = {
     pool        = "default"
     bridge      = "br1"
-    additional_network = "192.168.41.0/24"
   }
 }
 
@@ -866,6 +864,135 @@ module "ubuntu1604-sshminion" {
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
+module "sles11sp4-buildhost" {
+  providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_old_sle.configuration
+  product_version    = "4.1-released"
+  name               = "buildhost-sles11sp4"
+  image              = "sles11sp4"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:7c"
+    memory             = 2048
+    vcpu               = 2
+  }
+  server_configuration = {
+    hostname = "suma-qam-41-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "sles11sp3-terminal" {
+  providers = {
+    libvirt = libvirt.arrakis
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_old_sle.configuration
+  product_version    = "4.1-released"
+  name               = "terminal-sles11sp4"
+  image              = "sles11sp4" # This is not a typo
+  provider_settings = {
+    memory             = 1024
+    vcpu               = 1
+    pool               = "default"
+    additional_network = "192.168.41.0/24"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "sles12sp4-buildhost" {
+  providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_old_sle.configuration
+  product_version    = "4.1-released"
+  name               = "buildhost-sles12sp4"
+  image              = "sles12sp4o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:7d"
+    memory             = 2048
+    vcpu               = 2
+  }
+  server_configuration = {
+    hostname = "suma-qam-41-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "sles12sp4-terminal" {
+  providers = {
+    libvirt = libvirt.arrakis
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_old_sle.configuration
+  product_version    = "4.1-released"
+  name               = "terminal-sles12sp4"
+  image              = "sles12sp4o"
+  provider_settings = {
+    memory             = 1024
+    vcpu               = 1
+    pool               = "default"
+    additional_network = "192.168.41.0/24"
+  }
+
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "sles15sp2-buildhost" {
+  providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_newsle_ubuntu.configuration
+  product_version    = "4.1-released"
+  name               = "min-sles15sp2"
+  image              = "sles15sp2o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:7e"
+    memory             = 2048
+    vcpu               = 2
+  }
+
+  server_configuration = {
+    hostname = "suma-qam-41-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "sles15sp2-terminal" {
+  providers = {
+    libvirt = libvirt.arrakis
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_newsle_ubuntu.configuration
+  product_version    = "4.1-released"
+  name               = "terminal-sles15sp2"
+  image              = "sles15sp2o"
+  provider_settings = {
+    memory             = 2048
+    vcpu               = 2
+    pool               = "default"
+    additional_network = "192.168.41.0/24"
+  }
+
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "controller" {
   source             = "./modules/controller"
   base_configuration = module.base_core.configuration
@@ -929,6 +1056,14 @@ module "controller" {
 
   ubuntu2004_minion_configuration = module.ubuntu2004-minion.configuration
   ubuntu2004_sshminion_configuration = module.ubuntu2004-sshminion.configuration
+
+  sle11sp4_buildhost_configuration = module.sles11sp4-buildhost.configuration
+  sle12sp4_buildhost_configuration = module.sles12sp4-buildhost.configuration
+  sle15sp2_buildhost_configuration = module.sles15sp2-buildhost.configuration
+
+  sle11sp3_terminal_configuration = module.sles11sp3-terminal.configuration
+  sle12sp4_terminal_configuration = module.sles12sp4-terminal.configuration
+  sle15sp2_terminal_configuration = module.sles15sp2-terminal.configuration
 }
 
 resource "null_resource" "server_extra_nfs_mounts" {


### PR DESCRIPTION
We need 3 buildhosts for building all types of retail kiwi images and the same number of retail terminals. We also need to assure private network is located at the same hypervisor as proxy (branch server) and all the terminals for pxe booting.

This PR must be merged after: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/261