### PR TITLE
Avoid cucumber being killed by OOM killer

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -1220,7 +1220,7 @@ module "controller" {
   name               = "ctl"
   provider_settings = {
     mac                = "aa:b2:92:42:00:48"
-    memory             = 16384
+    memory             = 24576
     vcpu               = 8
   }
   swap_file_size = null

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -1185,7 +1185,7 @@ module "controller" {
   name               = "ctl"
   provider_settings = {
     mac                = "aa:b2:92:42:00:88"
-    memory             = 16384
+    memory             = 24576
     vcpu               = 8
   }
   swap_file_size = null


### PR DESCRIPTION
Avoid the test suite abrubtly stopping on the controller.

Output of dmesg:
```
[12802.008861] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=/,mems_allowed=0,global_oom,task_memcg=/,task=ruby.ruby2.5,pid=28148,uid=0
[12802.008925] Out of memory: Killed process 28148 (ruby.ruby2.5) total-vm:16689288kB, anon-rss:16089632kB, file-rss:0kB, shmem-rss:0kB
[12802.959889] oom_reaper: reaped process 28148 (ruby.ruby2.5), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
```