### PR TITLE
QE: Recover timeout by unactivity in our test pipelines

### DIFF
--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
@@ -31,7 +31,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
@@ -30,7 +30,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -31,7 +31,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-acceptance-tests
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 12, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 10, unit: 'HOURS') {
+    timeout(activity: true, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
In the past our pipelines were using activity timeout, instead of just a total timeout.
I think we should recover this approach, so we don't depend on how the test takes in time, but if it's doing something or not.