### PR TITLE
Fix SLE Micro 5.2 image name

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -926,7 +926,7 @@ module "slemicro52-minion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "4.3-released"
   name               = "min-slemicro52"
-  image              = "slemicro52-ign"
+  image              = "slemicro52-ignition"
   provider_settings = {
     mac                = "aa:b2:92:42:00:c0"
     memory             = 4096
@@ -1217,7 +1217,7 @@ module "slemicro52-sshminion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "4.3-released"
   name               = "minssh-slemicro52"
-  image              = "slemicro52-ign"
+  image              = "slemicro52-ignition"
   provider_settings = {
     mac                = "aa:b2:92:42:00:e0"
     memory             = 4096


### PR DESCRIPTION
This will fix the image name of SLE Micro 5.2. During running the 4.3.1 BV we found out the image name is wrong.

```bash
14:28:44  │ Error: Can't retrieve base volume with name 'suma-bv-43-slemicro52-ign': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'suma-bv-43-slemicro52-ign'')
14:28:44  │ 
14:28:44  │   with module.slemicro52-minion.module.minion.module.host.libvirt_volume.main_disk[0],
14:28:44  │   on /home/jenkins/jenkins-build/workspace/manager-4.3-qe-build-validation/results/sumaform/backend_modules/libvirt/host/main.tf line 51, in resource "libvirt_volume" "main_disk":
14:28:44  │   51: resource "libvirt_volume" "main_disk" {
14:28:44  │ 
14:28:44  ╵
14:28:44  ╷
14:28:44  │ Error: Can't retrieve base volume with name 'suma-bv-43-slemicro52-ign': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'suma-bv-43-slemicro52-ign'')
14:28:44  │ 
14:28:44  │   with module.slemicro52-sshminion.module.sshminion.module.host.libvirt_volume.main_disk[0],
14:28:44  │   on /home/jenkins/jenkins-build/workspace/manager-4.3-qe-build-validation/results/sumaform/backend_modules/libvirt/host/main.tf line 51, in resource "libvirt_volume" "main_disk":
14:28:44  │   51: resource "libvirt_volume" "main_disk" {
```