### PR TITLE
Use opensuse152-CI-PR for server

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr1-"
@@ -130,6 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse152"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-ci-pr", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr1-"
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
-      image = "opensuse152"
+      image = "opensuse152-ci-pr"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-ci-pr", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr2-"
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
-      image = "opensuse152"
+      image = "opensuse152-ci-pr"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr2-"
@@ -130,6 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse152"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-ci-pr", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr3-"
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
-      image = "opensuse152"
+      image = "opensuse152-ci-pr"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr3-"
@@ -130,6 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse152"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr4-"
@@ -130,6 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse152"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-ci-pr", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr4-"
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
-      image = "opensuse152"
+      image = "opensuse152-ci-pr"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-pr-ci", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-ci-pr", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr5-"
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
-      image = "opensuse152-pr-ci"
+      image = "opensuse152-ci-pr"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-pr-ci", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr5-"
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
-      image = "opensuse152"
+      image = "opensuse152-pr-ci"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr5-"
@@ -130,6 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse152"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr6-"
@@ -130,6 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse152"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -101,7 +101,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse152-ci-pr", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr6-"
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
-      image = "opensuse152"
+      image = "opensuse152-ci-pr"
     }
     proxy = {
       provider_settings = {


### PR DESCRIPTION
Because it has the required dependencies, so we will go from installing
more than 900 packages, which takes 15 minutes, to 115, which takes 3.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>