### PR TITLE
CI: Force unlock and ignore errors

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -112,7 +112,7 @@ def run(params) {
         finally {
             stage('Remove build project') {
                 if (params.must_remove_build) {
-                    sh "osc unlock ${params.builder_project}:${params.pull_request_number} -m 'unlock to remove'"
+                    sh "osc unlock ${params.builder_project}:${params.pull_request_number} -m 'unlock to remove' 2> /dev/null|| true"
                     sh "python3 ${WORKSPACE}/product/susemanager-utils/testing/automation/obs-project.py --prproject ${params.builder_project} --configfile $HOME/.oscrc remove --noninteractive ${params.pull_request_number}"
                 }
             }


### PR DESCRIPTION
We need to make sure the project is unlock before removing it in obs.
However, if it was not, unlocking returns an error. Let's just "force
the unlock" by running the unlock command and ignoring the error.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>