### PR TITLE
Add 4.3 pipelines and tf files

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
@@ -1,0 +1,35 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([cron('H H/4 * * *')]),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-4.3', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),            
+            booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            extendedChoice(name: 'functional_scopes',  multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30, value: '@scope_smdba,@scope_spacecmd,@scope_spacewalk_utils,@scope_visualization,@scope_notification_message,@scope_virtual_host_manager,@scope_subscription_matching,@scope_formulas,@scope_sp_migration,@scope_cve_audit,@scope_onboarding,@scope_content_lifecycle_management,@scope_res,@scope_recurring_actions,@scope_maintenance_windows,@scope_building_container_images,@scope_kubernetes_integration,@scope_openscap,@scope_ubuntu,@scope_action_chains,@scope_salt_ssh,@scope_tomcat,@scope_changing_software_channels,@scope_monitoring,@scope_salt,@scope_cobbler,@scope_sumatoolbox,@scope_virtualization,@scope_hub,@scope_retail,@scope_configuration_channels,@scope_content_staging,@scope_proxy,@scope_traditional_client,@scope_api,@scope_power_management,@scope_retracted_patches,@scope_ansible', description: 'Choose the functional scopes that you want to test')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 12, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
+}

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
@@ -1,0 +1,35 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([cron('0 2,6,10,14,18,22 * * *')]),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-4.3', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            extendedChoice(name: 'functional_scopes',  multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30, value: '@scope_smdba,@scope_spacecmd,@scope_spacewalk_utils,@scope_visualization,@scope_notification_message,@scope_virtual_host_manager,@scope_subscription_matching,@scope_formulas,@scope_sp_migration,@scope_cve_audit,@scope_onboarding,@scope_content_lifecycle_management,@scope_res,@scope_recurring_actions,@scope_maintenance_windows,@scope_building_container_images,@scope_kubernetes_integration,@scope_openscap,@scope_ubuntu,@scope_action_chains,@scope_salt_ssh,@scope_tomcat,@scope_changing_software_channels,@scope_monitoring,@scope_salt,@scope_cobbler,@scope_sumatoolbox,@scope_virtualization,@scope_hub,@scope_retail,@scope_configuration_channels,@scope_content_staging,@scope_proxy,@scope_traditional_client,@scope_api,@scope_power_management,@scope_retracted_patches,@scope_ansible', description: 'Choose the functional scopes that you want to test')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 12, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
+}

