### PR TITLE
Be able to select environments based on a file

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -1,0 +1,8 @@
+if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
+    first_env = 11;
+    last_env = 12;
+} else {
+    first_env = 1;
+    last_env = 10;
+}
+

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -14,7 +14,6 @@ def run(params) {
         terraform_init = true
         rake_namespace = 'cucumber'
         rake_parallel_namespace = 'parallel'
-        total_envs = 12
         jenkins_workspace = '/home/jenkins/jenkins-build/workspace/'
         pull_request_repo = 'https://github.com/uyuni-project/uyuni.git'
         builder_api = 'https://api.opensuse.org'
@@ -24,6 +23,8 @@ def run(params) {
         environment_workspace = null
         try {
             stage('Get environment') {
+                  echo "DEBUG: first environment: ${first_env}"
+                  echo "DEBUG: last environment: ${last_env}"
                   env.suma_pr_lockfile = "/tmp/suma-pr${params.pull_request_number}"
                   if(params.force_pr_lock_cleanup) {
                     sh "rm -rf ${env.suma_pr_lockfile}"
@@ -39,7 +40,7 @@ def run(params) {
                   fqdn_jenkins_node = sh(script: "hostname -f", returnStdout: true).trim()
                   echo "DEBUG: fqdn_jenkins_node: ${fqdn_jenkins_node}"
                   // Pick a free environment
-                  for (env_number = 1; env_number <= total_envs; env_number++) {
+                  for (env_number = first_env; env_number <= last_env; env_number++) {
                       env.env_file="/tmp/env-suma-pr-${env_number}.lock"
                       env_status = sh(script: "lockfile -001 -r1 -! ${env_file} 2>/dev/null && echo 'locked' || echo 'free' ", returnStdout: true).trim()
                       if(env_status == 'free'){
@@ -50,7 +51,7 @@ def run(params) {
                           sh "echo started:\$(date) >> ${env_file}.info"
                           break;
                       }
-                      if(env_number == total_envs){
+                      if(env_number == last_env){
                           error('Aborting the build. All our environments are busy.')
                       }
                   }

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -23,6 +23,14 @@ node('pull-request-test') {
         checkout scm
     }
     timeout(activity: false, time: 20, unit: 'HOURS') {
+        // set default values
+        first_env = 1;
+        last_env = 10;
+        // load values to override default ones
+        pr_env_filename = "jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy"
+        if (fileExists(pr_env_filename)) {
+            load pr_env_filename
+        }
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-pull-request.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
This way, we can have a different file in our forks and use this
mechanism to reserve environments for development purposes. Otherwise we
are all the time messing up the pipeline devs use.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>