### PR TITLE
Fix suse version of suse-minion for environment9

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -234,7 +234,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:04:00:84"


### PR DESCRIPTION
Environment 9 had sles15sp4 as base system for suse-minion, instead of
sles15sp3, as the rest of the environemnts.

This was overlooked here https://github.com/SUSE/susemanager-ci/commit/bc59e05c564b38024c3f92bd821e18c2a985e832#diff-7712ea0bfd1d1f548571642c801aa3427c5c1df666d81e1d16db8a961228934a

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>