### PR TITLE
Do not run smdba tests by default in Pull Requests

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -148,9 +148,9 @@ def run(params) {
                 }
                 if (deployed) {
                     try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing'"
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing_pr'"
                     } catch(Exception ex) {
-                        println("ERROR: rake cucumber:finishing failed")
+                        println("ERROR: rake cucumber:finishing_pr failed")
                         error = 1
                     }
                     try {


### PR DESCRIPTION
These take 9 minutes and they are not needed always.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>