### PR TITLE
Use Uyuni-2021.04 for Uyuni

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
@@ -7,7 +7,7 @@ node('sumaform-cucumber') {
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
-            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'cucumber_ref', defaultValue: 'Uyuni-2021.04', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),


### PR DESCRIPTION
As I need to retest it again, before re-releasing, because of the problems we had with publishing for the Server and the Proxy.