### PR TITLE
QE: Add new `login_timeout` parameter to Uyuni CI

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -131,6 +131,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:d1"
         memory = 10240
+        login_timeout = 28800
       }
     }
     proxy = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -131,8 +131,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:d1"
         memory = 10240
-        login_timeout = 28800
       }
+      login_timeout = 28800
     }
     proxy = {
       provider_settings = {


### PR DESCRIPTION
This adds the new introduced timeout parameter for a login session. It should improve the pipeline in order to have lesser automatic logouts and logins during the testsuite. In discussion with @srbarrios I set the timeout to 8h since some testsuite runs take up to 12h.

Links:

* https://github.com/uyuni-project/sumaform/pull/1074
* https://github.com/uyuni-project/sumaform/pull/1080