### PR TITLE
Add an additional repo for reference jobs

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -12,6 +12,7 @@ if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
         last_env = 10;
         sumaform_gitrepo = "https://github.com/jordimassaguerpla/sumaform.git";
         sumaform_ref = "master";
+        additional_repo_url = "http://minima-mirror.mgr.prv.suse.net/jordi/reference_job_additional_repo";
     } else { //not jordi, not reference
         first_env = 1;
         last_env = 8;

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -224,12 +224,12 @@ def run(params) {
                         env.MASTER_SUMAFORM_TOOLS_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${sumaform_tools_project}/${build_repo}/${arch}"
                         env.TEST_PACKAGES_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${test_packages_project}/rpm/${arch}"
                         env.UPDATE_REPO = "http://minima-mirror.mgr.prv.suse.net/jordi/some-updates/"
-                        if (params.additional_repo_url == '') {
+                        if (additional_repo_url == '') {
                             echo "Adding dummy repo for update repo"
                             env.ADDITIONAL_REPO_URL = "http://minima-mirror.mgr.prv.suse.net/jordi/dummy/"
                         } else {
-                            echo "Adding ${params.additional_repo_url}"
-                            env.ADDITIONAL_REPO_URL = params.additional_repo_url
+                            echo "Adding ${additional_repo_url}"
+                            env.ADDITIONAL_REPO_URL = additional_repo_url
                         }
                         env.SLE_CLIENT_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:SLE15-Uyuni-Client-Tools/SLE_15/${arch}"
                         env.CENTOS_CLIENT_REPO = "http://${fqdn_jenkins_node}/workspace/suma-pr${env_number}/repos/${source_project}:CentOS7-Uyuni-Client-Tools/CentOS_7/${arch}"

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -29,6 +29,7 @@ node('pull-request-test') {
         last_env = 10;
         email_to = params.email_to;
         pull_request_number = params.pull_request_number;
+        additional_repo_url = params.additional_repo_url;
         sumaform_gitrepo = "https://github.com/uyuni-project/sumaform.git";
         sumaform_ref = "master";
         // load values to override default ones


### PR DESCRIPTION
This was we can test new salt packages in the reference jobs which run
continuously.

