### PR TITLE
Fix proxy image

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse153-ci-pr-client"
     }
     suse-client = {
       image = "sles15sp2o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse153-ci-pr-client"
     }
     suse-client = {
       image = "sles15sp2o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse153-ci-pr-client"
     }
     suse-client = {
       image = "sles15sp2o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse153-ci-pr-client"
     }
     suse-client = {
       image = "sles15sp2o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse153-ci-pr-client"
     }
     suse-client = {
       image = "sles15sp2o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
       }
+      image = "opensuse153-ci-pr-client"
     }
     suse-client = {
       image = "sles15sp2o"


### PR DESCRIPTION
Proxy is by default opensuse153o, but I have removed this image in
purpose because sometimes is not available. Thus, I need to specify the
alternative image for proxy as well, the same way that was done for the
server.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>