### PR TITLE
Modify Uyuni images

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse154o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse154o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"


### PR DESCRIPTION
This modifies the image list in the Uyuni `main.tf`. The testsuite failes because the image for [SLES15 SP4 is missing](https://ci.suse.de/view/Manager/view/Manager-qe/job/uyuni-master-dev-acceptance-tests-NUE/3158/consoleFull):


```bash
16:17:37  │ Error: Can't retrieve base volume with name 'uyuni-master-sles15sp4o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'uyuni-master-sles15sp4o'')
16:17:37  │ 
16:17:37  │   with module.cucumber_testsuite.module.suse-client.module.client.module.host.libvirt_volume.main_disk[0],
16:17:37  │   on /home/jenkins/jenkins-build/workspace/uyuni-master-dev-acceptance-tests-NUE/results/sumaform/backend_modules/libvirt/host/main.tf line 51, in resource "libvirt_volume" "main_disk":
16:17:37  │   51: resource "libvirt_volume" "main_disk" {
16:17:37  │ 
16:17:37  ╵
16:17:37  ╷
16:17:37  │ Error: Can't retrieve base volume with name 'uyuni-master-sles15sp4o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'uyuni-master-sles15sp4o'')
```

Adds:
- SLES15 SP4

Removes:
- SLES15 SP2
- openSUSE Leap 15.2
- openSUSE Leap 15.3