### PR TITLE
Fix error to get local mirror public IP for MU pipeline

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-mu-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-mu-aws.groovy
@@ -89,7 +89,7 @@ def run(params) {
         stage("Upload local mirror data to AWS mirror") {
 
             // Get local and aws hostname
-            mirror_hostname_local = sh(script: "cat ${local_mirror_dir}/terraform.tfstate | jq -r '.outputs.local_mirrors_public_ip.value[0][0]' ",
+            mirror_hostname_local = sh(script: "cat ${local_mirror_dir}/terraform.tfstate | jq -r '.resources[3].instances[0].attributes.network_interface[0].addresses[0]' ",
                     returnStdout: true).trim()
             mirror_hostname_aws_public = sh(script: "cat ${aws_mirror_dir}/terraform.tfstate | jq -r '.outputs.aws_mirrors_public_name.value[0]' ",
                     returnStdout: true).trim()

--- a/terracumber_config/tf_files/local_mirror.tf
+++ b/terracumber_config/tf_files/local_mirror.tf
@@ -132,7 +132,3 @@ module "mirror" {
 output "local_mirrors_public_name" {
   value = module.mirror.configuration.hostnames
 }
-
-output "local_mirrors_public_ip" {
-  value = module.mirror.configuration.ipaddrs
-}


### PR DESCRIPTION
## What does this PR change?

I had to rewrite the way to handle the mirror public IP. First, I added it to the host output in sumaform but that change create issue with the cucumber testsuite. Therefore, I remove the output and my IP selection in the pipeline was broken. After some research and testing, I was able to find the right path to get this value directly from terraform.tfstate. This PR add the new path and fix the MU broken pipe.