### PR TITLE
Increase git timeout pr

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -75,8 +75,8 @@ def run(params) {
                         //      Inside userRemoteConfigs add credentialsId: 'github'
                         checkout([  
                                     $class: 'GitSCM', 
-                                    branches: [[name: "pr/${params.pull_request_number}"]], 
-                                    extensions: [[$class: 'CloneOption', depth: 1, shallow: true]],
+                                    branches: [[name: "pr/${params.pull_request_number}"]],
+                                    extensions: [[$class: 'CloneOption', depth: 1, shallow: true, timeout: 30]],
                                     userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*', url: "${pull_request_repo}"]],
                                     extensions: [
                                     [

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('manager-jenkins-worker-prs-2') {
+node('pull-request-test') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '5')),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('pull-request-test') {
+node('manager-jenkins-worker-prs-2') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '5')),
         parameters([


### PR DESCRIPTION
Currently, git clone timeout is by default set to 10 minutes. 
To clone uyuni project, you need around 20 minutes so jenkins jobs are always failing because of this 10 minutes timeout.

This PR increase the default timeout from 10 minutes to 30 minutes.

/!\ **This PR by itself will not fix the issue**, this variable need to be added when starting the jenkins agent ( in uyuni PR case : `jenkins-worker-prs.mgr.prv.suse.net` ) : 
` -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30` 

During my tests, cloning uyuni repository in Jenkins works with this agent configuration :

`/usr/bin/java -Djava.util.logging.config.file=/usr/share/java/logging-swarm-client.properties  -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar /usr/share/java/swarm-client-jar-with-dependencies.jar -master https://ci.suse.de/ -username manager -password linux -labels pull-request-test -executors 12 -name manager-jenkins-worker-prs -fsroot /home/jenkins/jenkins-build/ -disableSslVerification -disableClientsUniqueId -mode exclusive` 

I was not able to add the variable to `manager-jenkins-worker-prs` because when I kill the process, it automatically restarts and I don't have access to Jenkins configuration.