### PR TITLE
Use mirrored images of xen and kvm as workaround of the recurrent issue with official mirrors

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:0a"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:0b"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:76"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:77"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env11.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env11.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:82"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:83"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env12.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env12.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -271,8 +291,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:8e"
       }
@@ -284,10 +302,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:8f"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:16"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:17"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:22"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:23"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:2e"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:2f"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:3a"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:3b"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:46"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:47"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:52"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:53"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:5e"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:5f"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -114,6 +114,26 @@ variable "OPENSUSE_CLIENT_REPO" {
   type = string
 }
 
+variable "hvm_disk_image" {
+  description = "URL to the disk image to use for KVM guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "hvm_disk_image_hash" {
+  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+}
+
+variable "xen_disk_image" {
+  description = "URL to the disk image to use for Xen PV guests"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+}
+
+variable "xen_disk_image_hash" {
+  description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default     = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+}
+
 terraform {
   required_version = "1.0.10"
   required_providers {
@@ -272,8 +292,6 @@ module "cucumber_testsuite" {
     }
     kvm-host = {
       image = "opensuse153o"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:6a"
       }
@@ -285,10 +303,6 @@ module "cucumber_testsuite" {
     }
     xen-host = {
       image = "opensuse153o"
-      xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
-      xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
-      hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
-      hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
       provider_settings = {
         mac = "aa:b2:92:04:00:6b"
       }


### PR DESCRIPTION
This PR fix the workaround made by Cédric and Jordi some days ago, so we inject the variables not from the module but directly at top of main.tf