### PR TITLE
Exclude flaky tests

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -281,7 +281,9 @@ def run(params) {
                     if(must_test && ( params.functional_scopes || params.run_all_scopes) ) {
                         def exports = ""
                         if (params.functional_scopes){
-                          exports += "export TAGS=${params.functional_scopes}; "
+                          exports += "export TAGS=${params.functional_scopes},~@flaky; "
+                        } else {
+                          exports += "export TAGS=~@flaky; "
                         }
                         def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
                         def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${exports} cd /root/spacewalk/testsuite; rake ${rake_namespace}:secondary_parallelizable'", returnStatus:true


### PR DESCRIPTION
Let's exclude tests that have the label flaky. We are not interested on
running tests that are not stable and the result is not reliable, or at
least confusing, for the developer.

partial fix for https://github.com/SUSE/spacewalk/issues/17818