### PR TITLE
Add option to skip secondary tests in PR

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -161,7 +161,7 @@ def run(params) {
             }
             stage('Secondary features') {
                 ws(environment_workspace){
-                    if(params.must_test) {
+                    if(params.must_test && !params.skip_secondary_tests) {
                         def exports = ""
                         if (params.functional_scopes){
                           exports += "export TAGS=${params.functional_scopes}; "

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -12,6 +12,7 @@ node('pull-request-test') {
             booleanParam(name: 'must_build', defaultValue: true, description: 'Build project'),
             booleanParam(name: 'must_test', defaultValue: true, description: 'Run tests'),
             booleanParam(name: 'must_remove_build', defaultValue: true, description: 'Remove project built'),
+            booleanParam(name: 'skip_secondary_tests', defaultValue: false, description: 'Skip secondary tests'),
             booleanParam(name: 'publish_in_host', defaultValue: false, description: 'Experimental: Publish in host instead of in the build service'),
             booleanParam(name: 'parallel_build', defaultValue: false, description: 'Experimental: Run build in parallel'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),


### PR DESCRIPTION
Sometimes you don't have a specific secondary test to run. In that case,
there was no option to run none of the secondary tests. This commit adds
this option.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>