### PR TITLE
Do not use openSUSE official repos

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -19,6 +19,8 @@ def run(params) {
         builder_api = 'https://api.opensuse.org'
         builder_project = 'systemsmanagement:Uyuni:Master:PR'
         source_project = 'systemsmanagement:Uyuni:Master'
+        sumaform_tools_project = 'systemsmanagement:sumaform:tools'
+        test_packages_project = 'systemsmanagement:Uyuni:Test-Packages:Pool'
         build_repo = 'openSUSE_Leap_15.3'
         environment_workspace = null
         try {
@@ -149,7 +151,15 @@ def run(params) {
                         // We do not clean up the previous packages. This speeds up the checkout. We are assuming this project won't ever get deleted, so new builds should always have new release numbers.
                         sh "bash susemanager-utils/testing/automation/publish-rpms.sh -p \"${source_project}:Other\" -r ${build_repo} -a ${arch} -d \"${environment_workspace}/repos\" > ${environment_workspace}/repos/publish_logs/${source_project}_Other 2>&1 || touch ${environment_workspace}/repos/publish_logs/${source_project}_Other.error &"
                         
-                        echo "Publishing packages into http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:CentOS7-Uyuni-Client-Tools/CentOS_7/${arch}"
+                        echo "Publishing packages into http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${sumaform_tools_project}/${build_repo}/x86_64"
+                        // We do not clean up the previous packages. This speeds up the checkout. We are assuming this project won't ever get deleted, so new builds should always have new release numbers.
+                        sh "bash susemanager-utils/testing/automation/publish-rpms.sh -p \"${sumaform_tools_project}\" -r ${build_repo} -a x86_64 -d \"${environment_workspace}/repos\" > ${environment_workspace}/repos/publish_logs/${sumaform_tools_project} 2>&1 || touch ${environment_workspace}/repos/publish_logs/${sumaform_tools_project}.error &"
+
+                        echo "Publishing packages into http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${test_packages_project}/rpm"
+                        // We do not clean up the previous packages. This speeds up the checkout. We are assuming this project won't ever get deleted, so new builds should always have new release numbers.
+                        sh "bash susemanager-utils/testing/automation/publish-rpms.sh -p \"${test_packages_project}\" -r rpm -a x86_64 -d \"${environment_workspace}/repos\" > ${environment_workspace}/repos/publish_logs/${test_packages_project} 2>&1 || touch ${environment_workspace}/repos/publish_logs/${test_packages_project}.error &"
+
+                        echo "Publishing packages into http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:CentOS7-Uyuni-Client-Tools/CentOS_7/x86_64"
                         // We do not clean up the previous packages. This speeds up the checkout. We are assuming this project won't ever get deleted, so new builds should always have new release numbers.
                         sh "bash susemanager-utils/testing/automation/publish-rpms.sh -p \"${source_project}:CentOS7-Uyuni-Client-Tools\" -r CentOS_7 -a ${arch} -d \"${environment_workspace}/repos\" > ${environment_workspace}/repos/publish_logs/${source_project}_CentOS7-Uyuni-Client-Tools 2>&1 || touch ${environment_workspace}/repos/publish_logs/${source_project}_CentOS7-Uyuni-Client-Tools.error &"
 
@@ -211,6 +221,8 @@ def run(params) {
                         env.PULL_REQUEST_REPO= "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${builder_project}:${params.pull_request_number}/${build_repo}/${arch}"
                         env.MASTER_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}/${build_repo}/${arch}"
                         env.MASTER_OTHER_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:Other/${build_repo}/${arch}"
+                        env.MASTER_SUMAFORM_TOOLS_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${sumaform_tools_project}/${build_repo}/${arch}"
+                        env.TEST_PACKAGES_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${test_packages_project}/rpm/${arch}"
                         env.SLE_CLIENT_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:SLE15-Uyuni-Client-Tools/SLE_15/${arch}"
                         env.CENTOS_CLIENT_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:CentOS7-Uyuni-Client-Tools/CentOS_7/${arch}"
                         env.UBUNTU_CLIENT_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/${arch}"
@@ -222,7 +234,7 @@ def run(params) {
                         } else {
                             env.TERRAFORM_INIT = ''
                         }
-                        sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_SLE_CLIENT_REPO=${SLE_CLIENT_REPO};export TF_VAR_CENTOS_CLIENT_REPO=${CENTOS_CLIENT_REPO};export TF_VAR_UBUNTU_CLIENT_REPO=${UBUNTU_CLIENT_REPO};export TF_VAR_OPENSUSE_CLIENT_REPO=${OPENSUSE_CLIENT_REPO};export TF_VAR_PULL_REQUEST_REPO=${PULL_REQUEST_REPO}; export TF_VAR_MASTER_OTHER_REPO=${MASTER_OTHER_REPO};export TF_VAR_MASTER_REPO=${MASTER_REPO};export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${terraform_bin}; export TERRAFORM_PLUGINS=${terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
+                        sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_SLE_CLIENT_REPO=${SLE_CLIENT_REPO};export TF_VAR_CENTOS_CLIENT_REPO=${CENTOS_CLIENT_REPO};export TF_VAR_UBUNTU_CLIENT_REPO=${UBUNTU_CLIENT_REPO};export TF_VAR_OPENSUSE_CLIENT_REPO=${OPENSUSE_CLIENT_REPO};export TF_VAR_PULL_REQUEST_REPO=${PULL_REQUEST_REPO}; export TF_VAR_MASTER_OTHER_REPO=${MASTER_OTHER_REPO};export TF_VAR_MASTER_SUMAFORM_TOOLS_REPO=${MASTER_SUMAFORM_TOOLS_REPO}; export TF_VAR_TEST_PACKAGES_REPO=${TEST_PACKAGES_REPO}; export TF_VAR_MASTER_REPO=${MASTER_REPO};export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${terraform_bin}; export TERRAFORM_PLUGINS=${terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision"
                         deployed = true
                     }
                 }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:01"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:02"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0a"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0b"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:95"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:96"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:9e"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:9f"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0d"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:0e"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:16"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:17"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:19"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:1a"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:22"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:23"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:25"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:26"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:2e"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:2f"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:31"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:32"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3a"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3b"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3d"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:3e"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:46"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:47"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:71"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:72"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7a"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7b"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7d"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:7e"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:86"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:87"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -97,6 +97,14 @@ variable "MASTER_OTHER_REPO" {
   type = string
 }
 
+variable "MASTER_SUMAFORM_TOOLS_REPO" {
+  type = string
+}
+
+variable "TEST_PACKAGES_REPO" {
+  type = string
+}
+
 // Repositories containing the client tools RPMs
 variable "SLE_CLIENT_REPO" {
   type = string
@@ -143,7 +151,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "opensuse153o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -168,10 +176,17 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:89"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+
       }
       image = "opensuse153-ci-pr"
     }
@@ -179,12 +194,18 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:8a"
       }
+      additional_repos_only = true
       additional_repos = {
         pull_request_repo = var.PULL_REQUEST_REPO,
         master_repo = var.MASTER_REPO,
         master_repo_other = var.MASTER_OTHER_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -271,7 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -279,14 +300,20 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:92"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse153-ci-pr"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
@@ -296,8 +323,15 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:04:00:93"
       }
+      additional_repos_only = true
       additional_repos = {
         client_repo = var.OPENSUSE_CLIENT_REPO,
+        master_sumaform_tools_repo = var.MASTER_SUMAFORM_TOOLS_REPO,
+        test_packages_repo = var.TEST_PACKAGES_REPO,
+        non_os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/non-oss/",
+        os_pool = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.3/repo/oss/",
+        os_update = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/",
+        
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true


### PR DESCRIPTION
We are having trouble with the official repos. From time to time there
is an error. Thus, let's not use them at all.

Use minima mirror instead of download.opensuse.org

This is to minimize depending on external infrastructure such as
openSUSE mirrors.

Use an openSUSE image with no repositories at all for all openSUSE vms.

Add the repos with the tf_files, instead of using sumaform, so we can
add the ones in the minima mirror.

We are skipping update repos to avoid the problem with wrong metadata or
missing rpms. This way, it won't happen anymore plus it is
reproduceable.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>