### PR TITLE
Drop ARM testing for 4.1

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-build-validation.tf
@@ -262,30 +262,7 @@ module "base_debian" {
   }
 }
 
-module "base_arm" {
-  providers = {
-    libvirt = libvirt.overdrive4
-  }
-
-  source = "./modules/base"
-
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-41-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "opensuse153armo" ]
-
-  mirror = "minima-mirror-bv3.mgr.prv.suse.net"
-  use_mirror_images = true
-
-  testsuite = true
-
-  provider_settings = {
-    pool        = "ssd"
-    bridge      = "br0"
-  }
-}
+// No ARM support for openSUSE on 4.1 branch
 
 module "server" {
   source             = "./modules/server"
@@ -862,7 +839,7 @@ module "debian10-minion" {
 
 }
 
-# Debian 11 is not supported yet by 4.1
+// Debian 11 is not supported yet by 4.1
 
 module "sles11sp4-sshminion" {
   providers = {
@@ -1089,7 +1066,7 @@ module "debian10-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-# Debian 11 is not supported yet by 4.1
+// Debian 11 is not supported yet by 4.1
 
 module "sles11sp4-buildhost" {
   providers = {
@@ -1220,32 +1197,7 @@ module "sles15sp3-terminal" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-// TODO: no ARM support for openSUSE on 4.1 branch, this should be SLES instead
-module "opensuse153arm-minion" {
-  providers = {
-    libvirt = libvirt.overdrive4
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "4.1-released"
-  name               = "min-opensuse153arm"
-  image              = "opensuse153armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:6e"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "suma-bv-41-pxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  //opensuse153arm-minion_additional_repos
-
-}
+// No ARM support for openSUSE on 4.1 branch
 
 module "controller" {
   source             = "./modules/controller"
@@ -1324,8 +1276,7 @@ module "controller" {
   sle12sp5_terminal_configuration = module.sles12sp5-terminal.configuration
   sle15sp3_terminal_configuration = module.sles15sp3-terminal.configuration
 
-  // TODO: no ARM support for openSUSE on 4.1 branch, this should be SLES instead
-  opensuse153arm_minion_configuration = module.opensuse153arm-minion.configuration
+  // No ARM support for openSUSE on 4.1 branch
 }
 
 resource "null_resource" "server_extra_nfs_mounts" {


### PR DESCRIPTION
Apparently, openSUSE 15.2 ARM is supported on 4.1:
```
suma-bv-41-srv:~ # spacewalk-common-channels -u admin -p admin --list | grep open.*aarch64
 opensuse_leap15_1-aarch64: aarch64
 opensuse_leap15_1-updates-aarch64: aarch64
 opensuse_leap15_1-uyuni-client-aarch64: aarch64
 opensuse_leap15_1-uyuni-client-devel-aarch64: aarch64
 opensuse_leap15_2-aarch64: aarch64
 opensuse_leap15_2-updates-aarch64: aarch64
 opensuse_leap15_2-uyuni-client-aarch64: aarch64
 opensuse_leap15_2-uyuni-client-devel-aarch64: aarch64
```
but I did not find 15.2 images similar to the 15.3 images in https://download.opensuse.org/distribution/leap/15.3/appliances/ .

Dropping ARM testing for 4.1.
