### PR TITLE
change var definition to not use quotes in strings

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-dev-acceptance-tests-NUE"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.0"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.0-NUE (backup and staging) $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-backup.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.0-NUE: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-backupenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-PRV.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-dev-acceptance-tests-PRV"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.0"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.0-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.0-PRV: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.0-refenv-PRV.tf
@@ -1,71 +1,71 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.0/job/manager-4.0-infra-reference-PRV"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.0"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 // Not really used in this pipeline, as we do not send emails on success (no cucumber results)
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results REF4.0-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results REF4.0-PRV: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/SUSEManager-4.1-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-AWS.tf
@@ -1,118 +1,118 @@
 
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/SUSEManager-4.1-AWS"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.1"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Manager4.1-Master-MU $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Manager4.1-Master-MU: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "mnoel@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "mnoel@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "REGION" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "AVAILABILITY_ZONE" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "KEY_FILE" {
-  type = "string"
+  type = string
   default = "/home/jenkins/.ssh/testing-suma.pem"
 }
 
 
 variable "KEY_NAME" {
-  type = "string"
+  type = string
   default = "testing-suma"
 }
 
 variable "ACCESS_KEY" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "SECRET_KEY" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "SERVER_REGISTRATION_CODE" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "PROXY_REGISTRATION_CODE" {
-  type = "string"
+  type = string
   default = null
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-dev-acceptance-tests-NUE"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.1"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.1-NUE (backup and staging) $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-backup.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.1-NUE: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-backupenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-dev-acceptance-tests-PRV"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.1"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.1-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.1-PRV: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-qa-build-validation"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.1"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.1 Build Validation $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.1 Build Validation: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-noise@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-noise@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-refenv-PRV.tf
@@ -1,71 +1,71 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-infra-reference-PRV"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.1"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 // Not really used in this pipeline, as we do not send emails on success (no cucumber results)
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results REF4.1-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results REF4.1-PRV: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.2/job/manager-4.2-dev-acceptance-tests-NUE"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.2"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.2-NUE (backup and staging) $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-backup.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.2-NUE: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-backupenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.2/job/manager-4.2-dev-acceptance-tests-PRV"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.2"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.2-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.2-PRV: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.2/job/manager-4.2-qa-build-validation"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.2"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results 4.2 Build Validation $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results 4.2 Build Validation: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-noise@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-noise@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.2-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-refenv-PRV.tf
@@ -1,71 +1,71 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.2/job/manager-4.2-infra-reference-PRV"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.2"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 // Not really used in this pipeline, as we do not send emails on success (no cucumber results)
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results REF4.2-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results REF4.2-PRV: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-dev-acceptance-tests-NUE"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Head $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Head: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -1,71 +1,71 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-infra-reference-NUE"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 // Not really used in this pipeline, as we do not send emails on success (no cucumber results)
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results RefHead-NUE $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results RefHead-NUE: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-Hexagon-acceptance-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results TEST-HEXAGON $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results TEST-HEXAGON: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-acceptance-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results TEST $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results TEST: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-Naica-acceptance-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results TEST-NAICA $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results TEST-NAICA: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-Orion-acceptance-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results TEST-ORION $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results TEST-ORION: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -1,76 +1,76 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-dev-acceptance-tests-NUE"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni-Master $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Uyuni-Master: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -1,71 +1,71 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-infra-reference-NUE"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 // Not really used in this pipeline, as we do not run cucumber
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 // Not really used in this pipeline, as we do not send emails on success (no cucumber results)
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni RefMaster-NUE $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Uyuni RefMaster-NUE: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -1,107 +1,107 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni Pull Request $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Uyuni Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 // Repository containing the build for the tested Uyuni Pull Request
 variable "PULL_REQUEST_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_OTHER_REPO" {
-  type = "string"
+  type = string
 }
 
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "CENTOS_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "UBUNTU_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "OPENSUSE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -1,107 +1,107 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni Pull Request $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 // Repository containing the build for the tested Uyuni Pull Request
 variable "PULL_REQUEST_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_OTHER_REPO" {
-  type = "string"
+  type = string
 }
 
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "CENTOS_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "UBUNTU_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "OPENSUSE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -1,107 +1,107 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni Pull Request $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 // Repository containing the build for the tested Uyuni Pull Request
 variable "PULL_REQUEST_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_OTHER_REPO" {
-  type = "string"
+  type = string
 }
 
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "CENTOS_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "UBUNTU_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "OPENSUSE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -1,107 +1,107 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni Pull Request $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 // Repository containing the build for the tested Uyuni Pull Request
 variable "PULL_REQUEST_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_OTHER_REPO" {
-  type = "string"
+  type = string
 }
 
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "CENTOS_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "UBUNTU_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "OPENSUSE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -1,107 +1,107 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni Pull Request $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 // Repository containing the build for the tested Uyuni Pull Request
 variable "PULL_REQUEST_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_OTHER_REPO" {
-  type = "string"
+  type = string
 }
 
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "CENTOS_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "UBUNTU_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "OPENSUSE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -1,107 +1,107 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-prs-ci-tests"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni Pull Request $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "galaxy-ci@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null // Not needed for master, as it is public
 }
 
 // Repository containing the build for the tested Uyuni Pull Request
 variable "PULL_REQUEST_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "MASTER_OTHER_REPO" {
