### PR TITLE
Add request review and author assign workflows

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,26 @@
+reviewers:
+  # Reviewer groups each of which has a list of GitHub usernames
+  groups:
+    qa:
+      - ktsamis
+      - atighineanu
+      - maximenoel8
+      - lkotek
+      - srbarrios
+      - Bischoff
+      - calancha
+
+files:
+  # Keys are glob expressions.
+  # You can assign groups defined above as well as GitHub usernames.
+  'terracumber_config/tf_files/*beta-build-validation.tf':
+    - qa
+  'jenkins_pipelines/environments/common/pipeline-build-validation.groovy'
+    - qa
+
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - WIP
+    - DRAFT
+  enable_group_assignment: true

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,13 @@
+name: 'Auto Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.2.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,16 @@
+name: Auto Request Review
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize, reopened, edited]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.5.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml # Config file location override


### PR DESCRIPTION
Add request review and author assign workflows, I put some example files in reviewers.yml , we can add more or subtract. Also we should add each squad as reviewers for their own tf files to be updated every time they change. Or not. Let's discuss it.