### PR TITLE
Add product for openSUSE aarch64 client tools

### DIFF
--- a/terracumber_config/tf_files/common/nfs-mounts.sh
+++ b/terracumber_config/tf_files/common/nfs-mounts.sh
@@ -15,10 +15,12 @@ done
 
 for dir in 'distribution/leap/15.3' \
            'update/leap/15.3' \
+           'SUSE/Products/SLE-Manager-Tools/15/aarch64' \
+           'SUSE/Products/SLE-Manager-Tools/15-BETA/aarch64' \
            'SUSE/Updates/SLE-Manager-Tools/15/aarch64' \
            'SUSE/Updates/SLE-Manager-Tools/15-BETA/aarch64' \
            'repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3' \
-           '/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools'; do
+           'repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools'; do
   echo "minima-mirror-bv3.mgr.prv.suse.net:/srv/mirror/$dir  /mirror/$dir  nfs  defaults  0 0" >> /etc/fstab
   mount "/mirror/$dir"
 done


### PR DESCRIPTION
We were mirroring the products for openSUSE aarch64 client tools, but not NFS-mounting them.