### PR TITLE
CI: use a copy of master project but locked

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -27,6 +27,7 @@ def run(params) {
                                     extensions: [[$class: 'CloneOption', depth: 1, shallow: true]],
                                     userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*', url: "${params.pull_request_repo}"]]
                                 ])
+                        sh "osc lock ${params.source_project}:TEST:${env_number}:CR"
                         sh "python3 susemanager-utils/testing/automation/obs-project.py --prproject ${params.builder_project} --configfile $HOME/.oscrc add --repo ${params.build_repo} ${params.pull_request_number}"
                         sh "bash susemanager-utils/testing/automation/push-to-obs.sh -v -t -d \"${params.builder_api}|${params.source_project}\" -n \"${params.builder_project}:${params.pull_request_number}\" -c $HOME/.oscrc"
                         echo "Checking ${params.builder_project}:${params.pull_request_number}"
@@ -74,6 +75,7 @@ def run(params) {
                     // Passing the built repository by parameter using a environment variable to terraform file
                     // TODO: We will need to add a logic to replace the host, when we use IBS for spacewalk
                     env.PULL_REQUEST_REPO = "http://download.opensuse.org/repositories/${params.builder_project}:${params.pull_request_number}/openSUSE_Leap_15.2/"
+                    env.MASTER_REPO = "http://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR/openSUSE_Leap_15.2"
 
                     // Provision the environment
                     if (terraform_init) {
@@ -81,7 +83,7 @@ def run(params) {
                     } else {
                         env.TERRAFORM_INIT = ''
                     }
-                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_PULL_REQUEST_REPO=${PULL_REQUEST_REPO}; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${terraform_bin}; export TERRAFORM_PLUGINS=${terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
+                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_PULL_REQUEST_REPO=${PULL_REQUEST_REPO}; export TF_VAR_MASTER_REPO=${MASTER_REPO};export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${terraform_bin}; export TERRAFORM_PLUGINS=${terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
                     deployed = true
                 }
             }
@@ -132,6 +134,7 @@ def run(params) {
             stage('Remove build project') {
                 if (params.must_remove_build) {
                     sh "osc unlock ${params.builder_project}:${params.pull_request_number} -m 'unlock to remove' 2> /dev/null|| true"
+                    sh "osc unlock ${params.source_project}:TEST:${env_number}:CR -m 'unlock to rebuild' 2> /dev/null || true "
                     sh "python3 ${WORKSPACE}/product/susemanager-utils/testing/automation/obs-project.py --prproject ${params.builder_project} --configfile $HOME/.oscrc remove --noninteractive ${params.pull_request_number}"
                 }
             }

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -27,7 +27,7 @@ def run(params) {
                                     extensions: [[$class: 'CloneOption', depth: 1, shallow: true]],
                                     userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*', url: "${params.pull_request_repo}"]]
                                 ])
-                        sh "osc lock ${params.source_project}:TEST:${env_number}:CR"
+                        sh "osc lock ${params.source_project}:TEST:${env_number}:CR 2> /dev/null || true"
                         sh "python3 susemanager-utils/testing/automation/obs-project.py --prproject ${params.builder_project} --configfile $HOME/.oscrc add --repo ${params.build_repo} ${params.pull_request_number}"
                         sh "bash susemanager-utils/testing/automation/push-to-obs.sh -v -t -d \"${params.builder_api}|${params.source_project}\" -n \"${params.builder_project}:${params.pull_request_number}\" -c $HOME/.oscrc"
                         echo "Checking ${params.builder_project}:${params.pull_request_number}"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -79,6 +79,10 @@ variable "PULL_REQUEST_REPO" {
   type = "string"
 }
 
+variable "MASTER_REPO" {
+  type = "string"
+}
+
 provider "libvirt" {
   uri = "qemu+tcp://romulus.mgr.prv.suse.net/system"
 }
@@ -124,6 +128,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     proxy = {
@@ -132,6 +137,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     suse-client = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -79,6 +79,10 @@ variable "PULL_REQUEST_REPO" {
   type = "string"
 }
 
+variable "MASTER_REPO" {
+  type = "string"
+}
+
 provider "libvirt" {
   uri = "qemu+tcp://romulus.mgr.prv.suse.net/system"
 }
@@ -124,6 +128,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     proxy = {
@@ -132,6 +137,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     suse-client = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -79,6 +79,10 @@ variable "PULL_REQUEST_REPO" {
   type = "string"
 }
 
+variable "MASTER_REPO" {
+  type = "string"
+}
+
 provider "libvirt" {
   uri = "qemu+tcp://vulcan.mgr.prv.suse.net/system"
 }
@@ -124,6 +128,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     proxy = {
@@ -132,6 +137,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     suse-client = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -79,6 +79,10 @@ variable "PULL_REQUEST_REPO" {
   type = "string"
 }
 
+variable "MASTER_REPO" {
+  type = "string"
+}
+
 provider "libvirt" {
   uri = "qemu+tcp://vulcan.mgr.prv.suse.net/system"
 }
@@ -124,6 +128,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     proxy = {
@@ -132,6 +137,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     suse-client = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -79,6 +79,10 @@ variable "PULL_REQUEST_REPO" {
   type = "string"
 }
 
+variable "MASTER_REPO" {
+  type = "string"
+}
+
 provider "libvirt" {
   uri = "qemu+tcp://hyperion.mgr.prv.suse.net/system"
 }
@@ -124,6 +128,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     proxy = {
@@ -132,6 +137,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     suse-client = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -79,6 +79,10 @@ variable "PULL_REQUEST_REPO" {
   type = "string"
 }
 
+variable "MASTER_REPO" {
+  type = "string"
+}
+
 provider "libvirt" {
   uri = "qemu+tcp://hyperion.mgr.prv.suse.net/system"
 }
@@ -124,6 +128,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     proxy = {
@@ -132,6 +137,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
+        master_repo = var.MASTER_REPO,
       }
     }
     suse-client = {


### PR DESCRIPTION
This is for PR testing. In order to prevent issues when packages are
being rebuild, which happens for example when packages are in a state A
when deploying, and state B when running the tests. Some tests will try
to install packages.

Having an error because of inconsistent metadata at the test it is very
paintful because we have to retrigger a 2 hour job.

Instead, we have a project for each environment which has links to all
packages in sm:Uyuni:Master. This way, we can disable the build before
running the tests.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

https://github.com/SUSE/spacewalk/issues/14654