### PR TITLE
Force a workspace name in CI jobs without @N appended

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -1,5 +1,6 @@
 def run(params) {
     timestamps {
+        environment_workspace = env.JOB_BASE_NAME
         // Retrieve the hash commit of the last product built in OBS/IBS and previous job
         def prefix = env.JOB_BASE_NAME.split('-acceptance-tests')[0]
         if (prefix == "uyuni-master-dev") {
@@ -28,101 +29,117 @@ def run(params) {
         env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform"
         try {
             stage('Clone terracumber, susemanager-ci and sumaform') {
-                // Rename build using product commit hash
-                currentBuild.description =  "[${product_commit}]"
-                
-                // Create a directory for  to place the directory with the build results (if it does not exist)
-                sh "mkdir -p ${resultdir}"
-                git url: params.terracumber_gitrepo, branch: params.terracumber_ref
-                dir("susemanager-ci") {
-                    checkout scm
+                ws(environment_workspace){
+                    // Rename build using product commit hash
+                    currentBuild.description =  "[${product_commit}]"
+                    
+                    // Create a directory for  to place the directory with the build results (if it does not exist)
+                    sh "mkdir -p ${resultdir}"
+                    git url: params.terracumber_gitrepo, branch: params.terracumber_ref
+                    dir("susemanager-ci") {
+                        checkout scm
+                    }
+                    // Clone sumaform
+                    sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
                 }
-                // Clone sumaform
-                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
             }
             stage('Deploy') {
-                // Provision the environment
-                if (params.terraform_init) {
-                    env.TERRAFORM_INIT = '--init'
-                } else {
-                    env.TERRAFORM_INIT = ''
+                ws(environment_workspace){
+                    // Provision the environment
+                    if (params.terraform_init) {
+                        env.TERRAFORM_INIT = '--init'
+                    } else {
+                        env.TERRAFORM_INIT = ''
+                    }
+                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
+                    deployed = true
                 }
-                sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
-                deployed = true
             }
             stage('Product changes') {
-                sh """
-                    # Comparison between:
-                    #  - the previous git revision of spacewalk (or uyuni) repository pushed in IBS (or OBS)
-                    #  - the git revision of the current spacewalk (or uyuni) repository pushed in IBS (or OBS)
-                    # Note: This is a trade-off, we should be comparing the git revisions of all the packages composing our product
-                    #       For that extra mile, we need a new tag in the repo metadata of each built, with the git revision of the related repository.
-                """
-                sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/; git --no-pager log --pretty=format:\"%h %<(16,trunc)%cn  %s  %d\" ${previous_commit}..${product_commit}'", returnStatus:true
+                ws(environment_workspace){
+                    sh """
+                        # Comparison between:
+                        #  - the previous git revision of spacewalk (or uyuni) repository pushed in IBS (or OBS)
+                        #  - the git revision of the current spacewalk (or uyuni) repository pushed in IBS (or OBS)
+                        # Note: This is a trade-off, we should be comparing the git revisions of all the packages composing our product
+                        #       For that extra mile, we need a new tag in the repo metadata of each built, with the git revision of the related repository.
+                    """
+                    sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/; git --no-pager log --pretty=format:\"%h %<(16,trunc)%cn  %s  %d\" ${previous_commit}..${product_commit}'", returnStatus:true
+                }
             }
             stage('Sanity Check') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:sanity_check'"
+                ws(environment_workspace){
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:sanity_check'"
+                }
             }
             stage('Core - Setup') {
-                def exports = ""
-                if (params.long_tests){
-                  exports += "export LONG_TESTS=${params.long_tests}; "
+                ws(environment_workspace){
+                    def exports = ""
+                    if (params.long_tests){
+                      exports += "export LONG_TESTS=${params.long_tests}; "
+                    }
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake cucumber:core'"
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake cucumber:reposync'"
                 }
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake cucumber:core'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake cucumber:reposync'"
             }
             stage('Core - Initialize clients') {
-                def exports = ""
-                if (params.long_tests){
-                  exports += "export LONG_TESTS=${params.long_tests}; "
+                ws(environment_workspace){
+                    def exports = ""
+                    if (params.long_tests){
+                      exports += "export LONG_TESTS=${params.long_tests}; "
+                    }
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:init_clients'"
                 }
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:init_clients'"
             }
             stage('Secondary features') {
-                def exports = ""
-                if (params.functional_scopes){
-                  exports += "export TAGS=${params.functional_scopes}; "
+                ws(environment_workspace){
+                    def exports = ""
+                    if (params.functional_scopes){
+                      exports += "export TAGS=${params.functional_scopes}; "
+                    }
+                    if (params.long_tests){
+                      exports += "export LONG_TESTS=${params.long_tests}; "
+                    }
+                    def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
+                    def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus:true
+                    sh "exit \$(( ${statusCode1}|${statusCode2} ))"
                 }
-                if (params.long_tests){
-                  exports += "export LONG_TESTS=${params.long_tests}; "
-                }
-                def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
-                def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus:true
-                sh "exit \$(( ${statusCode1}|${statusCode2} ))"
             }
         }
         finally {
             stage('Get results') {
-                def error = 0
-                if (deployed) {
-                    try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing'"
-                    } catch(Exception ex) {
-                        println("ERROR: rake cucumber:finishing failed")
-                        error = 1
+                ws(environment_workspace){
+                    def error = 0
+                    if (deployed) {
+                        try {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing'"
+                        } catch(Exception ex) {
+                            println("ERROR: rake cucumber:finishing failed")
+                            error = 1
+                        }
+                        try {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+                        } catch(Exception ex) {
+                            println("ERROR: rake utils:generate_test_repor failed")
+                            error = 1
+                        }
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+                        publishHTML( target: [
+                                    allowMissing: true,
+                                    alwaysLinkToLastBuild: false,
+                                    keepAll: true,
+                                    reportDir: "${resultdirbuild}/cucumber_report/",
+                                    reportFiles: 'cucumber_report.html',
+                                    reportName: "TestSuite Report"]
+                        )
+                        junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
                     }
-                    try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
-                    } catch(Exception ex) {
-                        println("ERROR: rake utils:generate_test_repor failed")
-                        error = 1
-                    }
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
-                    publishHTML( target: [
-                                allowMissing: true,
-                                alwaysLinkToLastBuild: false,
-                                keepAll: true,
-                                reportDir: "${resultdirbuild}/cucumber_report/",
-                                reportFiles: 'cucumber_report.html',
-                                reportName: "TestSuite Report"]
-                    )
-                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+                    // Send email
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                    // Clean up old results
+                    sh "./clean-old-results -r ${resultdir}"
+                    sh "exit ${error}"
                 }
-                // Send email
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
-                // Clean up old results
-                sh "./clean-old-results -r ${resultdir}"
-                sh "exit ${error}"
             }
         }
     }


### PR DESCRIPTION
Related to: https://github.com/SUSE/spacewalk/issues/15779

When our Jenkins Master is rebooted, it lost connection with our Jenkins Worker, which continue running our CI jobs.
Once it restarts, it tries to connect again witht the Jenkins worker, then the current job fails, then the next job starts but using a different workspace name, appending a `@2` there.
As we rely in terraform files that are stored in the workspace between jobs, so we don't need to re-download all the images and stuff, so we can just do a taint terraform command in the current environment... all the job fails, as the workspace is different.
This PR tries to fix this issue by using always the same workspace name.