### PR TITLE
Record parameters used when running acceptance tests at PR

### DIFF
--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -18,6 +18,10 @@ node('pull-request-test') {
         ])
     ])
 
+    stage('Record activity') {
+        sh "echo $(DATE),${params.pull_request_number},${params.email_to},${params.run_all_scopes},${params.functional_scopes},${params.cucumber_gitrepo},${params.cucumber_ref},${params.additional_repo_url},${params.force_pr_lock_cleanup},${params.skip_package_build_check} >> /srv/www/htdocs/uyuni-prs-ci-tests-activity.csv"
+    }
+
     stage('Checkout pipeline') {
         checkout scm
     }


### PR DESCRIPTION
I want to know which parameters people use. Do they change the cucumber
git repo? Do people use the additional repo option? etc.

Let's simply append the info to a csv file. Using append, the OS deals
with the concurrency and we can do this safely from concurrent
pipelines.

