### PR TITLE
Check for activity in jenkins instead of total duration

### DIFF
--- a/jenkins_pipelines/environments/manager-4.0-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.0-dev-acceptance-tests-NUE
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.0-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-dev-acceptance-tests-PRV
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.0-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.0-infra-reference-PRV
@@ -25,7 +25,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
@@ -25,7 +25,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
@@ -25,7 +25,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
@@ -25,7 +25,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
@@ -30,7 +30,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -30,7 +30,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-acceptance-tests
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 12, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-mu-aws
+++ b/jenkins_pipelines/environments/manager-mu-aws
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-mu-aws.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -28,7 +28,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
@@ -25,7 +25,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-mu-cloud
+++ b/jenkins_pipelines/environments/uyuni-mu-cloud
@@ -27,7 +27,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 10, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-mu-cloud.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -21,7 +21,7 @@ node('pull-request-test') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 20, unit: 'HOURS') {
+    timeout(activity: true, time: 20, unit: 'HOURS') {
         // set default values
         first_env = 1;
         last_env = 10;


### PR DESCRIPTION
This is a continuation from https://github.com/SUSE/susemanager-ci/pull/502 for the rest of the testsuites. It might bring turbulence so we do it in steps. 