### PR TITLE
Temporary disable Nurenberg mirror for Uyuni

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -116,8 +116,8 @@ module "cucumber_testsuite" {
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
   // Comment the next two lines if no mirror should be used
-  mirror = "minima-mirror.mgr.suse.de"
-  use_mirror_images = true
+  # mirror = "minima-mirror.mgr.suse.de"
+  # use_mirror_images = true
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror.mgr.suse.de:445"


### PR DESCRIPTION
This will disable the minima mirror in Nuremberg for Uyuni since we do not have enough disk space to sync RES 8 required for Rocky 8.
