### PR TITLE
Remove from BV because we add them in the json

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -279,7 +279,6 @@ module "server" {
   from_email                     = "root@suse.de"
 
   //server_additional_repos
-  additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
 }
 
 module "proxy" {

--- a/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
@@ -280,7 +280,6 @@ module "server" {
 
   //server_additional_repos
 
-  additional_repos = { java11 = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/" }
 }
 
 module "proxy" {


### PR DESCRIPTION
Remove from BV because we add them in the json and otherwise makes deployment fail