### PR TITLE
Expand links when runing push-to-obs

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -46,7 +46,7 @@ def run(params) {
                                 ])
                         sh "osc lock ${params.source_project}:TEST:${env_number}:CR 2> /dev/null || true"
                         sh "python3 susemanager-utils/testing/automation/obs-project.py --prproject ${params.builder_project} --configfile $HOME/.oscrc add --repo ${params.build_repo} ${params.pull_request_number}"
-                        sh "bash susemanager-utils/testing/automation/push-to-obs.sh -v -t -d \"${params.builder_api}|${params.source_project}:TEST:${env_number}:CR\" -n \"${params.builder_project}:${params.pull_request_number}\" -c $HOME/.oscrc"
+                        sh "bash susemanager-utils/testing/automation/push-to-obs.sh -v -t -d \"${params.builder_api}|${params.source_project}:TEST:${env_number}:CR\" -n \"${params.builder_project}:${params.pull_request_number}\" -c $HOME/.oscrc -e"
                         echo "Checking ${params.builder_project}:${params.pull_request_number}"
                         sh "bash susemanager-utils/testing/automation/wait-for-builds.sh -u -a ${params.builder_api} -c $HOME/.oscrc -p ${params.builder_project}:${params.pull_request_number}"
                         built = true


### PR DESCRIPTION
Otherwise, given sm:Uyuni:Master:TEST:X:CR are links, the script always
finds out that all packages need to be updated, because it checkouts the
_link file instead of the contents.

See
https://github.com/uyuni-project/uyuni/pull/3643

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>