### PR TITLE
Use minima-mirror for server_mounted_mirror

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -189,6 +189,7 @@ module "cucumber_testsuite" {
 
       }
       image = "opensuse153-ci-pr"
+      server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
       provider_settings = {


### PR DESCRIPTION
-  Use minima-mirror for SCC mirroring: stabler and faster
- this goes with https://github.com/uyuni-project/sumaform/pull/1059