### PR TITLE
Enable SP migration at reposync and init_clients stages

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -33,10 +33,10 @@ def run(params) {
 
             stage('Core - Setup') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; cd /root/spacewalk/testsuite; rake cucumber:core'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; cd /root/spacewalk/testsuite; rake cucumber:reposync'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; export SERVICE_PACK_MIGRATION=${params.service_pack_migration}; cd /root/spacewalk/testsuite; rake cucumber:reposync'"
             }
             stage('Core - Initialize clients') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:init_clients'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; export SERVICE_PACK_MIGRATION=${params.service_pack_migration}; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:init_clients'"
             }
             stage('Secondary features') {
                 def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export LONG_TESTS=${params.long_tests}; export PROFILE=${params.functional_scope}; cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
@@ -14,6 +14,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
@@ -14,6 +14,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/manager-Head-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-Head-cucumber-NUE
@@ -14,6 +14,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/manager-Head-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-reference-NUE
@@ -12,6 +12,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
@@ -15,6 +15,7 @@ node('sumaform-cucumber') {
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
             booleanParam(name: 'long_tests', defaultValue: false, description: 'This will enable the execution of long tests'),
+            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),


### PR DESCRIPTION
In order to run the SP migration by default, we must
inject the environment variable controlling that into the pipe.

Add parameter service_pack_migration with default true.
Export SERVICE_PACK_MIGRATION in all the stages that need this variable.
- jenkins_pipelines/environments/common/pipeline.groovy
- jenkins_pipelines/environments/manager-4.1-cucumber-NUE
- jenkins_pipelines/environments/manager-4.1-cucumber-PRV
- jenkins_pipelines/environments/manager-Head-cucumber-NUE
- jenkins_pipelines/environments/manager-Head-reference-NUE
- jenkins_pipelines/environments/uyuni-master-cucumber-NUE