### PR TITLE
Revert "Remove traditional client VM from Uyuni CI"

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -141,6 +141,15 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
+    suse-client = {
+      image = "sles15sp4o"
+      name = "cli-sles15"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:d4"
+      }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
     suse-minion = {
       # left with SP3 since we update it to SP4 in the testsuite
       image = "sles15sp3o"


### PR DESCRIPTION
Reverts SUSE/susemanager-ci#538


Until we have Manager-4.3 branch we can't merge the testsuite code fixes dependent from this PR. So let's revert until then, to remove some noise.