### PR TITLE
Uyuni on AWS

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -33,7 +33,7 @@ def run(params) {
                     // Generate json file in the workspace
                     writeFile file: 'custom_repositories.json', text: params.custom_repositories, encoding: "UTF-8"
                     // Run Terracumber to deploy the environment
-                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk|data_disk|server_extra_nfs_mounts).*' --custom-repositories ${WORKSPACE}/custom_repositories.json --runstep provision"
+                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk|data_disk|server_extra_nfs_mounts).*' --custom-repositories ${WORKSPACE}/custom_repositories.json --sumaform-backend ${params.sumaform_backend} --runstep provision"
                     // Generate features
                     sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_build_validation_features'"
                     deployed = true

--- a/jenkins_pipelines/environments/common/pipeline-reference.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference.groovy
@@ -27,7 +27,22 @@ def run(params) {
                 } else {
                     env.TERRAFORM_INIT = ''
                 }
-                sh "set +x; source /home/jenkins/.credentials set -x; TERRAFORM=${params.terraform_bin} TERRAFORM_PLUGINS=${params.terraform_bin_plugins} ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
+                env.TERRAFORM_TAINT = ''
+                if (params.terraform_taint) {
+                    switch(params.sumaform_backend) {
+                        case "libvirt":
+                            env.TERRAFORM_TAINT = "--taint '.*(domain|main_disk).*'";
+                            break;
+                        case "aws":
+                            env.TERRAFORM_TAINT = "--taint '.*(host).*'";
+                            break;
+                        default:
+                            println("ERROR: Unknown backend ${params.sumaform_backend}");
+                            sh "exit 1";
+                            break;
+                    }
+                }
+                sh "set +x; source /home/jenkins/.credentials set -x; TERRAFORM=${params.terraform_bin} TERRAFORM_PLUGINS=${params.terraform_bin_plugins} ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} ${env.TERRAFORM_TAINT} --sumaform-backend ${params.sumaform_backend} --runstep provision"
                 deployed = true
             }
         }

--- a/jenkins_pipelines/environments/manager-4.0-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-dev-acceptance-tests-PRV
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-4.0-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-infra-reference-PRV
@@ -16,6 +16,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
         ])

--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
@@ -16,6 +16,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
         ])

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),            
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
@@ -16,6 +16,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
         ])

