### PR TITLE
Enabling accept_all_ssl_protocols in BVs

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -316,6 +316,7 @@ module "server" {
   disable_download_tokens        = false
   ssh_key_path                   = "./salt/controller/id_rsa.pub"
   from_email                     = "root@suse.de"
+  accept_all_ssl_protocols       = true
 
   //server_additional_repos
 
@@ -347,6 +348,7 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = true
   ssh_key_path              = "./salt/controller/id_rsa.pub"
+  accept_all_ssl_protocols  = true
 
   //proxy_additional_repos
 

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -316,6 +316,7 @@ module "server" {
   disable_download_tokens        = false
   ssh_key_path                   = "./salt/controller/id_rsa.pub"
   from_email                     = "root@suse.de"
+  accept_all_ssl_protocols       = true
 
   //server_additional_repos
 
@@ -347,6 +348,7 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = true
   ssh_key_path              = "./salt/controller/id_rsa.pub"
+  accept_all_ssl_protocols  = true
 
   //proxy_additional_repos
 


### PR DESCRIPTION
Enabling accept_all_ssl_protocols in BVs
So we don't have issues with SLES11SP4 due to TLS 1.2 support

Related PR:
https://github.com/uyuni-project/sumaform/pull/1015