### PR TITLE
Revert "QE: Temporary disable mirror in Uyuni CI"

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -116,8 +116,8 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   // Comment the next two lines if no mirror should be used
-  //mirror = "minima-mirror.mgr.suse.de"
-  //use_mirror_images = true
+  mirror = "minima-mirror.mgr.suse.de"
+  use_mirror_images = true
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
 


### PR DESCRIPTION
Reverts SUSE/susemanager-ci#611

This was only a temporary change is is reverted now. @vandabarata heads up for the Uyuni CI.

Fixes https://github.com/SUSE/spacewalk/issues/18424