### PR TITLE
Add custom header when deploying

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -218,6 +218,9 @@ def run(params) {
                         }
                         sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_SLE_CLIENT_REPO=${SLE_CLIENT_REPO};export TF_VAR_CENTOS_CLIENT_REPO=${CENTOS_CLIENT_REPO};export TF_VAR_UBUNTU_CLIENT_REPO=${UBUNTU_CLIENT_REPO};export TF_VAR_OPENSUSE_CLIENT_REPO=${OPENSUSE_CLIENT_REPO};export TF_VAR_PULL_REQUEST_REPO=${PULL_REQUEST_REPO}; export TF_VAR_MASTER_OTHER_REPO=${MASTER_OTHER_REPO};export TF_VAR_MASTER_REPO=${MASTER_REPO};export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${terraform_bin}; export TERRAFORM_PLUGINS=${terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
                         deployed = true
+                        println("Keep the environment locked for 24 hours so you can debug")
+                        sh "echo \"rm -f ${env_file}*\" | at now +24 hour"
+                        sh "echo keep:24h >> ${env_file}.info"
                     }
                 }
             }
@@ -283,10 +286,6 @@ def run(params) {
                         if (env.env_file) {
                             if (currentBuild.currentResult == 'SUCCESS' || !deployed){
                                 sh "rm -f ${env_file}*"
-                            }else{
-                                println("Keep the environment locked for one extra hour so you can debug")
-                                sh "echo \"rm -f ${env_file}*\" | at now +24 hour"
-                                sh "echo keep:1h >> ${env_file}.info"
                             }
                         }
                     }

