### PR TITLE
Revert "New variable for custom download endpoints"

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -116,7 +116,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -119,7 +119,6 @@ module "cucumber_testsuite" {
   mirror = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
@@ -116,7 +116,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -119,7 +119,6 @@ module "cucumber_testsuite" {
   mirror = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -116,7 +116,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -119,7 +119,6 @@ module "cucumber_testsuite" {
   mirror = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -116,7 +116,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -117,7 +117,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -116,7 +116,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -116,7 +116,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -118,7 +118,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
-  custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"
 
   host_settings = {
     controller = {


### PR DESCRIPTION
Reverts SUSE/susemanager-ci#652

Reverting because this breaks CI deployments 
https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-dev-acceptance-tests-PRV/190/console