### PR TITLE
Add config for the spacecmd unittests for SUMA

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -1,0 +1,87 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+
+        // CONF To edit
+        repository = 'SUSE/spacewalk'
+        context = 'spacecmd_unittests'
+        description = 'python unit test for spacecmd'
+        git_fs = "${env.WORKSPACE}"
+        filter = 'spacecmd/'
+        // the actual test is the git repo (inside spacewalk)
+        test = 'susemanager-utils/testing/automation/spacecmd-unittest.sh'
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+
+        stage('Run tests against PR') {
+            steps {
+                echo 'Run spacecmd unit tests!'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/spacecmd/reports/junit_tests.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the Jenkins configuration for running the spacecmd unittests also on SUMA PRs and not only Uyuni ones.

@jordimassaguerpla please review this and merge if it is okay.