### PR TITLE
fix controller image

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -138,6 +138,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:00"
       }
+      image = "opensuse153-ci-pr-client"
     }
     server = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -138,6 +138,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0c"
       }
+      image = "opensuse153-ci-pr-client"
     }
     server = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -138,6 +138,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:18"
       }
+      image = "opensuse153-ci-pr-client"
     }
     server = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -138,6 +138,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:24"
       }
+      image = "opensuse153-ci-pr-client"
     }
     server = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -138,6 +138,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:30"
       }
+      image = "opensuse153-ci-pr-client"
     }
     server = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -138,6 +138,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3c"
       }
+      image = "opensuse153-ci-pr-client"
     }
     server = {
       provider_settings = {


### PR DESCRIPTION
We are not downloading opensuse152o, so better use the 15.3 image we use
for clients.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>