### PR TITLE
Sync SLE15SP1 channels for 4.0 reference environments

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-NUE.tf
@@ -99,7 +99,7 @@ module "server" {
   use_os_released_updates = true
   disable_download_tokens = false
   from_email              = "root@suse.de"
-  channels                = ["sle-product-sles15-pool-x86_64", "sle-product-sles15-updates-x86_64", "sle-module-basesystem15-pool-x86_64", "sle-module-basesystem15-updates-x86_64", "sle-module-containers15-pool-x86_64", "sle-module-containers15-updates-x86_64"]
+  channels                = ["sle-product-sles15-sp1-pool-x86_64", "sle-product-sles15-sp1-updates-x86_64", "sle-module-basesystem15-sp1-pool-x86_64", "sle-module-basesystem15-sp1-updates-x86_64", "sle-module-containers15-sp1-pool-x86_64", "sle-module-containers15-sp1-updates-x86_64", "sle-manager-tools15-pool-x86_64-sp1", "sle-manager-tools15-updates-x86_64-sp1"]
 
   provider_settings = {
     mac    = "AA:B2:93:00:00:50"

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
@@ -101,7 +101,7 @@ module "server" {
   use_os_released_updates = true
   disable_download_tokens = false
   from_email              = "root@suse.de"
-  channels                = ["sle-product-sles15-pool-x86_64", "sle-product-sles15-updates-x86_64", "sle-module-basesystem15-pool-x86_64", "sle-module-basesystem15-updates-x86_64", "sle-module-containers15-pool-x86_64", "sle-module-containers15-updates-x86_64"]
+  channels                = ["sle-product-sles15-sp1-pool-x86_64", "sle-product-sles15-sp1-updates-x86_64", "sle-module-basesystem15-sp1-pool-x86_64", "sle-module-basesystem15-sp1-updates-x86_64", "sle-module-containers15-sp1-pool-x86_64", "sle-module-containers15-sp1-updates-x86_64", "sle-manager-tools15-pool-x86_64-sp1", "sle-manager-tools15-updates-x86_64-sp1"]
 
   provider_settings = {
     mac    = "aa:b2:92:00:00:10"


### PR DESCRIPTION
We have SLE15SP1 client, so we need SLE15SP1 channels (same as we do for 4.1).

This starting failing since I removed SLE15SP0 from the mirror on December, and seems nobody complained, so looks to me that the ref40 environment is not that popular :-)