### PR TITLE
Use master branch in reference jobs for PRs

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -7,7 +7,7 @@ if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
 } else {
     if (env.JOB_NAME == "uyuni-prs-ci-tests-reference") {
         email_to = "aaaaeoayla72kj6blracdlufr4@suse.slack.com";
-        pull_request_number = "4886";
+        pull_request_number = "master";
         first_env = 1;
         last_env = 8;
     } else { //not jordi, not reference

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -77,12 +77,21 @@ def run(params) {
                         sh "git config --global user.name 'jenkins'"
                         //TODO: When checking out spacewalk, we will need credentials in the Jenkins Slave
                         //      Inside userRemoteConfigs add credentialsId: 'github'
-                        checkout([  
-                                    $class: 'GitSCM', 
+                        if (pull_request_number == "master") {
+                            checkout([
+                                    $class: 'GitSCM',
+                                    branches: [[name: "master"]],
+                                    extensions: [[$class: 'CloneOption', depth: 1, timeout: 30, shallow: true, noTags: true, honorRefspec: true]],
+                                    userRemoteConfigs: [[refspec: '+refs/heads/master:refs/remotes/origin/master', url: "${pull_request_repo}"]],
+                                   ])
+                        } else {
+                            checkout([
+                                    $class: 'GitSCM',
                                     branches: [[name: "pr/${pull_request_number}"]], 
                                     extensions: [[$class: 'CloneOption', depth: 1, timeout: 30, shallow: true, noTags: true, honorRefspec: true]],
                                     userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*', url: "${pull_request_repo}"]],
                                    ])
+                        }
                     }
                     
                 }


### PR DESCRIPTION
This way we get the latest fixes from master and we do not have to
rebase the reference PR every day.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>