### PR TITLE
Add base image for the proxy on terminus

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -207,7 +207,7 @@ module "base_retail" {
   name_prefix = "suma-bv-41-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp2o", "opensuse152o", "sles11sp4", "sles12sp4o"]
+  images      = [ "opensuse152o", "sles11sp4", "sles12sp4o", "sles15sp2o" ]
 
   // mirror = "minima-mirror-qam.mgr.prv.suse.net"
   // use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
@@ -207,7 +207,7 @@ module "base_retail" {
   name_prefix = "suma-bv-42-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp2o", "opensuse152o", "sles11sp4", "sles12sp4o"]
+  images      = [ "opensuse152o", "sles11sp4", "sles12sp4o", "sles15sp2o", "sles15sp3o" ]
 
   // mirror = "minima-mirror-qam.mgr.prv.suse.net"
   // use_mirror_images = true


### PR DESCRIPTION
4.2 build validation:

proxy moved to same hypervisor as build hosts and retail terminals

its base image needs therefore to be there as well