### PR TITLE
Adjust Head and Test tf files to use salt bundle

### DIFF
--- a/jenkins_pipelines/environments/manager-TEST-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-acceptance-tests
@@ -7,10 +7,10 @@ node('sumaform-cucumber') {
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
-            string(name: 'cucumber_ref', defaultValue: 'use-salt-bundle-for-salt-ssh', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'cucumber_ref', defaultValue: 'master-test-deadlock', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master-set-mgr_force_venv_salt_minion-for-head-and-4.3', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'master-test-deadlock', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -133,6 +133,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:b2"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-client = {
       image = "sles15sp2o"
@@ -140,6 +142,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:b4"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-minion = {
       image = "sles15sp2o"
@@ -147,6 +151,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:b6"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-sshminion = {
       image = "sles15sp2o"
@@ -154,6 +160,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:b8"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     debian-minion = {
       name = "min-ubuntu2004"
@@ -161,6 +169,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:bc"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp2o"
@@ -168,6 +178,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:bd"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     pxeboot-minion = {
       image = "sles15sp3o"
@@ -177,12 +189,16 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:be"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     xen-host = {
       image = "sles15sp3o"
       provider_settings = {
         mac = "aa:b2:93:01:00:bf"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
   }
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -115,6 +115,8 @@ module "server" {
     mac = "aa:b2:93:01:00:c1"
     memory = 8192
   }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "suse-client" {
@@ -130,6 +132,8 @@ module "suse-client" {
   provider_settings = {
     mac = "aa:b2:93:01:00:c4"
   }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "suse-minion" {
@@ -145,6 +149,8 @@ module "suse-minion" {
   provider_settings = {
     mac = "aa:b2:93:01:00:c6"
   }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "debian-minion" {
@@ -158,6 +164,8 @@ module "debian-minion" {
   provider_settings = {
     mac = "aa:b2:93:01:00:cb"
   }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "build-host" {
@@ -171,6 +179,8 @@ module "build-host" {
   provider_settings = {
     mac = "aa:b2:93:01:00:cd"
   }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "kvm-minion" {
@@ -184,4 +194,6 @@ module "kvm-minion" {
   provider_settings = {
     mac = "aa:b2:93:01:00:ce"
   }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -158,7 +158,8 @@ module "proxy" {
   use_os_released_updates   = true
   ssh_key_path              = "./salt/controller/id_rsa.pub"
 
-
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "suse-sshminion" {
@@ -174,6 +175,8 @@ module "suse-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "suse-minion" {
@@ -192,6 +195,9 @@ module "suse-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "sles15sp2-client" {
@@ -211,6 +217,9 @@ module "sles15sp2-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "redhat-minion" {
@@ -229,6 +238,9 @@ module "redhat-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path  = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -150,8 +150,8 @@ module "cucumber_testsuite" {
 //        salt15sp2_server_apps_module = "http://download.suse.de/ibs/SUSE:/Maintenance:/17878/SUSE_Updates_SLE-Module-Server-Applications_15-SP2_x86_64/",
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing:/sle15sp4/standard/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
     suse-client = {
       image = "sles15sp2o"
@@ -162,8 +162,8 @@ module "cucumber_testsuite" {
       additional_repos = {
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing:/sle15sp2/standard/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
     suse-minion = {
       image = "sles15sp2o"
@@ -174,8 +174,8 @@ module "cucumber_testsuite" {
       additional_repos = {
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing:/sle15sp2/standard/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
     suse-sshminion = {
       image = "sles15sp2o"
@@ -186,24 +186,24 @@ module "cucumber_testsuite" {
       additional_repos = {
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing:/sle15sp2/standard/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
-    redhat-minion = {
-      image = "centos7o"
-      provider_settings = {
-        mac = "aa:b2:93:01:00:49"
-        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
-        // Also, openscap cannot run with less than 1.25 GB of RAM
-        memory = 2048
-        vcpu = 2
-      }
-      additional_repos = {
-        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools:/SaltBundle/SUSE_RES-7_Update_standard/"
-      }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-    }
+//    redhat-minion = {
+//      image = "centos7o"
+//      provider_settings = {
+//        mac = "aa:b2:93:01:00:49"
+//        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+//        // Also, openscap cannot run with less than 1.25 GB of RAM
+//        memory = 2048
+//        vcpu = 2
+//      }
+//      additional_repos = {
+//        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools:/SaltBundle/SUSE_RES-7_Update_standard/"
+//      }
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
+//    }
     debian-minion = {
       image = "ubuntu2004o"
       name = "min-ubuntu1804"
@@ -213,8 +213,8 @@ module "cucumber_testsuite" {
       additional_repos = {
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-cve-ubuntu18.04/standard/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp2o"
@@ -227,13 +227,13 @@ module "cucumber_testsuite" {
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing:/sle15sp2/standard/"
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing/SLE_15_SP2/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
     pxeboot-minion = {
       image = "sles15sp3o"
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
     kvm-host = {
       image = "sles15sp3o"
@@ -244,8 +244,8 @@ module "cucumber_testsuite" {
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing:/sle15sp2/standard/"
 //        Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/salt-testing/SLE_15_SP3/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
     }
 //    xen-host = {
 //      image = "sles15sp3o"

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:40"
       }
-      branch = "master-test-deadlock"
+  //    branch = "master-test-deadlock"
     }
     server = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:40"
       }
-//      branch = "fix-login"
+      branch = "master-test-deadlock"
     }
     server = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -139,6 +139,8 @@ module "cucumber_testsuite" {
       additional_repos = {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Naica/openSUSE_Leap_15.3/"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     */
     suse-client = {
@@ -147,6 +149,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:64"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-minion = {
       image = "sles15sp2o"
@@ -154,6 +158,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:66"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-sshminion = {
       image = "sles15sp2o"
@@ -161,6 +167,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:68"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     redhat-minion = {
       image = "centos7o"
@@ -171,6 +179,8 @@ module "cucumber_testsuite" {
         memory = 2048
         vcpu = 2
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     debian-minion = {
       name = "min-ubuntu2004"
@@ -178,6 +188,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:6b"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp2o"
@@ -185,6 +197,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:6d"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
   }
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -142,6 +142,8 @@ module "cucumber_testsuite" {
       additional_repos = {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Orion/SLE_15_SP4/"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-client = {
       image = "sles15sp2o"
@@ -149,6 +151,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:74"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-minion = {
       image = "sles15sp2o"
@@ -156,6 +160,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:76"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-sshminion = {
       image = "sles15sp2o"
@@ -163,6 +169,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:78"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
 /*
     redhat-minion = {
@@ -173,6 +181,8 @@ module "cucumber_testsuite" {
         memory = 2048
         vcpu = 2
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
 */
     pxeboot-minion = {
@@ -184,12 +194,16 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:7b"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp2o"
       provider_settings = {
         mac = "aa:b2:93:01:00:7d"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
   }
   provider_settings = {


### PR DESCRIPTION
As title mentioned, changes the TF files for the following environments to use Salt bundle (venv-salt-minion):

- head
- refhead
- testorion
- testnaica
- testhexagon

After this PR, the deployed instances will not have any "salt" package installed but instead `venv-salt-minion` package will be preinstalled. This changes also make the testsuite to know this instances are managed by `venv-salt-minion` and thefore proceed accordingly.