### PR TITLE
Disabling again remainings of ARM Minion in BV42

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -108,11 +108,6 @@ provider "libvirt" {
   uri = "qemu+tcp://trantor.mgr.prv.suse.net/system"
 }
 
-provider "libvirt" {
-  alias = "overdrive4"
-  uri = "qemu+tcp://overdrive4.mgr.suse.de/system"
-}
-
 module "base_core" {
   source = "./modules/base"
 
@@ -260,32 +255,6 @@ module "base_debian" {
     bridge      = "br1"
   }
 }
-
-// Disabled because of heat in NUE
-// module "base_arm" {
-//   providers = {
-//     libvirt = libvirt.overdrive4
-//   }
-//
-//   source = "./modules/base"
-//
-//   cc_username = var.SCC_USER
-//   cc_password = var.SCC_PASSWORD
-//   name_prefix = "suma-bv-42-"
-//   use_avahi   = false
-//   domain      = "mgr.prv.suse.net"
-//   images      = [ "opensuse154armo" ]
-//
-//   mirror = "minima-mirror-bv3.mgr.prv.suse.net"
-//   use_mirror_images = true
-//
-//   testsuite = true
-//
-//   provider_settings = {
-//     pool        = "ssd"
-//     bridge      = "br1"
-//   }
-// }
 
 module "server" {
   source             = "./modules/server"
@@ -914,33 +883,6 @@ module "debian11-minion" {
 
 }
 
-// Disabled because of heat in NUE
-//module "opensuse154arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.2-released"
-//  name               = "min-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:01:00:f2"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-42-pxy.mgr.prv.suse.net"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  //opensuse154arm-minion_additional_repos
-//
-//}
-
 module "sles12sp4-sshminion" {
   providers = {
     libvirt = libvirt.tatooine
@@ -1202,25 +1144,6 @@ module "debian11-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse154arm-sshminion" {
-  providers = {
-    libvirt = libvirt.overdrive4
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "4.2-released"
-  name               = "minssh-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:93:01:00:f3"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "sles12sp5-buildhost" {
   providers = {
     libvirt = libvirt.terminus
@@ -1366,9 +1289,6 @@ module "controller" {
 
   debian11_minion_configuration    = module.debian11-minion.configuration
   debian11_sshminion_configuration = module.debian11-sshminion.configuration
-
-  opensuse154arm_minion_configuration = module.opensuse154arm-minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp3_buildhost_configuration = module.sles15sp3-buildhost.configuration


### PR DESCRIPTION
BV 4.2 deployment is failing because we tried to enable ARM Minion, but we did it partially.
I removed completely all trace of ARM Minion, and if we want to enable it again, please let's do it with a card in our board and all the necessary checkboxes to don't miss anything and a reviewed PR.