### PR TITLE
QE: Add new QE testing pipeline for PRs

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -4,6 +4,13 @@ if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
     // if you change the sumaform repo or reference, you need to remove the sumaform directory from the results folder
     sumaform_gitrepo = "https://github.com/jordimassaguerpla/sumaform.git";
     sumaform_ref = "master";
+} else if (env.JOB_NAME == "head-prs-ci-tests-qe-servicepack-migration")
+    // special pipeline for QE to test new service packs and service pack migrations
+    first_env = 7;
+    last_env = 8;
+    // if you change the sumaform repo or reference, you need to remove the sumaform directory from the results folder
+    sumaform_gitrepo = "https://github.com/uyuni-project/sumaform.git";
+    sumaform_ref = "qe-service-pack-migration";
 } else {
     if (env.JOB_NAME == "uyuni-prs-ci-tests-reference") {
         email_to = "aaaaeoayla72kj6blracdlufr4@suse.slack.com";
@@ -13,7 +20,7 @@ if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
         additional_repo_url = "http://minima-mirror.mgr.prv.suse.net/jordi/reference_job_additional_repo";
     } else { //not jordi, not reference
         first_env = 1;
-        last_env = 8;
+        last_env = 6;
     }
 }
 

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:73"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:74"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:75"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:79"
       }
@@ -296,7 +296,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       additional_repos = {
         client_repo = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153-ci-pr", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:7f"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:80"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:81"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:85"
       }
@@ -296,7 +296,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       additional_repos = {
         client_repo = var.SLE_CLIENT_REPO,
       }


### PR DESCRIPTION
This will add necessary changes to be able to use a new Jenkins CI pipeline for QE to test new service packs and service pack migrations.

What is still missing FMPOV:
- be able to do this for spacewalk/HEAD and not for Uyuni regarding PRs
- server and proxy should use SLES15SP4


#### References

- https://github.com/SUSE/spacewalk/issues/17410
- https://github.com/SUSE/spacewalk/pull/17629
- https://github.com/SUSE/susemanager-ci/pull/527