### PR TITLE
Move Uyuni PR test envs to SLE15SP3/SP4

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:03"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:04"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:05"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:09"
       }
@@ -296,7 +296,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       additional_repos = {
         client_repo = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:93"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:94"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:95"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:99"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:13"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:14"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:15"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:19"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:23"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:24"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:25"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:29"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:33"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:34"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:35"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:39"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:43"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:44"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:45"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:49"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:53"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:54"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:55"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:59"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:63"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:64"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:65"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:69"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:73"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:74"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:75"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:79"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -222,7 +222,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:83"
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:84"
@@ -246,7 +246,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:85"
@@ -285,7 +285,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:04:00:89"
       }


### PR DESCRIPTION
We still use SLE15SP2 for the client, minion and SSH minion. With the move of Uyuni/HEAD to SLE15SP4 we need to adjust the other environments, too otherwise all PR jobs will fail.

The current state in Uyuni/Head is:

server: SP4
proxy: SP4
suse-client: SP4
suse-minion: SP3 (since we want to migrate to SP4)
suse-sshminion: SP3 (since we want to migrate to SP4)
buildhost: SP4
pxeboot-minion: SP4
kvm-host: SP4/15.4
xen-host: SP4/15.4

FYI: the other terraform files that use Uyuni/HEAD should be adjusted too. The ones that use Manager 4.1/4.2 can be left with the old images.

```bash
$ grep -rin 'image = "sles15sp2o"'
terracumber_config/tf_files/SUSEManager-Test-NUE-cobbler-3.3.2:159:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-NUE-cobbler-3.3.2:171:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-NUE-cobbler-3.3.2:183:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-NUE-cobbler-3.3.2:222:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-NUE.tf:159:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-NUE.tf:171:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-NUE.tf:183:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-AWS.tf:311:  image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf:147:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf:156:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf:165:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf:195:      image = "sles15sp2o"
terracumber_config/tf_files/Uyuni-Master-tests-coverage.tf:140:      image = "sles15sp2o"
terracumber_config/tf_files/Uyuni-Master-tests-coverage.tf:149:      image = "sles15sp2o"
terracumber_config/tf_files/Uyuni-Master-tests-coverage.tf:158:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-PRV.tf:142:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-PRV.tf:151:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-PRV.tf:160:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-PRV.tf:190:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf:147:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf:159:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf:168:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf:191:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf:150:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf:162:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf:174:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf:215:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-NUE.tf:139:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-NUE.tf:148:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-NUE.tf:157:      image = "sles15sp2o"
terracumber_config/tf_files/SUSEManager-4.3-NUE.tf:187:      image = "sles15sp2o"
```

### Links

- https://github.com/SUSE/susemanager-ci/pull/594
- https://github.com/SUSE/susemanager-ci/pull/543
- https://github.com/SUSE/susemanager-ci/pull/610