### PR TITLE
Switch build host to SLE15SP4 on HEAD

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -187,8 +187,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     build-host = {
-      # left with SP2 since since images are missing in the registry
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:00:bd"


### PR DESCRIPTION
This will switch the build host image to SLE15SP4 since we now have the
proper images in our registries.

Uyuni already has this change:
https://github.com/SUSE/susemanager-ci/blob/5a2fd000265c129033e7d76442004581c6c85c47/terracumber_config/tf_files/Uyuni-Master-NUE.tf#L197-L198
