### PR TITLE
Add openSUSE Leap 15.3 to Uyuni Refmaster tf file

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -81,7 +81,7 @@ module "base" {
   name_prefix = "uyuni-refmaster-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = ["centos7o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1804o"]
+  images      = ["centos7o", "opensuse153o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1804o"]
   provider_settings = {
     pool         = "ssd"
     network_name = null


### PR DESCRIPTION
This is a fixup commit for #327. The Jenkins pipeline fails because of the missing openSUSE Leap 15.3 image.