--- a/terracumber_config/scripts/set_custom_header.sh
+++ b/terracumber_config/scripts/set_custom_header.sh
@@ -1,0 +1,58 @@
+ENV="1"
+HYPERVISOR="server.kvm.lan"
+FILE="/usr/share/rhn/config-defaults/rhn_java.conf"
+HOURS=24;
+EMAIL="a@b.com"
+DEADLINE_TIME=$(date -d "$(date) + 24 hours")
+
+usage() {
+  echo "Usage: $0 -m email -h hours -y hypervisor -f file -e environment"
+  echo "Example: $0 -m a@b.com -h 24 -h server.kvm.lan -f /usr/share/rhn/config-defaults/rhn_java.conf -e 1"
+  echo "Parameters are option. If not specified, you will get the defaults from the example"
+  exit -1
+}
+
+while [[ $# -gt 0 ]];do
+    key=$1
+    case $key in
+        -m|--mail)
+            EMAIL=$2
+            shift
+            shift
+            ;;
+        -t|--time)
+            HOURS=$2
+	    DEADLINE_TIME=$(date -d "$(date) + $HOURS hours")
+            shift
+            shift
+            ;;
+        -y|--hypervisor)
+            HYPERVISOR=$2
+            shift
+            shift
+            ;;
+        -f|--file)
+            FILE=$2
+            shift
+            shift
+            ;;
+        -e|--environment)
+             ENV=$2
+             shift
+             shift
+             ;;    
+        -h|--help)
+            usage
+            shift
+            ;;
+    esac
+done
+
+sed -e "s%java.custom_header =.*%java.custom_header = \
+     In case of FAILURE, you can access this server until ${DEADLINE_TIME}. \
+     Otherwise, this server will be removed at the end of the pipeline. \
+     Test environment for ${EMAIL}. \
+     Run on environment ${ENV}. \
+     On hypervisor ${HYPERVISOR}. \
+    %g" -i ${FILE}
+spacewalk-service restart

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -37,12 +37,22 @@ variable "MAIL_TEMPLATE" {
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
   type = string
-  default = "Results Uyuni Pull Request: Environment setup failed"
+  default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
+}
+
+variable "ENVIRONMENT" {
+  type = string
+  default = "1"
+}
+
+variable "HYPER" {
+  type = string
+  default = "romulus.mgr.prv.suse.net"
 }
 
 variable "MAIL_FROM" {
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://romulus.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +146,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr1-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.101.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -37,12 +37,22 @@ variable "MAIL_TEMPLATE" {
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
   type = string
-  default = "Results Uyuni Pull Request: Environment setup failed"
+  default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
+}
+
+variable "ENVIRONMENT" {
+  type = string
+  default = "10"
+}
+
+variable "HYPER" {
+  type = string
+  default = "mojito.mgr.prv.suse.net"
 }
 
 variable "MAIL_FROM" {
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://mojito.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +146,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr10-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.110.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env11.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env11.tf
@@ -37,12 +37,22 @@ variable "MAIL_TEMPLATE" {
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
   type = string
-  default = "Results Uyuni Pull Request: Environment setup failed"
+  default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
+}
+
+variable "ENVIRONMENT" {
+  type = string
+  default = "11"
+}
+
+variable "HYPER" {
+  type = string
+  default = "moscowmule.mgr.prv.suse.net"
 }
 
 variable "MAIL_FROM" {
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://moscowmule.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +146,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr11-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.111.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env12.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env12.tf
@@ -37,12 +37,22 @@ variable "MAIL_TEMPLATE" {
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
   type = string
-  default = "Results Uyuni Pull Request: Environment setup failed"
+  default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
+}
+
+variable "ENVIRONMENT" {
+  type = string
+  default = "12"
+}
+
+variable "HYPER" {
+  type = string
+  default = "moscowmule.mgr.prv.suse.net"
 }
 
 variable "MAIL_FROM" {
@@ -115,7 +125,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://moscowmule.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +145,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr12-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +305,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.112.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -45,6 +45,16 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
 }
 
+variable "ENVIRONMENT" {
+  type = string
+  default="2"
+}
+
+variable "HYPER" {
+  type = string
+  default = "romulus.mgr.prv.suse.net"
+}
+
 variable "MAIL_FROM" {
   type = string
   default = "galaxy-ci@suse.de"
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://romulus.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +146,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr2-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.102.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -45,6 +45,16 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
 }
 
+variable "ENVIRONMENT" {
+  type = string
+  default = "3"
+}
+
+variable "HYPER" {
+  type = string
+  default = "vulcan.mgr.prv.suse.net"
+}
+
 variable "MAIL_FROM" {
   type = string
   default = "galaxy-ci@suse.de"
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://vulcan.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -132,10 +143,10 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr3-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.103.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -45,6 +45,16 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
 }
 
+variable "ENVIRONMENT" {
+  type = string
+  default = "4"
+}
+
+variable "HYPER" {
+  type = string
+  default = "vulcan.mgr.prv.suse.net"
+}
+
 variable "MAIL_FROM" {
   type = string
   default = "galaxy-ci@suse.de"
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://vulcan.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -132,10 +143,10 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr4-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.104.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -45,6 +45,16 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
 }
 
+variable "ENVIRONMENT" {
+  type = string
+  default = "5"
+}
+
+variable "HYPER" {
+  type = string
+  default = "hyperion.mgr.prv.suse.net"
+}
+
 variable "MAIL_FROM" {
   type = string
   default = "galaxy-ci@suse.de"
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://hyperion.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -132,10 +143,10 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr5-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.105.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -45,6 +45,16 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
 }
 
+variable "ENVIRONMENT" {
+  type = string
+  default = "6"
+}
+
+variable "HYPER" {
+  type = string
+  default = "hyperion.mgr.prv.suse.net"
+}
+
 variable "MAIL_FROM" {
   type = string
   default = "galaxy-ci@suse.de"
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://hyperion.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -132,10 +143,10 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr6-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.106.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -37,12 +37,22 @@ variable "MAIL_TEMPLATE" {
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
   type = string
-  default = "Results Uyuni Pull Request: Environment setup failed"
+  default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
+}
+
+variable "ENVIRONMENT" {
+  type = string
+  default = "7"
+}
+
+variable "HYPER" {
+  type = string
+  default = "daiquiri.mgr.prv.suse.net"
 }
 
 variable "MAIL_FROM" {
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://daiquiri.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +146,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr7-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.107.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -37,12 +37,22 @@ variable "MAIL_TEMPLATE" {
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
   type = string
-  default = "Results Uyuni Pull Request: Environment setup failed"
+  default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
+}
+
+variable "ENVIRONMENT" {
+  type = string
+  default = "8"
+}
+
+variable "HYPER" {
+  type = string
+  default = "daiquiri.mgr.prv.suse.net"
 }
 
 variable "MAIL_FROM" {
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://daiquiri.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +146,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr8-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -293,9 +304,39 @@ module "cucumber_testsuite" {
     network_name       = null
     bridge             = "br1"
     additional_network = "192.168.108.0/24"
-
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -37,12 +37,22 @@ variable "MAIL_TEMPLATE" {
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
   type = string
-  default = "Results Uyuni Pull Request: Environment setup failed"
+  default = "Results Pull Request: Environment setup failed"
 }
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
   default = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"
+}
+
+variable "ENVIRONMENT" {
+  type = string
+  default = "9"
+}
+
+variable "HYPER" {
+  type = string
+  default = "mojito.mgr.prv.suse.net"
 }
 
 variable "MAIL_FROM" {
@@ -114,8 +124,9 @@ terraform {
   }
 }
 
+
 provider "libvirt" {
-  uri = "qemu+tcp://mojito.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://${var.HYPER}/system"
 }
 
 module "cucumber_testsuite" {
@@ -135,7 +146,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
-  name_prefix  = "suma-pr9-"
+  name_prefix  = "suma-pr${var.ENVIRONMENT}-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -295,6 +306,37 @@ module "cucumber_testsuite" {
     additional_network = "192.168.109.0/24"
   }
 }
+
+
+resource "null_resource" "add_test_information" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+ provisioner "file" {
+    source      = "../../susemanager-ci/terracumber_config/scripts/set_custom_header.sh"
+    destination = "/tmp/set_custom_header.sh"
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+  provisioner "remote-exec" {
+    inline = [
+       "echo hola > /tmp/hola",
+       "chmod +x /tmp/set_custom_header.sh",
+      "/tmp/set_custom_header.sh -e ${var.ENVIRONMENT} -y ${var.HYPER} -m ${var.MAIL_TO} -t 24",
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.server.hostname}"
+    }
+  }
+}
+
 
 output "configuration" {
   value = module.cucumber_testsuite.configuration


### PR DESCRIPTION
This PR adds a custom header in the server web pages, to show that this is a test environment, who started and when to expect this to be removed. All this information is very useful because the same environment would be reused later for another user and you want to know if it is still the environment you deployed for you to debug, or if this is a new environment. This is more relevant now that we keep them for 24h, because it can be handy to know when the 24h had passed.
