### PR TITLE
Use a different label for jenkins worker in Provo

### DIFF
--- a/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-dev-acceptance-tests-PRV
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.1-infra-reference-PRV
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.1-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.1-qe-build-validation
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-dev-acceptance-tests-PRV
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-infra-reference-PRV
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.2-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.2-qe-build-validation
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),


### PR DESCRIPTION
Use a different label for jenkins worker in Provo

The new label is defined in the infrastructure pillars