### PR TITLE
Skip opensuse mirror

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -83,6 +83,10 @@ variable "MASTER_REPO" {
   type = "string"
 }
 
+variable "MASTER_OTHER_REPO" {
+  type = "string"
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = "string"
@@ -107,7 +111,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "uyuni-master"
+  product_version = "uyuni-pr"
   
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
@@ -146,6 +150,7 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
       image = "opensuse153-ci-pr"
     }
@@ -156,6 +161,7 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
       image = "opensuse153o"
     }
@@ -221,6 +227,9 @@ module "cucumber_testsuite" {
     }
     pxeboot-minion = {
       image = "sles15sp3o"
+      additional_repos = {
+        client_repo = var.SLE_CLIENT_REPO,
+      }
     }
     kvm-host = {
       image = "opensuse153o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -83,6 +83,10 @@ variable "MASTER_REPO" {
   type = "string"
 }
 
+variable "MASTER_OTHER_REPO" {
+  type = "string"
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = "string"
@@ -107,7 +111,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "uyuni-master"
+  product_version = "uyuni-pr"
   
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
@@ -118,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr2-"
@@ -146,6 +150,7 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
       image = "opensuse153-ci-pr"
     }
@@ -156,8 +161,9 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
     }
     suse-client = {
       image = "sles15sp2o"
@@ -221,9 +227,12 @@ module "cucumber_testsuite" {
     }
     pxeboot-minion = {
       image = "sles15sp3o"
+      additional_repos = {
+        client_repo = var.SLE_CLIENT_REPO,
+      }
     }
     kvm-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:16"
       }
@@ -232,7 +241,7 @@ module "cucumber_testsuite" {
       }
     }
     xen-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:17"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr2-"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr3-"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -83,6 +83,10 @@ variable "MASTER_REPO" {
   type = "string"
 }
 
+variable "MASTER_OTHER_REPO" {
+  type = "string"
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = "string"
@@ -107,7 +111,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "uyuni-master"
+  product_version = "uyuni-pr"
   
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
@@ -118,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr3-"
@@ -146,6 +150,7 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
       image = "opensuse153-ci-pr"
     }
@@ -156,8 +161,9 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
     }
     suse-client = {
       image = "sles15sp2o"
@@ -221,9 +227,12 @@ module "cucumber_testsuite" {
     }
     pxeboot-minion = {
       image = "sles15sp3o"
+      additional_repos = {
+        client_repo = var.SLE_CLIENT_REPO,
+      }
     }
     kvm-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:22"
       }
@@ -232,7 +241,7 @@ module "cucumber_testsuite" {
       }
     }
     xen-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:23"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -83,6 +83,10 @@ variable "MASTER_REPO" {
   type = "string"
 }
 
+variable "MASTER_OTHER_REPO" {
+  type = "string"
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = "string"
@@ -107,7 +111,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "uyuni-master"
+  product_version = "uyuni-pr"
   
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
@@ -118,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr4-"
@@ -146,6 +150,7 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
       image = "opensuse153-ci-pr"
     }
@@ -156,8 +161,9 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
     }
     suse-client = {
       image = "sles15sp2o"
@@ -221,9 +227,12 @@ module "cucumber_testsuite" {
     }
     pxeboot-minion = {
       image = "sles15sp3o"
+      additional_repos = {
+        client_repo = var.SLE_CLIENT_REPO,
+      }
     }
     kvm-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:2e"
       }
@@ -232,7 +241,7 @@ module "cucumber_testsuite" {
       }
     }
     xen-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:2f"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr4-"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr5-"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -83,6 +83,10 @@ variable "MASTER_REPO" {
   type = "string"
 }
 
+variable "MASTER_OTHER_REPO" {
+  type = "string"
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = "string"
@@ -107,7 +111,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "uyuni-master"
+  product_version = "uyuni-pr"
   
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
@@ -118,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr5-"
@@ -146,6 +150,7 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
       image = "opensuse153-ci-pr"
     }
@@ -156,8 +161,9 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
     }
     suse-client = {
       image = "sles15sp2o"
@@ -221,9 +227,12 @@ module "cucumber_testsuite" {
     }
     pxeboot-minion = {
       image = "sles15sp3o"
+      additional_repos = {
+        client_repo = var.SLE_CLIENT_REPO,
+      }
     }
     kvm-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:3a"
       }
@@ -232,7 +241,7 @@ module "cucumber_testsuite" {
       }
     }
     xen-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:3b"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr6-"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -83,6 +83,10 @@ variable "MASTER_REPO" {
   type = "string"
 }
 
+variable "MASTER_OTHER_REPO" {
+  type = "string"
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = "string"
@@ -107,7 +111,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "uyuni-master"
+  product_version = "uyuni-pr"
   
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER
@@ -118,7 +122,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "opensuse153-ci-pr-client", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr6-"
@@ -146,6 +150,7 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
       image = "opensuse153-ci-pr"
     }
@@ -156,8 +161,9 @@ module "cucumber_testsuite" {
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
+        master_repo_other = var.MASTER_OTHER_REPO,
       }
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
     }
     suse-client = {
       image = "sles15sp2o"
@@ -221,9 +227,12 @@ module "cucumber_testsuite" {
     }
     pxeboot-minion = {
       image = "sles15sp3o"
+      additional_repos = {
+        client_repo = var.SLE_CLIENT_REPO,
+      }
     }
     kvm-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:46"
       }
@@ -232,7 +241,7 @@ module "cucumber_testsuite" {
       }
     }
     xen-host = {
-      image = "opensuse153-ci-pr-client"
+      image = "opensuse153o"
       provider_settings = {
         mac = "aa:b2:92:04:00:47"
       }


### PR DESCRIPTION
openSUSE mirror is unreliable. For testing at the PR level, where some shortcuts are accepted, we will instead download the RPMs from obs using the API. Then, we will create a repo ourselves.

This will remove also the obs publisher from the testing. We have seen obs publisher can sometimes take a lot of time. Downloading from the build service using the API means we do not rely on the publisher.

Then, if we do this, we do not need a repo in the build service for each environment, so we can remove all the logic related to the CR subprojects. Instead, we will have a local repo in the jenkins worker for each environment.

In order to do this, we will use "osc getbinaries" for master, other and client subrepos.

For the server and proxy, we realized we also need the Other subproject, where ansible and other packages are. This is the reason why we are adding the other subproject.

We tried building the "image repo", using "osc build *.kiwi image". However, this failed locally, and autobuild couldn't give a reason. It was failing locally, while it was succeeding in the server, so I consider this unreliable as well.

One may say that getting the packages from the repo is not the same a user will have, that we should instead download them from the image repos. Yes, but this is not what we are testing at the Pull Request tests, so it is fine that we get the packages from the master and  master:other subrepo.

With this, we move the complexity from the buildservice to the worker, but all in all, this is not more complex than it was, and this should remove all those random issues about packages not being available, or not being in sync with the metadata.

At the pull request testing, we are not testing the openSUSE mirror infrastructure, so it should be fine that we skip it.