### PR TITLE
Do not use openSUSE official repos

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:01"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:02"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0a"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0b"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:95"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:96"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:9e"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:9f"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0d"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0e"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:16"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:17"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:19"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:1a"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:22"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:23"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:25"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:26"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:2e"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:2f"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:31"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:32"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3a"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3b"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3d"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3e"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:46"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:47"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:71"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:72"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7a"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7b"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7d"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7e"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:86"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:87"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -168,10 +168,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:89"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,10 +186,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:8a"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       image = "opensuse153o"
       additional_packages = [ "venv-salt-minion" ]
@@ -279,8 +293,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:92"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -296,8 +317,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:93"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        Update_repository_of_openSUSE_Backports = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/backports/",
+        Non_Oss_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        Main_Repository = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        Update_repository_with_updates_from_SUSE_Linux_Enterprise_15 = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/sle/",
+        Update_Repository_Non_Oss = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/non-oss/",
+        Main_Update_Repository = "http://minima-mirror.mgr.prv.suse.net/update/leap/15.3/oss",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true


### PR DESCRIPTION
We are having trouble with the official repos. From time to time there
is an error. Thus, let's not use them at all.

Use minima mirror instead of download.opensuse.org

This is to minimize depending on external infrastructure such as
openSUSE mirrors