### PR TITLE
Add ARM support to 4.1 BV as well

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -108,6 +108,11 @@ provider "libvirt" {
   uri = "qemu+tcp://mandalore.mgr.prv.suse.net/system"
 }
 
+provider "libvirt" {
+  alias = "overdrive3"
+  uri = "qemu+tcp://overdrive3.arch.suse.de/system"
+}
+
 module "base_core" {
   source = "./modules/base"
 
@@ -253,6 +258,31 @@ module "base_debian" {
   provider_settings = {
     pool        = "ssd"
     bridge      = "br1"
+  }
+}
+
+module "base_arm" {
+  providers = {
+    libvirt = libvirt.overdrive3
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "suma-bv-41-"
+  use_avahi   = false
+  domain      = "mgr.prv.suse.net"
+  images      = [ "opensuse153armo" ]
+
+  mirror = "minima-mirror-bv.mgr.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite = true
+
+  provider_settings = {
+    pool        = "ssd"
+    bridge      = "br0"
   }
 }
 
@@ -1223,6 +1253,116 @@ module "sles15sp2-terminal" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+// TODO: no ARM support for openSUSE on 4.1 branch, this should be SLES instead
+module "opensuse153arm-minion" {
+  providers = {
+    libvirt = libvirt.overdrive3
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.1-released"
+  name               = "min-opensuse153arm"
+  image              = "opensuse153armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:6d"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = <<EOT
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <!-- XSL transformation for aarch64 -->
+
+  <xsl:output omit-xml-declaration="yes" />
+
+  <!-- no IDE on aarch64, use SCSI instead -->
+  <xsl:template match="@bus[.='ide']">
+    <xsl:attribute name="bus"> <xsl:text>scsi</xsl:text> </xsl:attribute>
+  </xsl:template>
+
+  <!-- provide flash for booting -->
+  <xsl:template match="os">
+    <xsl:copy>
+      <xsl:apply-templates select="*|@*" />
+      <xsl:element name="loader">
+        <xsl:attribute name="type"> <xsl:text>pflash</xsl:text> </xsl:attribute>
+        <xsl:attribute name="readonly"> <xsl:text>yes</xsl:text> </xsl:attribute>
+        <xsl:text>/usr/share/qemu/aavmf-aarch64-code.bin</xsl:text>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- change machine type -->
+  <xsl:template match="type">
+    <xsl:element name="type">
+      <xsl:attribute name="machine"> <xsl:text>virt</xsl:text> </xsl:attribute>
+      <xsl:text>hvm</xsl:text>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- use host passthrough mode for CPU -->
+  <xsl:template match="cpu">
+    <xsl:element name="cpu">
+      <xsl:attribute name="mode"> <xsl:text>host-passthrough</xsl:text> </xsl:attribute>
+      <xsl:attribute name="check"> <xsl:text>none</xsl:text> </xsl:attribute>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- work around https://gitlab.com/libvirt/libvirt/-/issues/177
+       for <controller type="virtio-serial"> -->
+  <!-- no LSI logic on aarch64, use virtio-scsi instead -->
+  <xsl:template match="devices">
+    <xsl:copy>
+      <xsl:apply-templates select="*|@*" />
+      <xsl:element name="controller">
+        <xsl:attribute name="type"> <xsl:text>virtio-serial</xsl:text> </xsl:attribute>
+        <xsl:element name="address">
+          <xsl:attribute name="type"> <xsl:text>virtio-mmio</xsl:text> </xsl:attribute>
+        </xsl:element>
+      </xsl:element>
+      <xsl:element name="controller">
+        <xsl:attribute name="type"> <xsl:text>scsi</xsl:text> </xsl:attribute>
+        <xsl:attribute name="model"> <xsl:text>virtio-scsi</xsl:text> </xsl:attribute>
+        <xsl:element name="address">
+          <xsl:attribute name="type"> <xsl:text>virtio-mmio</xsl:text> </xsl:attribute>
+        </xsl:element>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- work around https://gitlab.com/libvirt/libvirt/-/issues/177
+       for <disk type="volume"> -->
+  <xsl:template match="disk[@type='volume']">
+    <xsl:copy>
+      <xsl:apply-templates select="*|@*" />
+      <xsl:element name="address">
+        <xsl:attribute name="type"> <xsl:text>virtio-mmio</xsl:text> </xsl:attribute>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- work around https://gitlab.com/libvirt/libvirt/-/issues/177
+       for <rng> -->
+  <xsl:template match="rng" />
+
+  <!-- just copy the rest -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*" />
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>
+EOT
+  }
+  server_configuration = {
+    hostname = "suma-bv-41-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  //opensuse153arm-minion_additional_repos
+
+}
+
 module "controller" {
   source             = "./modules/controller"
   base_configuration = module.base_core.configuration
@@ -1299,6 +1439,9 @@ module "controller" {
   sle12sp4_terminal_configuration = module.sles12sp4-terminal.configuration
   sle12sp5_terminal_configuration = module.sles12sp5-terminal.configuration
   sle15sp2_terminal_configuration = module.sles15sp2-terminal.configuration
+
+  // TODO: no ARM support for openSUSE on 4.1 branch, this should be SLES instead
+  opensuse153arm_minion_configuration = module.opensuse153arm-minion.configuration
 }
 
 resource "null_resource" "server_extra_nfs_mounts" {

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -1323,7 +1323,7 @@ EOT
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  //sle15sp3arm-minion_additional_repos
+  //opensuse153arm-minion_additional_repos
 
 }
 


### PR DESCRIPTION
This PR adds ARM support to 4.1 BV.

This is the same code that has already been reverted, plus the bit that was missing to make it work.

I also changed overdrive4 to overdrive3, so each test suite has its own ARM hypervisor.

I also fixed a bug in 4.2 preventing to use the JSON file for ARM.

If this still creates problems, please don't revert this time, but just comment out the problematic bit.