### PR TITLE
Clean up published RPMS for PR

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -308,6 +308,7 @@ def run(params) {
             stage('Remove build project') {
                 if(environment_workspace){
                   ws(environment_workspace){
+                      sh "rm -rf ${environment_workspace}/repos/${builder_project}:${pull_request_number}/${build_repo}/${arch}"
                       sh "rm -rf ${builder_project}:${pull_request_number}" 
                   }
                 }


### PR DESCRIPTION
RPMs for PR need to be recreated each time in the jenkins worker to
server as a "mirror" for the tests.

If we do not clean up them at the end of the pipeline, they are left in
the disc space as trash.

We run out of disc space because of this.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>