### PR TITLE
update uyuni master to leap 154

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -95,7 +95,7 @@ module "base_core" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "sles15sp2o"]
+  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp2o"]
 
   use_avahi    = false
   name_prefix  = "suma-testhexagon-"

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -91,7 +91,7 @@ module "base" {
   name_prefix = "uyuni-refmaster-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = ["centos7o", "opensuse153o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1804o"]
+  images      = ["centos7o", "opensuse154o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1804o"]
 
   provider_settings = {
     pool         = "ssd"

--- a/terracumber_config/tf_files/Uyuni-Master-tests-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-coverage.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["opensuse152o", "opensuse153o", "sles15sp2o", "sles15sp3o"]
+  images = ["opensuse152o", "opensuse154o", "sles15sp2o", "sles15sp3o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr8-"


### PR DESCRIPTION
uyuni master is now based on opensuse leap 15.4.

We need to update the scripts to download the new image on the base module definition.