### PR TITLE
Attempt to use mortadelo on uyuni

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -1220,7 +1220,7 @@ module "controller" {
   name               = "ctl"
   provider_settings = {
     mac                = "aa:b2:92:42:00:48"
-    memory             = 24576
+    memory             = 4096
     vcpu               = 8
   }
   swap_file_size = null

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -1185,7 +1185,7 @@ module "controller" {
   name               = "ctl"
   provider_settings = {
     mac                = "aa:b2:92:42:00:88"
-    memory             = 24576
+    memory             = 4096
     vcpu               = 8
   }
   swap_file_size = null

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -75,7 +75,7 @@ variable "GIT_PASSWORD" {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
+  uri = "qemu+tcp://mortadelo.mgr.suse.de/system"
 }
 
 module "cucumber_testsuite" {


### PR DESCRIPTION
This PR:

* gets back to 4 GB for the controller on BV test suite (after we analyzed the OOMs)
* attempts to use mortadelo instead of ramrod for Uyuni master

For a start, Mortadelo will still use a storage pool `ssd` on another disk, like it is done on ramrod.
If we still see performance issues, I will change that too.