### PR TITLE
Fix client repos

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -150,10 +150,10 @@ def run(params) {
                         // TODO: We will need to add a logic to replace the host, when we use IBS for spacewalk
                         env.PULL_REQUEST_REPO= "http://${fqdn_jenkins_node}/workspace/${params.builder_project}:${params.pull_request_number}/${params.build_repo}/x86_64"
                         env.MASTER_REPO = "http://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR/${params.build_repo}"
-                        env.SLE_CLIENT_REPO = "https://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:SLE15-Uyuni-Client-Tools/SLE_15"
-                        env.CENTOS_CLIENT_REPO = "https://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:CentOS7-Uyuni-Client-Tools/CentOS_7"
-                        env.UBUNTU_CLIENT_REPO = "https://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/"
-                        env.OPENSUSE_CLIENT_REPO = "https://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0"
+                        env.SLE_CLIENT_REPO = "http://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:SLE15-Uyuni-Client-Tools/SLE_15"
+                        env.CENTOS_CLIENT_REPO = "http://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:CentOS7-Uyuni-Client-Tools/CentOS_7"
+                        env.UBUNTU_CLIENT_REPO = "http://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/"
+                        env.OPENSUSE_CLIENT_REPO = "http://download.opensuse.org/repositories/${params.source_project}:TEST:${env_number}:CR:openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0"
                         // Provision the environment
                         if (terraform_init) {
                             env.TERRAFORM_INIT = '--init'


### PR DESCRIPTION
Use http instead of https because otherwise we get a 301 permanently
redirect error message. This is because openSUSE mirrors have issues
with https.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>