### PR TITLE
Venv aws

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-mu-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-mu-aws.groovy
@@ -164,9 +164,15 @@ def run(params) {
             sh "sed -i 's/download.suse.de/${mirror_hostname_aws_private}/g' ${WORKSPACE}/custom_repositories.json"
             sh "sed -r 's/ibs\\///g' ${WORKSPACE}/custom_repositories.json"
 
+            // Parameters
+            if (params.use_latest_ami_image) {
+                global_variable = "set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; export TF_VAR_SERVER_AMI=${env.server_ami}; export TF_VAR_PROXY_AMI=${env.proxy_ami}"
+            } else {
+                global_variable = "set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}"
+            }
             // Deploying AWS server using MU repositories
-            sh "echo \"set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; export TF_VAR_SERVER_AMI=${env.server_ami}; export TF_VAR_PROXY_AMI=${env.proxy_ami}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem\""
-            sh "set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; export TF_VAR_SERVER_AMI=${env.server_ami}; export TF_VAR_PROXY_AMI=${env.proxy_ami}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem"
+            sh "echo \"${global_variable}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem\""
+            sh "${global_variable}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem"
         }
     }
 }

--- a/jenkins_pipelines/environments/common/pipeline-mu-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-mu-aws.groovy
@@ -164,15 +164,9 @@ def run(params) {
             sh "sed -i 's/download.suse.de/${mirror_hostname_aws_private}/g' ${WORKSPACE}/custom_repositories.json"
             sh "sed -r 's/ibs\\///g' ${WORKSPACE}/custom_repositories.json"
 
-            // Parameters
-            if (params.use_latest_ami_image) {
-                global_variable = "set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; export TF_VAR_SERVER_AMI=${env.server_ami}; export TF_VAR_PROXY_AMI=${env.proxy_ami}"
-            } else {
-                global_variable = "set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}"
-            }
             // Deploying AWS server using MU repositories
-            sh "echo \"${global_variable}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem\""
-            sh "${global_variable}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem"
+            sh "echo \"set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; export TF_VAR_SERVER_AMI=${env.server_ami}; export TF_VAR_PROXY_AMI=${env.proxy_ami}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem\""
+            sh "set +x; source /home/jenkins/.credentials set -x; source /home/jenkins/.aws/.aws set -x; source /home/jenkins/.registration set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TF_VAR_MIRROR=${env.mirror_hostname_aws_private}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; export TF_VAR_SERVER_AMI=${env.server_ami}; export TF_VAR_PROXY_AMI=${env.proxy_ami}; ./terracumber-cli ${aws_common_params} --logfile ${resultdirbuild}/sumaform-aws.log ${TERRAFORM_INIT} --taint '.*(domain|main_disk).*' --runstep provision --sumaform-backend aws --bastion_ssh_key /home/jenkins/.ssh/testing-suma.pem"
         }
     }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -319,7 +319,7 @@ module "debian-minion" {
 module "build-host"  {
   image = "sles15sp2o"
   name = "build-host"
-  source             = "./modules/minion"
+  source             = "./modules/build_host"
   base_configuration = module.base.configuration
   sles_registration_code = var.SLES_REGISTRATION_CODE
   product_version    = "4.3-released"

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -245,6 +245,7 @@ module "suse-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  additional_packages = [ "venv-salt-minion" ]
   //  product_version = "4.2-released"
 }
 
@@ -259,7 +260,7 @@ module "suse-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
+  additional_packages = [ "venv-salt-minion" ]
   //sle15sp2-minion_additional_repos
 
 }
@@ -274,7 +275,7 @@ module "suse-sshminion" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
-
+  additional_packages = [ "venv-salt-minion" , "iptables"]
   //sle15sp3-minion_additional_repos
 
 }
@@ -294,6 +295,7 @@ module "redhat-minion"  {
   server_configuration = module.server.configuration
   auto_connect_to_master = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  additional_packages = [ "venv-salt-minion" ]
 }
 
 module "debian-minion" {
@@ -305,6 +307,7 @@ module "debian-minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  additional_packages = [ "venv-salt-minion" ]
 }
 
 module "build-host"  {
@@ -318,6 +321,7 @@ module "build-host"  {
   auto_connect_to_master  = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  additional_packages = [ "venv-salt-minion" ]
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -229,6 +229,7 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = true
   //proxy_additional_repos
 
 }
@@ -246,6 +247,7 @@ module "suse-client" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
   //  product_version = "4.2-released"
 }
 
@@ -261,6 +263,7 @@ module "suse-minion" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
   //sle15sp2-minion_additional_repos
 
 }
