### PR TITLE
Remove debian 9 from 4.3 BV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -248,7 +248,7 @@ module "base_debian" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu1804o", "ubuntu2004o", "debian9o", "debian10o", "debian11o" ]
+  images      = [ "ubuntu1804o", "ubuntu2004o", "debian10o", "debian11o" ]
 
   mirror = "minima-mirror-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -765,31 +765,6 @@ module "ubuntu2004-minion" {
 
 }
 
-module "debian9-minion" {
-  providers = {
-    libvirt = libvirt.mandalore
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
-  name               = "min-debian9"
-  image              = "debian9o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:eb"
-    memory             = 4096
-  }
-
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  //debian9-minion_additional_repos
-
-}
-
 module "debian10-minion" {
   providers = {
     libvirt = libvirt.mandalore
@@ -1016,23 +991,6 @@ module "ubuntu2004-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian9-sshminion" {
-  providers = {
-    libvirt = libvirt.mandalore
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
-  name               = "minssh-debian9"
-  image              = "debian9o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:fb"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "debian10-sshminion" {
   providers = {
     libvirt = libvirt.mandalore
@@ -1235,9 +1193,6 @@ module "controller" {
 
   ubuntu2004_minion_configuration    = module.ubuntu2004-minion.configuration
   ubuntu2004_sshminion_configuration = module.ubuntu2004-sshminion.configuration
-
-  debian9_minion_configuration    = module.debian9-minion.configuration
-  debian9_sshminion_configuration = module.debian9-sshminion.configuration
 
   debian10_minion_configuration    = module.debian10-minion.configuration
   debian10_sshminion_configuration = module.debian10-sshminion.configuration


### PR DESCRIPTION
Remove debian 9 from 4.3 BV because we no longer get updates for it and support it