### PR TITLE
Add new experimental java in all CI runs to test

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -121,6 +121,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:81"
       }
+      additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:81"
       }
-      additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
+      additional_repos = { java11 = "https://download.opensuse.org/repositories/Java:/Factory/SLE_15_SP1/" }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -120,6 +120,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:a1"
       }
+      additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -120,7 +120,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:a1"
       }
-      additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
+      additional_repos = { java11 = "https://download.opensuse.org/repositories/Java:/Factory/SLE_15_SP2/" }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -279,7 +279,7 @@ module "server" {
   from_email                     = "root@suse.de"
 
   //server_additional_repos
-  additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
+  additional_repos = { java11 = "https://download.opensuse.org/repositories/Java:/Factory/SLE_15_SP2/" }
 }
 
 module "proxy" {

--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -279,7 +279,7 @@ module "server" {
   from_email                     = "root@suse.de"
 
   //server_additional_repos
-
+  additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
 }
 
 module "proxy" {

--- a/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
@@ -280,6 +280,7 @@ module "server" {
 
   //server_additional_repos
 
+  additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
 }
 
 module "proxy" {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -82,7 +82,7 @@ module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
   product_version = "head"
-  
+
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
   git_password = var.GIT_PASSWORD
@@ -117,6 +117,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:b1"
       }
+      additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -82,7 +82,7 @@ module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
   product_version = "uyuni-master"
-  
+
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
   git_password = var.GIT_PASSWORD
@@ -117,6 +117,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:d1"
       }
+      additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -117,7 +117,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:d1"
       }
-      additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
     }
     proxy = {
       provider_settings = {


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/14634

It might cause problems in the build validation repos, we might have duplicate the additional_repos key. I will see in the next deployment and fix it. The fix would be simply to remove it from main.tf and add it in the default template in the json