@@ -276,6 +279,7 @@ module "suse-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   additional_packages = [ "venv-salt-minion" , "iptables"]
+  install_salt_bundle = true
   //sle15sp3-minion_additional_repos
 
 }
@@ -296,6 +300,7 @@ module "redhat-minion"  {
   auto_connect_to_master = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "debian-minion" {
@@ -308,6 +313,7 @@ module "debian-minion" {
   auto_connect_to_master  = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "build-host"  {
@@ -322,6 +328,7 @@ module "build-host"  {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -136,16 +136,6 @@ variable "NAME_PREFIX" {
   default = null
 }
 
-variable "PROXY_AMI" {
-  type = string
-  default = "sles15sp4o"
-}
-
-variable "SERVER_AMI" {
-  type = string
-  default = "sles15sp4o"
-}
-
 provider "aws" {
   region     = var.REGION
   access_key = var.ACCESS_KEY
@@ -189,7 +179,6 @@ module "server" {
   name                       = "server"
   product_version            = "4.3-release"
   repository_disk_size       = 1500
-  image                      = var.SERVER_AMI
   server_registration_code   = var.SERVER_REGISTRATION_CODE
 
   auto_accept                    = false
@@ -218,7 +207,6 @@ module "proxy" {
   server_configuration      = module.server.configuration
   product_version           = "4.3-release"
   name                      = "proxy"
-  image                     = var.PROXY_AMI
   proxy_registration_code   = var.PROXY_REGISTRATION_CODE
 
   auto_register             = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -190,7 +190,7 @@ module "server" {
   product_version            = "4.3-release"
   repository_disk_size       = 1500
   image                      = var.SERVER_AMI
-  server_registration_code = var.SERVER_REGISTRATION_CODE
+  server_registration_code   = var.SERVER_REGISTRATION_CODE
 
   auto_accept                    = false
   monitored                      = true
@@ -219,6 +219,7 @@ module "proxy" {
   product_version           = "4.3-release"
   name                      = "proxy"
   image                     = var.PROXY_AMI
+  proxy_registration_code   = var.PROXY_REGISTRATION_CODE
 
   auto_register             = false
   auto_connect_to_master    = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -187,7 +187,7 @@ module "server" {
     mirror = null
   })
   name                       = "server"
-  product_version            = "4.3-build_image"
+  product_version            = "4.3-release"
   repository_disk_size       = 1500
   image                      = var.SERVER_AMI
   server_registration_code = var.SERVER_REGISTRATION_CODE
@@ -216,7 +216,7 @@ module "proxy" {
   source                    = "./modules/proxy"
   base_configuration        = module.base.configuration
   server_configuration      = module.server.configuration
-  product_version           = "4.3-build_image"
+  product_version           = "4.3-release"
   name                      = "proxy"
   image                     = var.PROXY_AMI
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -177,7 +177,7 @@ module "server" {
     mirror = null
   })
   name                       = "server"
-  product_version            = "4.3-release"
+  product_version            = "4.3-released"
   repository_disk_size       = 1500
   server_registration_code   = var.SERVER_REGISTRATION_CODE
 
@@ -205,7 +205,7 @@ module "proxy" {
   source                    = "./modules/proxy"
   base_configuration        = module.base.configuration
   server_configuration      = module.server.configuration
-  product_version           = "4.3-release"
+  product_version           = "4.3-released"
   name                      = "proxy"
   proxy_registration_code   = var.PROXY_REGISTRATION_CODE
 
@@ -228,7 +228,7 @@ module "suse-client" {
   source             = "./modules/client"
   base_configuration = module.base.configuration
   name                 = "cli-sles15"
-  image                = "sles15sp2o"
+  image                = "sles15sp4o"
   product_version    = "4.3-released"
   server_configuration = module.server.configuration
   sles_registration_code = var.SLES_REGISTRATION_CODE
@@ -245,7 +245,7 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
   name               = "min-sles15"
-  image              = "sles15sp2o"
+  image              = "sles15sp3o"
   server_configuration = module.server.configuration
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
@@ -262,7 +262,7 @@ module "suse-sshminion" {
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
   name               = "minssh-sles15"
-  image              = "sles15sp2o"
+  image              = "sles15sp3o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -306,7 +306,7 @@ module "debian-minion" {
 }
 
 module "build-host"  {
-  image = "sles15sp2o"
+  image = "sles15sp4o"
   name = "build-host"
   source             = "./modules/build_host"
   base_configuration = module.base.configuration


### PR DESCRIPTION
## What does this PR change?

Update ci deployment on AWS for SUMA 4.3 : 
- add venv package to clients and proxy
- add install_salt_bundle variable
- use build_host module for build_host
- rewrite main terraform file to use SCC registration deployment method
- upgrade minion / build_host / client to sles15sp4o