### PR TITLE
Fix CI OBS links

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -46,7 +46,7 @@ def run(params) {
                                 ])
                         sh "osc lock ${params.source_project}:TEST:${env_number}:CR 2> /dev/null || true"
                         sh "python3 susemanager-utils/testing/automation/obs-project.py --prproject ${params.builder_project} --configfile $HOME/.oscrc add --repo ${params.build_repo} ${params.pull_request_number}"
-                        sh "bash susemanager-utils/testing/automation/push-to-obs.sh -v -t -d \"${params.builder_api}|${params.source_project}\" -n \"${params.builder_project}:${params.pull_request_number}\" -c $HOME/.oscrc"
+                        sh "bash susemanager-utils/testing/automation/push-to-obs.sh -v -t -d \"${params.builder_api}|${params.source_project}:TEST:${env_number}:CR\" -n \"${params.builder_project}:${params.pull_request_number}\" -c $HOME/.oscrc"
                         echo "Checking ${params.builder_project}:${params.pull_request_number}"
                         sh "bash susemanager-utils/testing/automation/wait-for-builds.sh -a ${params.builder_api} -c $HOME/.oscrc -p ${params.builder_project}:${params.pull_request_number}"
                         built = true


### PR DESCRIPTION
Links should go to sm:Uyuni:Master:TEST:XX:CR , so they get a higher
release number. Otherwise, packages could be installed from
sm:Uyuni:Master:TEST:XX:CR instead of from sm:Uyuni:Master:PR:YY

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>