--- a/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
@@ -16,6 +16,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
         ])

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
@@ -18,6 +18,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/manager-TEST-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-acceptance-tests
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -6,12 +6,12 @@ node('sumaform-cucumber') {
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([
-            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
-            string(name: 'cucumber_ref', defaultValue: 'Manager-4.0', description: 'Testsuite Git reference (branch, tag...)'),
-            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf', description: 'Path to the tf file to be used'),
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-AWS.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
-            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'sumaform_backend', choices: ['aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
             booleanParam(name: 'long_tests', defaultValue: true, description: 'This will enable the execution of long tests'),
@@ -21,7 +21,7 @@ node('sumaform-cucumber') {
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
-            booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
+            booleanParam(name: 'show_product_changes', defaultValue: false, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
             extendedChoice(name: 'functional_scopes',  multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30, value: '@scope_smdba,@scope_spacecmd,@scope_spacewalk_utils,@scope_visualization,@scope_notification_message,@scope_virtual_host_manager,@scope_subscription_matching,@scope_formulas,@scope_sp_migration,@scope_cve_audit,@scope_onboarding,@scope_content_lifecycle_management,@scope_res,@scope_recurring_actions,@scope_maintenance_windows,@scope_cluster_management,@scope_building_container_images,@scope_kubernetes_integration,@scope_openscap,@scope_ubuntu,@scope_action_chains,@scope_salt_ssh,@scope_tomcat,@scope_changing_software_channels,@scope_monitoring,@scope_salt,@scope_cobbler,@scope_sumatoolbox,@scope_virtualization,@scope_hub,@scope_retail,@scope_configuration_channels,@scope_content_staging,@scope_proxy,@scope_traditional_client,@scope_xmlrpc,@scope_power_management,@scope_retracted_patches', description: 'Choose the functional scopes that you want to test')
         ])

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
@@ -19,6 +19,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),

--- a/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
@@ -16,6 +16,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
         ])

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -1,0 +1,220 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "hhttp://localhost:8080/job/uyuni-master-dev-acceptance-tests-AWS"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "export PRODUCT='Uyuni' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = string
+  default = "https://github.com/uyuni-project/uyuni.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Uyuni-Master $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Uyuni-Master: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "jgonzalez@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "REGION" {
+  type = string
+  default = "eu-central-1"
+}
+
+variable "AVAILABILITY_ZONE" {
+  type = string
+  default = "eu-central-1a"
+}
+
+variable "KEY_FILE" {
+  type = string
+  default = "/home/jenkins/.ssh/id_rsa"
+}
+
+variable "KEY_NAME" {
+  type = string
+  default = "uyuni-jenkins"
+}
+
+variable "MY_IP" {
+  type = "string"
+}
+
+provider "aws" {
+  region     = var.REGION
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "uyuni-master"
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7", "opensuse152o", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004"]
+
+  use_avahi    = false
+  name_prefix  = "uyuni-master-"
+  // domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  // no_auth_registry = "registry.mgr.suse.de"
+  // auth_registry      = "registry.mgr.suse.de:5000/cucutest"
+  // auth_registry_username = "cucutest"
+  // auth_registry_password = "cucusecret"
+  git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
+
+  // server_http_proxy = "galaxy-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    controller = {
+    }
+    server = {
+      provider_settings = {
+      }
+    }
+    proxy = {
+      provider_settings = {
+      }
+    }
+    suse-client = {
+      image = "opensuse152o"
+      name = "cli-opensuse15"
+      provider_settings = {
+      }
+    }
+    suse-minion = {
+      image = "opensuse152o"
+      name = "min-opensuse15"
+      provider_settings = {
+      }
+    }
+    suse-sshminion = {
+      image = "opensuse152o"
+      name = "minssh-opensuse15"
+      provider_settings = {
+      }
+    }
+    redhat-minion = {
+      image = "centos7"
+      provider_settings = {
+        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+        // Also, openscap cannot run with less than 1.25 GB of RAM
+        memory = 2048
+        vcpu = 2
+      }
+    }
+    debian-minion = {
+      name = "min-ubuntu2004"
+      image = "ubuntu2004"
+      provider_settings = {
+      }
+    }
+    build-host = {
+      image = "opensuse153o"
+      provider_settings = {
+      }
+    }
+// No PXE support for AWS yet
+//    pxeboot-minion = {
+//       image = "opensuse153o"
+//      provider_settings = {
+//      }
+//    }
+// We need to clarify if this is supported at AWS
+//    kvm-host = {
+//      image = "opensuse153o"
+//      provider_settings = {
+//      }
+//    }
+//    xen-host = {
+//      image = "opensuse153o"
+//      provider_settings = {
+//      }
+//    }
+  }
+  provider_settings = {
+    create_network                       = false
+    public_subnet_id                     = "subnet-0f8f5847460b0be70"
+    private_subnet_id                    = "subnet-0346035ce4cd25764"
+    private_additional_subnet_id         = "subnet-0459583d3361b8aa2"
+    public_security_group_id             = "sg-0535a11916638b7e3"
+    private_security_group_id            = "sg-01d023b03409de006"
+    private_additional_security_group_id = "sg-0cbf3be126cfcf355"
+    bastion_host                         = "ec2-18-157-102-83.eu-central-1.compute.amazonaws.com"
+    availability_zone                    = var.AVAILABILITY_ZONE
+    region                               = var.REGION
+    ssh_allowed_ips                      = []
+    key_name                             = var.KEY_NAME
+    key_file                             = var.KEY_FILE
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}


### PR DESCRIPTION
- Add a new pipeline definition for Uyuni Master at AWS, as well as a new TF file
- Use the `sumaform_backend` parameter from the jobs
- Add the possibility to run jobs without tainting the environment. Mostly useful for AWS, so you don't need to pay for new instances (AWS bills by hour)

With this and https://github.com/uyuni-project/sumaform/pull/989, and I was able to launch an acceptance pipeline from a Jenkins at AWS, with no access to the R&D network at all.

Somethings are missing, however, before we can consider the work complete, but this is for other PRs, maybe even for other repositories like the testsuite.

Reference: https://github.com/SUSE/spacewalk/issues/11398