### PR TITLE
Update image version matrix for Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ image for testing Pull Requests built with the open build service. This needs to
 
 | Version | Minion      | SSH minion  | Client      | RH-like  | Deb-like     | Virthosts   | Buildhost   | Terminal    | Controller |
 | ------- | ----------- | ----------- | ----------- | -------- | ------------ | ----------- | ----------- | ----------- | ---------- |
-|  Uyuni  | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 20.04 | Leap 15.4   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.2  |
-|  HEAD   | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 20.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.2  |
-|  4.3    | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 20.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.2  |
+|  Uyuni  | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 22.04 | Leap 15.4   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.2  |
+|  HEAD   | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.2  |
+|  4.3    | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.2  |
 |  4.2    | SLES 15 SP3 | SLES 15 SP3 | SLES 15 SP3 | CentOS 7 | Ubuntu 20.04 | SLES 15 SP3 | SLES 15 SP3 | SLES 15 SP3 | Leap 15.2  |
 |  4.1    | SLES 15 SP1 | SLES 15 SP1 | SLES 15 SP1 | CentOS 7 | Ubuntu 20.04 | SLES 15 SP2 | SLES 15 SP2 | SLES 15 SP2 | Leap 15.2  |


### PR DESCRIPTION
This updates the used Ubuntu version for Uyuni, HEAD and 4.3 in the image matrix.