### PR TITLE
Remove OBS project when starting

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -48,6 +48,7 @@ def run(params) {
                                         userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*', url: "${params.pull_request_repo}"]]
                                     ])
                             sh "osc lock ${params.source_project}:TEST:${env_number}:CR 2> /dev/null || true"
+                            sh "osc rdelete -rf -m 'removing project before creating it again' ${params.builder_project}:${params.pull_request_number}"
                             if(params.publish_in_host) {
                                 sh "python3 susemanager-utils/testing/automation/obs-project.py --prproject ${params.builder_project} --configfile $HOME/.oscrc add --repo ${params.build_repo} ${params.pull_request_number} --disablepublish"
                             } else {


### PR DESCRIPTION
Otherwise, if the previous run was run with the option to not delete the
build, the next build starts with the previous project, which means you
might end up having packages that you don't want and you get an  error
when doing the linkpac for the release notes.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>