### PR TITLE
Changing again to total timeout instead of activity timeout (due to Jenkins bug), increasing from 10 to 14 hours

### DIFF
--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
@@ -31,7 +31,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
@@ -30,7 +30,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -31,7 +31,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-acceptance-tests
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
@@ -29,7 +29,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 10, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
@@ -26,7 +26,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: true, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
We decided to change to an activity timeout, because we had a total timeout of 10 hours that sometime aborted test suites that were totally fine. 
The reason for it is that some time ago we did not wait to have all channels fully synchronized, now we do. Plus recent timeout increases in several checks due to the lost of performance of our servers.

But it seems the activity timeout feature has a bug https://issues.jenkins.io/browse/JENKINS-58752 and so it doesn't take activity from the console output into account, failing after the 3 hours that we up.

**Therefore, we will come back to a total timeout for now, increasing it from 10 to 14 hours expecting this increase is enough big for the synchronization time added. As I'm not 100% sure how it will reacts if we remove the whole timeout statement which have embedded the call to the pipeline**
