### PR TITLE
Temporary disable the SP migration

### DIFF
--- a/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-NUE
@@ -14,7 +14,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
-            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
+            booleanParam(name: 'service_pack_migration', defaultValue: false, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-cucumber-PRV
@@ -14,7 +14,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
-            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
+            booleanParam(name: 'service_pack_migration', defaultValue: false, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/manager-Head-cucumber-NUE
+++ b/jenkins_pipelines/environments/manager-Head-cucumber-NUE
@@ -14,7 +14,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
-            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
+            booleanParam(name: 'service_pack_migration', defaultValue: false, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/manager-Head-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-reference-NUE
@@ -12,7 +12,7 @@ node('sumaform-cucumber') {
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
-            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
+            booleanParam(name: 'service_pack_migration', defaultValue: false, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),

--- a/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-cucumber-NUE
@@ -15,7 +15,7 @@ node('sumaform-cucumber') {
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform_bin'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
             booleanParam(name: 'long_tests', defaultValue: false, description: 'This will enable the execution of long tests'),
-            booleanParam(name: 'service_pack_migration', defaultValue: true, description: 'This will enable the execution of service pack migration'),
+            booleanParam(name: 'service_pack_migration', defaultValue: false, description: 'This will enable the execution of service pack migration'),
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://gitlab.suse.de/juliogonzalezgil/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),


### PR DESCRIPTION
After the SP migration the migrated minion gets
the Salt version in SCC, i.e., and older version that
the one we should test.
Disable the SP migration while we investigate a long-term solution.