### PR TITLE
QE: Temporary disable mirror in Uyuni CI

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -116,8 +116,8 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   // Comment the next two lines if no mirror should be used
-  mirror = "minima-mirror.mgr.suse.de"
-  use_mirror_images = true
+  //mirror = "minima-mirror.mgr.suse.de"
+  //use_mirror_images = true
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
 


### PR DESCRIPTION
To rule out issue and to be sure the issue is (not) coming from the mirror, we disable the mirror in the Uyuni Ci temporarily.