### PR TITLE
Allow parallel builds of the same unit-test job

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-    disableConcurrentBuilds(),
+    buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -1,8 +1,7 @@
 #!/usr/bin/env groovy
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
@@ -1,8 +1,7 @@
 #!/usr/bin/env groovy
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
@@ -1,8 +1,7 @@
 #!/usr/bin/env groovy
 
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -3,8 +3,7 @@
 // WARNING: This pipeline is working progress, the test is not finished. So please, don't add to the list of PR Checks
 
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-    disableConcurrentBuilds(),
+    buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_ruby_rubocop
@@ -1,8 +1,7 @@
 #!/usr/bin/env groovy
 
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -3,8 +3,7 @@
 // WARNING: This pipeline is working progress, the test is not finished. So please, don't add to the list of PR Checks
 
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
@@ -2,8 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4')),
-        disableConcurrentBuilds(),
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
 ])
 
 pipeline {


### PR DESCRIPTION
This PR removes the limitation of running only one build per pipeline in our unit-test.
Unless there is a real limitation for it, we should be allowing that.