### PR TITLE
sonarqube: need to remove the .scannerwork from the container

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-sonarqube
+++ b/jenkins_pipelines/environments/uyuni-master-sonarqube
@@ -31,6 +31,7 @@ node('sumadocker-nue') {
     }
     stage('Clean up') {
         dir("uyuni") {
+            sh "docker run --rm -v \$PWD:/usr/src sonarsource/sonar-scanner-cli sh -c 'rm -rf .scannerwork'"
             sh "git clean -dxf"
         }
     }


### PR DESCRIPTION
`git clean` complains about insufficient permissions on `.scannerwork`: use the container to remove it before.