### PR TITLE
Define images names for CentOS 7 for 4.1/4.2/4.3

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "centos7o"
+      name = "min-centos7"
       provider_settings = {
         mac = "aa:b2:93:01:00:a9"
         // Openscap cannot run with less than 1.25 GB of RAM

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -160,6 +160,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "centos7o"
+      name = "min-centos7"
       provider_settings = {
         mac = "aa:b2:92:03:00:a9"
         // Openscap cannot run with less than 1.25 GB of RAM

--- a/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
@@ -157,6 +157,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "centos7o"
+      name = "min-centos7"
       provider_settings = {
         mac = "aa:b2:93:01:00:89"
         // Openscap cannot run with less than 1.25 GB of RAM

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -160,6 +160,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "centos7o"
+      name = "min-centos7"
       provider_settings = {
         mac = "aa:b2:92:03:00:c9"
         // Openscap cannot run with less than 1.25 GB of RAM

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -165,6 +165,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "centos7o"
+      name = "min-centos7"
       provider_settings = {
         mac = "aa:b2:93:01:00:99"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -168,6 +168,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "centos7o"
+      name = "min-centos7"
       provider_settings = {
         mac = "aa:b2:92:03:00:89"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-"
@@ -193,7 +193,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     redhat-minion = {
-      image = "centos7o"
+      image = "rocky8o"
       provider_settings = {
         mac = "aa:b2:93:01:00:49"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM


### PR DESCRIPTION
This will add the image names for the Red Hat-like minions on 4.3/4.2/4.1