### PR TITLE
Let's not merge with git master

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -82,15 +82,6 @@ def run(params) {
                                     branches: [[name: "pr/${params.pull_request_number}"]], 
                                     extensions: [[$class: 'CloneOption', depth: 1, shallow: true]],
                                     userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*', url: "${pull_request_repo}"]],
-                                    extensions: [
-                                    [
-                                        $class: 'PreBuildMerge',
-                                        options: [
-                                             fastForwardMode: 'NO_FF',
-                                             mergeRemote: 'origin',
-                                             mergeTarget: 'master'
-                                       ]
-                                     ]]
                                    ])
                     }
                     


### PR DESCRIPTION
I believe merging with master makes the git fetch/clone take longer
because a shallow copy is not enough if we want to merge the PR with
master.

This has the disadvantage that we are not including latest fixes from
master, so the developer will have to rebase her branch.

It has the advantage of being more stable and predictable.

