### PR TITLE
Use upstream sumaform for reference jobs (CI on PRs)

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -10,8 +10,6 @@ if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
         pull_request_number = "master";
         first_env = 9;
         last_env = 10;
-        sumaform_gitrepo = "https://github.com/jordimassaguerpla/sumaform.git";
-        sumaform_ref = "master";
         additional_repo_url = "http://minima-mirror.mgr.prv.suse.net/jordi/reference_job_additional_repo";
     } else { //not jordi, not reference
         first_env = 1;


### PR DESCRIPTION
Otherwise, we do not get the latest fixes. This happened today, there
was a fix from Oscar and the reference jobs started to fail because I
was using my own fork.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>