### PR TITLE
Prepend the workspace folder into the path for CI envs

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -1,6 +1,6 @@
 def run(params) {
     timestamps {
-        environment_workspace = env.JOB_BASE_NAME
+        environment_workspace = "workspace/${env.JOB_BASE_NAME}"
         // Retrieve the hash commit of the last product built in OBS/IBS and previous job
         def prefix = env.JOB_BASE_NAME.split('-acceptance-tests')[0]
         if (prefix == "uyuni-master-dev") {


### PR DESCRIPTION
Prepend the workspace folder into the path for CI envs

On top of https://github.com/SUSE/susemanager-ci/pull/336