### PR TITLE
CI: switch minions to correct service pack

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-42-"
@@ -134,21 +134,21 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:84"
       }
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:86"
       }
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:88"
@@ -170,7 +170,7 @@ module "cucumber_testsuite" {
       }
     }
     build-host = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       provider_settings = {
         mac = "aa:b2:93:01:00:8d"
         memory = 2048

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi = false
   name_prefix = "suma-42-"
@@ -137,21 +137,21 @@ module "cucumber_testsuite" {
       }
     }
     suse-client = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:c4"
       }
     }
     suse-minion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:c6"
       }
     }
     suse-sshminion = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:c8"
@@ -173,7 +173,7 @@ module "cucumber_testsuite" {
       }
     }
     build-host = {
-      image = "sles15sp2o"
+      image = "sles15sp3o"
       provider_settings = {
         mac = "aa:b2:92:03:00:cd"
         memory = 2048

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-43-"
@@ -145,7 +145,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
+      image = "sles15sp4o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:96"
@@ -154,7 +154,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
+      image = "sles15sp4o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:98"

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi = false
   name_prefix = "suma-43-"
@@ -148,7 +148,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
+      image = "sles15sp4o"
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:86"
@@ -157,7 +157,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
+      image = "sles15sp4o"
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:88"

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-head-"

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse154o", "sles15sp3o", "sles15sp4o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"


### PR DESCRIPTION
Since we moved the service pack migration from the CI to the BV, we can
now use the proper images in terraform configuration files.

[According](https://suse.slack.com/archives/C02CLBJ5RGF/p1660826764390329?thread_ts=1660822494.753399&cid=C02CLBJ5RGF) to @Bischoff these are the correct versions:
```bash
4.3 - Head - Uyuni:

client - minion - ssh_minion   SLES 15.4
rhlike                         CentOS 7.0
deblike                        Ubuntu 20.04
virthost                       SLES 15.4

4.2:

client - minion - ssh_minion   SLES 15.3
rhlike                         CentOS 7.0
deblike                        Ubuntu 20.04
virthost                       SLES 15.3

4.1:

client - minion - ssh_minion   SLES 15.1
rhlike                         CentOS 7.0
deblike                        Ubuntu 20.04
virthost                       SLES 15.2
```