### PR TITLE
Switch 4.3 terraform files to SLE15SP3/4

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -238,7 +238,7 @@ module "suse-client" {
   source             = "./modules/client"
   base_configuration = module.base.configuration
   name                 = "cli-sles15"
-  image                = "sles15sp2o"
+  image                = "sles15sp4o"
   product_version    = "4.3-released"
   server_configuration = module.server.configuration
   sles_registration_code = var.SLES_REGISTRATION_CODE
@@ -253,7 +253,7 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
   name               = "min-sles15"
-  image              = "sles15sp2o"
+  image              = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
   server_configuration = module.server.configuration
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
@@ -269,7 +269,7 @@ module "suse-sshminion" {
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
   name               = "minssh-sles15"
-  image              = "sles15sp2o"
+  image              = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -308,7 +308,7 @@ module "debian-minion" {
 }
 
 module "build-host"  {
-  image = "sles15sp2o"
+  image = "sles15sp4o"
   name = "build-host"
   source             = "./modules/minion"
   base_configuration = module.base.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -136,7 +136,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:94"
@@ -145,7 +145,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:96"
@@ -154,7 +154,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:98"
@@ -184,7 +184,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     build-host = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:9d"
       }
@@ -192,10 +192,10 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
     }
     kvm-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:9e"
       }
@@ -203,7 +203,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     xen-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:9f"
       }

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -139,7 +139,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:84"
@@ -148,7 +148,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:86"
@@ -157,7 +157,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:88"
@@ -187,7 +187,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     build-host = {
-      image = "sles15sp2o"
+      image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:03:00:8d"
       }
@@ -195,10 +195,10 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
     }
     kvm-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       additional_grains = {
         hvm_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
         hvm_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
@@ -210,7 +210,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     xen-host = {
-      image = "sles15sp3o"
+      image = "sles15sp4o"
       additional_grains = {
         xen_disk_image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-15.4-kvm-and-xen-Current.qcow2"
         xen_disk_image_hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-15.4-kvm-and-xen-Current.qcow2.sha256"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -1129,15 +1129,15 @@ module "sles12sp5-terminal" {
   }
 }
 
-module "sles15sp3-buildhost" {
+module "sles15sp4-buildhost" {
   providers = {
     libvirt = libvirt.coruscant
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
   product_version    = "4.3-released"
-  name               = "build-sles15sp3"
-  image              = "sles15sp3o"
+  name               = "build-sles15sp4"
+  image              = "sles15sp4o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:cd"
     memory             = 2048
@@ -1151,14 +1151,14 @@ module "sles15sp3-buildhost" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp3-terminal" {
+module "sles15sp4-terminal" {
   providers = {
     libvirt = libvirt.coruscant
   }
   source             = "./modules/pxe_boot"
   base_configuration = module.base_retail.configuration
-  name               = "terminal-sles15sp3"
-  image              = "sles15sp3o"
+  name               = "terminal-sles15sp4"
+  image              = "sles15sp4o"
   provider_settings = {
     memory             = 2048
     vcpu               = 2
@@ -1261,10 +1261,10 @@ module "controller" {
   debian11_sshminion_configuration = module.debian11-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
-  sle15sp3_buildhost_configuration = module.sles15sp3-buildhost.configuration
+  sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration
 
   sle12sp5_terminal_configuration = module.sles12sp5-terminal.configuration
-  sle15sp3_terminal_configuration = module.sles15sp3-terminal.configuration
+  sle15sp4_terminal_configuration = module.sles15sp4-terminal.configuration
 
   opensuse153arm_minion_configuration = module.opensuse153arm-minion.configuration
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
@@ -124,7 +124,7 @@ module "suse-client" {
   base_configuration = module.base.configuration
   product_version    = "4.3-nightly"
   name               = "cli-sles15"
-  image              = "sles15sp3o"
+  image              = "sles15sp4o"
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -141,7 +141,7 @@ module "suse-minion" {
   base_configuration = module.base.configuration
   product_version    = "4.3-nightly"
   name               = "min-sles15"
-  image              = "sles15sp3o"
+  image              = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
 
   server_configuration    = module.server.configuration
   use_os_released_updates = true
@@ -194,7 +194,7 @@ module "build-host" {
   base_configuration      = module.base.configuration
   product_version         = "4.3-nightly"
   name                    = "min-build"
-  image                   = "sles15sp3o"
+  image                   = "sles15sp4o"
   server_configuration    = module.server.configuration
 
   provider_settings = {
@@ -209,7 +209,7 @@ module "kvm-minion" {
   base_configuration   = module.base.configuration
   product_version      = "head"
   name                 = "min-kvm"
-  image                = "sles15sp3o"
+  image                = "sles15sp4o"
   server_configuration = module.server.configuration
 
   provider_settings = {


### PR DESCRIPTION
This will move our 4.3 terraform files to use SLE15SP3 and SP4 like we do in the Uyuni/HEAD CI.

Someone from QE should have a look at the change to the build validations file.