### PR TITLE
Do not let user choose the sumaform repo. Simplify.

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -1,6 +1,9 @@
 if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
     first_env = 9;
     last_env = 10;
+    // if you change the sumaform repo or reference, you need to remove the sumaform directory from the results folder
+    sumaform_gitrepo = "https://github.com/jordimassaguerpla/sumaform.git";
+    sumaform_ref = "master";
 } else {
     first_env = 1;
     last_env = 8;

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -10,8 +10,6 @@ node('pull-request-test') {
             extendedChoice(name: 'functional_scopes',  multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30, value: '@scope_smdba,@scope_spacecmd,@scope_spacewalk_utils,@scope_visualization,@scope_notification_message,@scope_virtual_host_manager,@scope_subscription_matching,@scope_formulas,@scope_sp_migration,@scope_cve_audit,@scope_onboarding,@scope_content_lifecycle_management,@scope_res,@scope_recurring_actions,@scope_maintenance_windows,@scope_cluster_management,@scope_building_container_images,@scope_kubernetes_integration,@scope_openscap,@scope_ubuntu,@scope_action_chains,@scope_salt_ssh,@scope_tomcat,@scope_changing_software_channels,@scope_monitoring,@scope_salt,@scope_cobbler,@scope_sumatoolbox,@scope_virtualization,@scope_hub,@scope_retail,@scope_configuration_channels,@scope_content_staging,@scope_proxy,@scope_traditional_client,@scope_xmlrpc,@scope_power_management,@scope_retracted_patches', description: 'Secondary tests: choose the functional scopes that you want to test.'),
             booleanParam(name: 'must_build', defaultValue: true, description: 'Advanced: Uncheck this if you want to reuse a previous build packages from the build service'),
             booleanParam(name: 'must_test', defaultValue: true, description: 'Advanced: Uncheck this if you do not want to run any tests'),
-            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Advanced: Sumaform Git Repository, only if you want to test changes in sumaform'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Advanced: Sumaform Git reference (branch, tag...), only if you want to test changes in sumaform'),
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Advanced: Change this by your repo, only if you changed the tests in your PR'),
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Advanced: Change this by your branch, only if you changed the tests in your PR'),
             booleanParam(name: 'force_pr_lock_cleanup', defaultValue: false, description: 'Advanced: Check this parameter to force a cleanup of the locks associated with this PR. Be careful, only do this if you are certain no one else is running a test for the same PR. More at https://github.com/SUSE/spacewalk/wiki/How-to-run-the-test-suite-on-a-given-Pull-Request#troubleshooting'),
@@ -26,6 +24,8 @@ node('pull-request-test') {
         // set default values
         first_env = 1;
         last_env = 10;
+        sumaform_gitrepo = "git@github.com:uyuni-project/sumaform.git";
+        sumaform_ref = "master";
         // load values to override default ones
         pr_env_filename = "jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy"
         if (fileExists(pr_env_filename)) {


### PR DESCRIPTION
You can setup the sumaform via the environment file, which uses one or
the other value depending on the job name.

This way, we can still use a different sumaform, but it needs to be done
via changing that file. This is preferable because when changing the
sumaform, you need to do a manual clean up, so better do not make it too
easy for anyone to change this.