### PR TITLE
Use test-pr ant target for Uyuni PRs Java_pgsql_tests

### DIFF
--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -26,7 +26,7 @@ pipeline {
         filter = "java/"
         git_fs = "${env.WORKSPACE}"
         // the actual test is the git repo
-        test = "'susemanager-utils/testing/automation/java-unittests-pgsql.sh -t test-coverage-report'"
+        test = "susemanager-utils/testing/automation/java-unittests-pgsql.sh"
         gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
         gitarro_cmd = 'gitarro.ruby2.5'
         gitarro_local = 'ruby gitarro.rb'


### PR DESCRIPTION
Now that the `test-pr` target depends on `test-coverage-report` better use it as it sets the stage to fail if there are errors in the tests