-  type = "string"
+  type = string
 }
 
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "CENTOS_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "UBUNTU_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 variable "OPENSUSE_CLIENT_REPO" {
-  type = "string"
+  type = string
 }
 
 provider "libvirt" {

--- a/terracumber_config/tf_files/aws_mirror.tf
+++ b/terracumber_config/tf_files/aws_mirror.tf
@@ -1,108 +1,108 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Manager-4.1/job/SUSEManager-4.1-AWS"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='SUSE-Manager' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/SUSE/spacewalk.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "Manager-4.1"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Manager4.1-Master-MU $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Uyuni-Master: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "mnoel@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "mnoel@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null
   // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null
   // Not needed for master, as it is public
 }
 
 variable "REGION" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "AVAILABILITY_ZONE" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "KEY_FILE" {
-  type = "string"
+  type = string
   default = "/home/jenkins/.ssh/testing-suma.pem"
 }
 
 variable "KEY_NAME" {
-  type = "string"
+  type = string
   default = "testing-suma"
 }
 
 variable "ACCESS_KEY" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "SECRET_KEY" {
-  type = "string"
+  type = string
   default = null
 }
 
@@ -112,12 +112,12 @@ variable "ALLOWED_IPS" {
 }
 
 variable "SERVER_REGISTRATION_CODE" {
-  type = "string"
+  type = string
   default = null
 }
 
 variable "PROXY_REGISTRATION_CODE" {
-  type = "string"
+  type = string
   default = null
 }
 

--- a/terracumber_config/tf_files/local_mirror.tf
+++ b/terracumber_config/tf_files/local_mirror.tf
@@ -1,77 +1,77 @@
 // Mandatory variables for terracumber
 variable "URL_PREFIX" {
-  type = "string"
+  type = string
   default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-manager-mu-cloud"
 }
 
 // Not really used as this is for --runall parameter, and we run cucumber step by step
 variable "CUCUMBER_COMMAND" {
-  type = "string"
+  type = string
   default = "export PRODUCT='Uyuni' && run-testsuite"
 }
 
 variable "CUCUMBER_GITREPO" {
-  type = "string"
+  type = string
   default = "https://github.com/uyuni-project/uyuni.git"
 }
 
 variable "CUCUMBER_BRANCH" {
-  type = "string"
+  type = string
   default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {
-  type = "string"
+  type = string
   default = "/root/spacewalk/testsuite"
 }
 
 variable "MAIL_SUBJECT" {
-  type = "string"
+  type = string
   default = "Results Uyuni-Master $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
 }
 
 variable "MAIL_TEMPLATE" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "Results Uyuni-Master: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
-  type = "string"
+  type = string
   default = "../mail_templates/mail-template-jenkins-env-fail.txt"
 }
 
 variable "MAIL_FROM" {
-  type = "string"
+  type = string
   default = "mnoel@suse.de"
 }
 
 variable "MAIL_TO" {
-  type = "string"
+  type = string
   default = "mnoel@suse.de"
 }
 
 // sumaform specific variables
 variable "SCC_USER" {
-  type = "string"
+  type = string
 }
 
 variable "SCC_PASSWORD" {
-  type = "string"
+  type = string
 }
 
 variable "GIT_USER" {
-  type = "string"
+  type = string
   default = null
   // Not needed for master, as it is public
 }
 
 variable "GIT_PASSWORD" {
-  type = "string"
+  type = string
   default = null
   // Not needed for master, as it is public
 }


### PR DESCRIPTION
In preparation to terraform upgrade:
In variable declaration blocks, the type argument previously accepted v0.11-style type constraints given as quoted strings. This legacy syntax is removed in Terraform v0.15.

Signed-off-by: Ricardo Mateus <rmateus@suse.com>