### PR TITLE
We need a different stage for common channels

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -59,6 +59,15 @@ def run(params) {
                 }
             }
 
+            stage('Add Common Channels') {
+                    echo 'Add common channels'
+                    res_common_channels = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_add_common_channels'", returnStatus: true)
+                    echo "Custom channels and MU repositories status code: ${res_common_channels}"
+                    res_sync_common_channels = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'", returnStatus: true)
+                    echo "Common channels synchronization status code: ${res_sync_common_channels}"
+                    sh "exit \$(( ${res_common_channels}|${res_sync_common_channels} ))"
+            }
+            
             stage('Add MUs') {
                 if(params.must_add_channels) {
                     echo 'Add custom channels and MU repositories'


### PR DESCRIPTION
As we must sync first common channels, and we moved it inside the same stage than custom channels, we have a conflict when we run them in parallel.
BV testsuite is designed to be fast, by running in parallel, let's keep this in mind for future refactors!