### PR TITLE
Remove if not deployed

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -265,7 +265,7 @@ def run(params) {
                 if(environment_workspace){
                     ws(environment_workspace){
                         if (env.env_file) {
-                            if (currentBuild.currentResult == 'SUCCESS '){
+                            if (currentBuild.currentResult == 'SUCCESS' || !deployed){
                                 sh "rm -f ${env_file}"
                             }else{
                                 println("Keep the environment locked for one extra hour so you can debug")

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -316,10 +316,10 @@ def run(params) {
                             if (params.email_to != '') {
                                 sh " export TF_VAR_MAIL_TO=${params.email_to}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
                             }
+                            // Clean up old results
+                            sh "./clean-old-results -r ${resultdir}"
+                            sh "exit ${error}"
                         }
-                        // Clean up old results
-                        sh "./clean-old-results -r ${resultdir}"
-                        sh "exit ${error}"
                     }
                 }
             }


### PR DESCRIPTION
Makes no sense to keep the environment locked for an extra hour if we
could not deployed. For example, this happens if there is any error
prior to the deploy phase. In that case, several retries which will take
less than an hour, will end up with all environment locked.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>