### PR TITLE
Fix getting hostname where the pipeline-pull-request is running

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -16,7 +16,7 @@ def run(params) {
         rake_namespace = 'cucumber'
         env_number = 6
         repo_dir = '/home/jenkins/jenkins-build/workspace/'
-        fqdn_jenkins_node = env.BUILD_URL.split('/')[2].split(':')[0]
+        fqdn_jenkins_node = sh(script: "hostname -f", returnStdout: true).trim()
         try {
             stage('Get environment') {
                   // Pick a free environment


### PR DESCRIPTION
We were getting the hostname of jenkins, when I was expecting the
"worker" hostname.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>