### PR TITLE
NFS mounts for 3rd mirror

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -1363,30 +1363,7 @@ module "controller" {
 
 resource "null_resource" "server_extra_nfs_mounts" {
   provisioner "remote-exec" {
-    inline = [
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7  /mirror/repo/$RCE/RES7  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES7'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7-SUSE-Manager-Tools  /mirror/repo/$RCE/RES7-SUSE-Manager-Tools  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES7-SUSE-Manager-Tools'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta  /mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES  /mirror/SUSE/Updates/RES  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Updates/RES'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-CB  /mirror/SUSE/Updates/RES-CB  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Updates/RES-CB'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-AS  /mirror/SUSE/Updates/RES-AS  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Updates/RES-AS'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Products/RES  /mirror/SUSE/Products/RES  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Products/RES'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8",
-      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/distribution/leap/15.3  /mirror/distribution/leap/15.3  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/distribution/leap/15.3",
-      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3"
-    ]
+    script = "./common/nfs-mounts.sh"
     connection {
       type     = "ssh"
       user     = "root"

--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -1377,7 +1377,15 @@ resource "null_resource" "server_extra_nfs_mounts" {
       "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-AS  /mirror/SUSE/Updates/RES-AS  nfs  defaults  0 0' >> /etc/fstab",
       "mount '/mirror/SUSE/Updates/RES-AS'",
       "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Products/RES  /mirror/SUSE/Products/RES  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Products/RES'"
+      "mount '/mirror/SUSE/Products/RES'",
+      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7",
+      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8",
+      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/distribution/leap/15.3  /mirror/distribution/leap/15.3  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/distribution/leap/15.3",
+      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3"
     ]
     connection {
       type     = "ssh"

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -1324,30 +1324,7 @@ module "controller" {
 
 resource "null_resource" "server_extra_nfs_mounts" {
   provisioner "remote-exec" {
-    inline = [
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7  /mirror/repo/$RCE/RES7  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES7'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7-SUSE-Manager-Tools  /mirror/repo/$RCE/RES7-SUSE-Manager-Tools  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES7-SUSE-Manager-Tools'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta  /mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES  /mirror/SUSE/Updates/RES  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Updates/RES'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-CB  /mirror/SUSE/Updates/RES-CB  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Updates/RES-CB'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-AS  /mirror/SUSE/Updates/RES-AS  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Updates/RES-AS'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Products/RES  /mirror/SUSE/Products/RES  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Products/RES'",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7",
-      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8",
-      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/distribution/leap/15.3  /mirror/distribution/leap/15.3  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/distribution/leap/15.3",
-      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  nfs  defaults  0 0' >> /etc/fstab",
-      "mount /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3"
-    ]
+    script = "./common/nfs-mounts.sh"
     connection {
       type     = "ssh"
       user     = "root"

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -1338,7 +1338,15 @@ resource "null_resource" "server_extra_nfs_mounts" {
       "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-AS  /mirror/SUSE/Updates/RES-AS  nfs  defaults  0 0' >> /etc/fstab",
       "mount '/mirror/SUSE/Updates/RES-AS'",
       "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Products/RES  /mirror/SUSE/Products/RES  nfs  defaults  0 0' >> /etc/fstab",
-      "mount '/mirror/SUSE/Products/RES'"
+      "mount '/mirror/SUSE/Products/RES'",
+      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7",
+      "echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8",
+      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/distribution/leap/15.3  /mirror/distribution/leap/15.3  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/distribution/leap/15.3",
+      "echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  nfs  defaults  0 0' >> /etc/fstab",
+      "mount /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3"
     ]
     connection {
       type     = "ssh"

--- a/terracumber_config/tf_files/common/nfs-mounts.sh
+++ b/terracumber_config/tf_files/common/nfs-mounts.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7  /mirror/repo/$RCE/RES7  nfs  defaults  0 0' >> /etc/fstab
+mount '/mirror/repo/$RCE/RES7'
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7-SUSE-Manager-Tools  /mirror/repo/$RCE/RES7-SUSE-Manager-Tools  nfs  defaults  0 0' >> /etc/fstab
+mount '/mirror/repo/$RCE/RES7-SUSE-Manager-Tools'
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta  /mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta  nfs  defaults  0 0' >> /etc/fstab
+mount '/mirror/repo/$RCE/RES7-SUSE-Manager-Tools-Beta'
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES  /mirror/SUSE/Updates/RES  nfs  defaults  0 0' >> /etc/fstab
+mount '/mirror/SUSE/Updates/RES'
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-CB  /mirror/SUSE/Updates/RES-CB  nfs  defaults  0 0' >> /etc/fstab
+mount '/mirror/SUSE/Updates/RES-CB'
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Updates/RES-AS  /mirror/SUSE/Updates/RES-AS  nfs  defaults  0 0' >> /etc/fstab
+mount '/mirror/SUSE/Updates/RES-AS'
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/SUSE/Products/RES  /mirror/SUSE/Products/RES  nfs  defaults  0 0' >> /etc/fstab
+mount '/mirror/SUSE/Products/RES'
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7  nfs  defaults  0 0' >> /etc/fstab
+mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7
+
+echo 'minima-mirror-bv2.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8  nfs  defaults  0 0' >> /etc/fstab
+mount /mirror/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8
+
+echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/distribution/leap/15.3  /mirror/distribution/leap/15.3  nfs  defaults  0 0' >> /etc/fstab
+mount /mirror/distribution/leap/15.3
+
+echo 'minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3  nfs  defaults  0 0' >> /etc/fstab
+mount /mirror/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3


### PR DESCRIPTION
This PR:

* creates new NFS mounts for RedHat, for a cleaner separation of mirrors
* creates new NFS mounts for the third mirror
* factorizes the script that completes /etc/fstab and mounts the result