### PR TITLE
Fix wrong MACs after removal of centos and ubuntu, add 12sp5 buildhost in 4.1

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -490,7 +490,7 @@ module "centos7-client" {
   name               = "cli-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:58"
+    mac                = "aa:b2:92:42:00:57"
     memory             = 4096
   }
   server_configuration = {
@@ -686,7 +686,7 @@ module "centos7-minion" {
   name               = "min-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:68"
+    mac                = "aa:b2:92:42:00:67"
     memory             = 4096
   }
   server_configuration = {
@@ -710,7 +710,7 @@ module "centos8-minion" {
   name               = "min-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:69"
+    mac                = "aa:b2:92:42:00:68"
     memory             = 4096
   }
   server_configuration = {
@@ -734,7 +734,7 @@ module "ubuntu1804-minion" {
   name               = "min-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:6b"
+    mac                = "aa:b2:92:42:00:69"
     memory             = 4096
   }
   server_configuration = {
@@ -758,7 +758,7 @@ module "ubuntu2004-minion" {
   name               = "min-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:6c"
+    mac                = "aa:b2:92:42:00:6a"
     memory             = 4096
   }
   server_configuration = {
@@ -782,7 +782,7 @@ module "debian9-minion" {
   name               = "min-debian9"
   image              = "debian9o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:6d"
+    mac                = "aa:b2:92:42:00:6b"
     memory             = 4096
   }
   server_configuration =  { hostname =  "suma-bv-41-pxy.mgr.prv.suse.net" }
@@ -804,7 +804,7 @@ module "debian10-minion" {
   name               = "min-debian10"
   image              = "debian10o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:6e"
+    mac                = "aa:b2:92:42:00:6c"
     memory             = 4096
   }
   server_configuration =  { hostname =  "suma-bv-41-pxy.mgr.prv.suse.net" }
@@ -949,7 +949,7 @@ module "centos7-sshminion" {
   name               = "minssh-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:78"
+    mac                = "aa:b2:92:42:00:77"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -966,7 +966,7 @@ module "centos8-sshminion" {
   name               = "minssh-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:79"
+    mac                = "aa:b2:92:42:00:78"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -983,7 +983,7 @@ module "ubuntu1804-sshminion" {
   name               = "minssh-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:7b"
+    mac                = "aa:b2:92:42:00:79"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1000,7 +1000,7 @@ module "ubuntu2004-sshminion" {
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:7c"
+    mac                = "aa:b2:92:42:00:7a"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1017,7 +1017,7 @@ module "debian9-sshminion" {
   name               = "minssh-debian9"
   image              = "debian9o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:7d"
+    mac                = "aa:b2:92:42:00:7b"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1034,7 +1034,7 @@ module "debian10-sshminion" {
   name               = "minssh-debian10"
   image              = "debian10o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:7e"
+    mac                = "aa:b2:92:42:00:7c"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1115,6 +1115,49 @@ module "sles12sp4-terminal" {
   product_version    = "4.1-released"
   name               = "terminal-sles12sp4"
   image              = "sles12sp4o"
+  provider_settings = {
+    memory             = 1024
+    vcpu               = 1
+  }
+  server_configuration = {
+    hostname = "suma-bv-41-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "sles12sp5-buildhost" {
+  providers = {
+    libvirt = libvirt.coruscant
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_retail.configuration
+  product_version    = "4.1-released"
+  name               = "build-sles12sp5"
+  image              = "sles12sp5o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:82"
+    memory             = 2048
+    vcpu               = 2
+  }
+  server_configuration = {
+    hostname = "suma-bv-41-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "sles12sp5-terminal" {
+  providers = {
+    libvirt = libvirt.coruscant
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_retail.configuration
+  product_version    = "4.1-released"
+  name               = "terminal-sles12sp5"
+  image              = "sles12sp5o"
   provider_settings = {
     memory             = 1024
     vcpu               = 1
@@ -1243,10 +1286,12 @@ module "controller" {
 
   sle11sp4_buildhost_configuration = module.sles11sp4-buildhost.configuration
   sle12sp4_buildhost_configuration = module.sles12sp4-buildhost.configuration
+  sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp2_buildhost_configuration = module.sles15sp2-buildhost.configuration
 
   sle11sp3_terminal_configuration = module.sles11sp3-terminal.configuration
   sle12sp4_terminal_configuration = module.sles12sp4-terminal.configuration
+  sle12sp5_terminal_configuration = module.sles12sp5-terminal.configuration
   sle15sp2_terminal_configuration = module.sles15sp2-terminal.configuration
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-beta-build-validation.tf
@@ -495,7 +495,7 @@ module "centos7-client" {
   name               = "cli-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:98"
+    mac                = "aa:b2:92:42:00:97"
     memory             = 4096
   }
   server_configuration = {
@@ -695,7 +695,7 @@ module "centos7-minion" {
   name               = "min-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:a8"
+    mac                = "aa:b2:92:42:00:a7"
     memory             = 4096
   }
   server_configuration = {
@@ -719,7 +719,7 @@ module "centos8-minion" {
   name               = "min-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:a9"
+    mac                = "aa:b2:92:42:00:a8"
     memory             = 4096
   }
   server_configuration = {
@@ -744,7 +744,7 @@ module "ubuntu1804-minion" {
   name               = "min-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:ab"
+    mac                = "aa:b2:92:42:00:a9"
     memory             = 4096
   }
   server_configuration = {
@@ -768,7 +768,7 @@ module "ubuntu2004-minion" {
   name               = "min-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:ac"
+    mac                = "aa:b2:92:42:00:aa"
     memory             = 4096
   }
   server_configuration = {
@@ -792,7 +792,7 @@ module "debian9-minion" {
   name               = "min-debian9"
   image              = "debian9o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:ad"
+    mac                = "aa:b2:92:42:00:ab"
     memory             = 4096
   }
 
@@ -817,7 +817,7 @@ module "debian10-minion" {
   name               = "min-debian10"
   image              = "debian10o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:ae"
+    mac                = "aa:b2:92:42:00:ac"
     memory             = 4096
   }
 
@@ -974,7 +974,7 @@ module "centos7-sshminion" {
   name               = "minssh-centos7"
   image              = "centos7o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:b8"
+    mac                = "aa:b2:92:42:00:b7"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -991,7 +991,7 @@ module "centos8-sshminion" {
   name               = "minssh-centos8"
   image              = "centos8o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:b9"
+    mac                = "aa:b2:92:42:00:b8"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1009,7 +1009,7 @@ module "ubuntu1804-sshminion" {
   name               = "minssh-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:bb"
+    mac                = "aa:b2:92:42:00:b9"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1026,7 +1026,7 @@ module "ubuntu2004-sshminion" {
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:bc"
+    mac                = "aa:b2:92:42:00:ba"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1043,7 +1043,7 @@ module "debian9-sshminion" {
   name               = "minssh-debian9"
   image              = "debian9o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:bd"
+    mac                = "aa:b2:92:42:00:bb"
     memory             = 4096
   }
   use_os_released_updates = false
@@ -1060,7 +1060,7 @@ module "debian10-sshminion" {
   name               = "minssh-debian10"
   image              = "debian10o"
   provider_settings = {
-    mac                = "aa:b2:92:42:00:be"
+    mac                = "aa:b2:92:42:00:bc"
     memory             = 4096
   }
   use_os_released_updates = false


### PR DESCRIPTION
After I removed the centos 6 and ubuntu 16 I didn't fix the offset in the main.tf and now we have mismatches