### PR TITLE
Add needed Leap 15.x images to Uyuni

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse154o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse154o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"


### PR DESCRIPTION
It seems older versions of openSUSE Leap are still needed, so I put them back in the Uyuni `main.tf` file.