--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
@@ -1,0 +1,32 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([cron('H 0 * * *')]),
+        parameters([
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            // Temporary: should move to uyuni-project
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 10, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
+        pipeline.run(params)
+    }
+}

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -1,0 +1,224 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-dev-acceptance-tests-NUE"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = string
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "Manager-4.3"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results 4.3-NUE (backup and staging) $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins-backup.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results 4.3-NUE: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins-backupenv-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "4.3-nightly"
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+
+  use_avahi    = false
+  name_prefix  = "suma-43-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  no_auth_registry = "registry.mgr.suse.de"
+  auth_registry = "registry.mgr.suse.de:5000/cucutest"
+  auth_registry_username = "cucutest"
+  auth_registry_password = "cucusecret"
+  git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
+
+  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+
+  host_settings = {
+    controller = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:90"
+      }
+    }
+    server = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:91"
+      }
+    }
+    proxy = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:92"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    suse-client = {
+      image = "sles15sp2o"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:94"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    suse-minion = {
+      image = "sles15sp2o"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:96"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    suse-sshminion = {
+      image = "sles15sp2o"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:98"
+      }
+      additional_packages = [ "venv-salt-minion", "iptables" ]
+      install_salt_bundle = true
+    }
+    redhat-minion = {
+      image = "centos7o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:99"
+        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+        // Also, openscap cannot run with less than 1.25 GB of RAM
+        memory = 2048
+        vcpu = 2
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    debian-minion = {
+      name = "min-ubuntu2004"
+      image = "ubuntu2004o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9c"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    build-host = {
+      image = "sles15sp2o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9d"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    pxeboot-minion = {
+      image = "sles15sp3o"
+    }
+    kvm-host = {
+      image = "sles15sp3o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9e"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    xen-host = {
+      image = "sles15sp3o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9f"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+  }
+  provider_settings = {
+    pool = "ssd"
+    network_name = null
+    bridge = "br0"
+    additional_network = "192.168.42.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -1,0 +1,237 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-dev-acceptance-tests-PRV"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = string
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "Manager-4.3"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results 4.3-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results 4.3-PRV: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://metropolis.mgr.prv.suse.net/system"
+}
+
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "4.3-nightly"
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+
+  use_avahi = false
+  name_prefix = "suma-43-"
+  domain = "mgr.prv.suse.net"
+  from_email = "root@suse.de"
+
+  no_auth_registry = "registry.mgr.prv.suse.net"
+  auth_registry = "registry.mgr.prv.suse.net:5000/cucutest"
+  auth_registry_username = "cucutest"
+  auth_registry_password = "cucusecret"
+  git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
+
+  mirror = "minima-mirror.mgr.prv.suse.net"
+  use_mirror_images = true
+  server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
+
+  host_settings = {
+    controller = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:90"
+      }
+    }
+    server = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:91"
+      }
+    }
+    proxy = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:92"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    suse-client = {
+      image = "sles15sp2o"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:94"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    suse-minion = {
+      image = "sles15sp2o"
+      name = "min-sles15"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:96"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    suse-sshminion = {
+      image = "sles15sp2o"
+      name = "minssh-sles15"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:98"
+      }
+      additional_packages = [ "venv-salt-minion", "iptables" ]
+      install_salt_bundle = true
+    }
+    redhat-minion = {
+      image = "centos7o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:99"
+        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+        // Also, openscap cannot run with less than 1.25 GB of RAM
+        memory = 2048
+        vcpu = 2
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    debian-minion = {
+      name = "min-ubuntu2004"
+      image = "ubuntu2004o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9c"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    build-host = {
+      image = "sles15sp2o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9d"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    pxeboot-minion = {
+      image = "sles15sp3o"
+    }
+    kvm-host = {
+      image = "sles15sp3o"
+      additional_grains = {
+        hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
+        hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+      }
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9e"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+    xen-host = {
+      image = "sles15sp3o"
+      additional_grains = {
+        xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-15.4-kvm-and-xen-Current.qcow2"
+        xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-15.4-kvm-and-xen-Current.qcow2.sha256"
+        hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
+        hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+      }
+      provider_settings = {
+        mac = "aa:b2:93:01:00:9f"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+  }
+  provider_settings = {
+    pool = "ssd"
+    network_name = null
+    bridge = "br1"
+    additional_network = "192.168.42.0/24"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
@@ -1,0 +1,220 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-infra-reference-PRV"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_GITREPO" {
+  type = string
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "Manager-4.3"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/spacewalk/testsuite"
+}
+
+// Not really used in this pipeline, as we do not send emails on success (no cucumber results)
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results REF4.3-PRV $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results REF4.3-PRV: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://selektah.mgr.prv.suse.net/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  name_prefix       = "suma-ref43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = ["centos7o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+  mirror            = "minima-mirror.mgr.prv.suse.net"
+  use_mirror_images = true
+
+  provider_settings = {
+    pool         = "ssd"
+    network_name = null
+    bridge       = "br1"
+  }
+}
+
+module "server" {
+  source                  = "./modules/server"
+  base_configuration      = module.base.configuration
+  product_version         = "4.3-nightly"
+  name                    = "srv"
+  monitored               = true
+  use_os_released_updates = true
+  disable_download_tokens = false
+  from_email              = "root@suse.de"
+  channels                = ["sle-product-sles15-sp4-pool-x86_64", "sle-product-sles15-sp4-updates-x86_64", "sle-module-basesystem15-sp4-pool-x86_64", "sle-module-basesystem15-sp4-updates-x86_64", "sle-module-containers15-sp4-pool-x86_64", "sle-module-containers15-sp4-updates-x86_64", "sle-manager-tools15-pool-x86_64-sp3", "sle-manager-tools15-updates-x86_64-sp3", "sle-module-server-applications15-sp4-pool-x86_64", "sle-module-server-applications15-sp4-updates-x86_64"]
+
+  provider_settings = {
+    mac = "aa:b2:92:03:00:91"
+    memory = 8192
+  }
+}
+
+module "suse-client" {
+  source             = "./modules/client"
+  base_configuration = module.base.configuration
+  product_version    = "4.3-nightly"
+  name               = "cli-sles15"
+  image              = "sles15sp3o"
+
+  server_configuration    = module.server.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "aa:b2:92:03:00:96"
+  }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "suse-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "4.3-nightly"
+  name               = "min-sles15"
+  image              = "sles15sp3o"
+
+  server_configuration    = module.server.configuration
+  use_os_released_updates = true
+
+  provider_settings = {
+    mac = "aa:b2:92:03:00:98"
+  }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "redhat-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  product_version    = "4.3-nightly"
+  name               = "min-centos7"
+  image              = "centos7o"
+
+  server_configuration   = module.server.configuration
+  auto_connect_to_master = false
+
+  provider_settings = {
+    mac = "aa:b2:92:03:00:99"
+    // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+    // Also, openscap cannot run with less than 1.25 GB of RAM
+    memory = 2048
+    vcpu = 2
+  }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "debian-minion" {
+  source               = "./modules/minion"
+  base_configuration   = module.base.configuration
+  product_version      = "4.3-nightly"
+  name                 = "min-ubuntu2004"
+  image                = "ubuntu2004o"
+  server_configuration = module.server.configuration
+
+  provider_settings = {
+    mac = "aa:b2:92:03:00:9c"
+  }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "build-host" {
+  source                  = "./modules/build_host"
+  base_configuration      = module.base.configuration
+  product_version         = "4.3-nightly"
+  name                    = "min-build"
+  image                   = "sles15sp3o"
+  server_configuration    = module.server.configuration
+
+  provider_settings = {
+    mac = "aa:b2:92:03:00:9d"
+  }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "kvm-minion" {
+  source               = "./modules/virthost"
+  base_configuration   = module.base.configuration
+  product_version      = "head"
+  name                 = "min-kvm"
+  image                = "sles15sp3o"
+  server_configuration = module.server.configuration
+
+  provider_settings = {
+    mac = "aa:b2:92:03:00:9e"
+  }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}


### PR DESCRIPTION
How I did this:

- Copied the 4.2 tf files and pipeline definitions as 4.3
- `tf` files and pipeline definitions: Replaced `4.2` to `4.3` and `42` to `43`
- `tf` files:  Adjusted the images to match what we have on Head
- `tf` files: Enabled the bundle and extra packages, according to what we have on Head
- `tf` files:  Increased RAM and CPU for the redhat minions, according to what we have on Head
- `tf` files:   Adjusted the MAC addresses according to the PR for the DHCP/DNS configuraiton
- `tf` files:  For the reference server, I adjusted the links to the images, and verified they are working

