### PR TITLE
QE: Switch Uyuni CI to use SLES15SP4 and Leap 15.4

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -151,6 +151,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
+      # left with SP3 since we update it to SP4 in the testsuite
       image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
@@ -160,6 +161,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
+      # left with SP3 since we update it to SP4 in the testsuite
       image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -142,7 +142,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:d4"
@@ -151,7 +151,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:d6"
@@ -160,7 +160,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:d8"
@@ -193,7 +193,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:dd"
       }
@@ -201,12 +201,12 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse153o"
+      image = "opensuse154o"
       provider_settings = {
         mac = "aa:b2:93:01:00:de"
       }
@@ -214,7 +214,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     xen-host = {
-      image = "opensuse153o"
+      image = "opensuse154o"
       provider_settings = {
         mac = "aa:b2:93:01:00:df"
       }


### PR DESCRIPTION
We move the testsuite CI to use SLES15SP4. We made the changes only on Uyuni (and therefore HEAD) so we have to adjust the Uyuni `.tf`, too otherwise the testsuite will not work correctly.

See:
- https://github.com/SUSE/spacewalk/issues/17410
- https://github.com/uyuni-project/uyuni/pull/5413
- https://github.com/SUSE/susemanager-ci/pull/543