### PR TITLE
Use lockfile for concurrent PR e2e testing

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -21,10 +21,9 @@ def run(params) {
                   // Pick a free environment
                   for (env_number = 1; env_number <= total_envs; env_number++) {
                       env.env_file="/tmp/suma-pr${env_number}.lock"
-                      env_status = sh(script: "test -f ${env_file} && echo 'locked' || echo 'free' ", returnStdout: true).trim()
+                      env_status = sh(script: "lockfile -001 -r1 -! ${env_file} && echo 'locked' || echo 'free' ", returnStdout: true).trim()
                       if(env_status == 'free'){
                           echo "Using environment suma-pr${env_number}"
-                          sh "touch ${env_file}"
                           environment_workspace = "${jenkins_workspace}suma-pr${env_number}"
                           break;
                       }
@@ -207,7 +206,7 @@ def run(params) {
                     ws(environment_workspace){
                         def error = 0
                         if (env.env_file) {
-                            sh "rm ${env_file}"
+                            sh "rm -f ${env_file}"
                         }
                         if (deployed) {
                             try {


### PR DESCRIPTION
We were using test and touch for "acquiring" the test environment.

However, during our tests, we found out that two jobs could, and
actually did, take the same environment.

Most probably, this happened because two jobs run the "test" before one
of them could do the "touch".

Instead, let's use "lockfile" command, which implements semaphores,
which is what actually we were trying to implement with the "test and
touch".

Fixes https://github.com/SUSE/spacewalk/issues/15176