### PR TITLE
Keep environment for 24h in case of failure

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -283,7 +283,7 @@ def run(params) {
                                 sh "rm -f ${env_file}*"
                             }else{
                                 println("Keep the environment locked for one extra hour so you can debug")
-                                sh "echo \"rm -f ${env_file}*\" | at now +1 hour"
+                                sh "echo \"rm -f ${env_file}*\" | at now +24 hour"
                                 sh "echo keep:1h >> ${env_file}.info"
                             }
                         }

--- a/terracumber_config/mail_templates/mail-template-jenkins-pull-request.txt
+++ b/terracumber_config/mail_templates/mail-template-jenkins-pull-request.txt
@@ -26,6 +26,8 @@ https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-dev-acceptance-tests
 
 In case of failure, you can connect to the server host. See $urlprefix/$timestamp for connection details.
 
+Your environment will be kept for 24h.
+
 
 Do you need help? Ask for help at our slack channel
 


### PR DESCRIPTION
Now that we have 12 environments, we should be able to keep them for 24h without running out of them.