### PR TITLE
Remove an additional repo for Java bugfix

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -120,9 +120,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:a1"
       }
-      additional_repos = {
-        java_TEST = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/"
-      }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -279,9 +279,6 @@ module "server" {
   from_email                     = "root@suse.de"
 
   //server_additional_repos
-  additional_repos = {
-    java_TEST = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/"
-  }
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -120,9 +120,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c1"
       }
-      additional_repos = {
-        java_TEST = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/"
-      }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -117,9 +117,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:b1"
       }
-      additional_repos = {
-        java_TEST = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/"
-      }
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -117,9 +117,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:d1"
       }
-      additional_repos = {
-        java_TEST = "http://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/"
-      }
     }
     proxy = {
       provider_settings = {


### PR DESCRIPTION
This content was already released so we don't need to inject any more:

https://download.suse.de/ibs/home:/fstrba:/branches:/SUSE:/SLE-15:/Update/SUSE_SLE-15_Update/