### PR TITLE
opensuse152o is unused. Remove it from tf files

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse154o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-41-"

--- a/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.1-PRV.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse154o", "sles15sp1o", "sles15sp2o", "ubuntu2004o"]
 
   use_avahi = false
   name_prefix = "suma-41-"

--- a/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse154o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi    = false
   name_prefix  = "suma-42-"

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp3o", "ubuntu2004o"]
+  images = ["centos7o", "opensuse154o", "sles15sp3o", "ubuntu2004o"]
 
   use_avahi = false
   name_prefix = "suma-42-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-43-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi = false
   name_prefix = "suma-43-"

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-head-"

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp2o", "sles15sp3o", "sles15sp4o"]
+  images = ["centos7o", "opensuse154o", "sles15sp2o", "sles15sp3o", "sles15sp4o"]
 
   use_avahi    = false
   name_prefix  = "suma-testhexagon-"

--- a/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
@@ -93,7 +93,7 @@ module "base_core" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse153o", "opensuse154o", "sles15sp3o", "sles15sp4o"]
+  images = ["centos7o", "opensuse154o", "sles15sp3o", "sles15sp4o"]
   use_avahi    = false
   name_prefix  = "suma-testhub-"
   domain       = "mgr.suse.de"

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE-cobbler-3.3.2
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE-cobbler-3.3.2
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse154o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-"

--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-"

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-testnaica-"

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -103,8 +103,8 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  //images = ["opensuse152o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
-  images = ["centos7o", "opensuse152o", "opensuse154o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
+  //images = ["opensuse154o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse154o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-testorion-"

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse152o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"

--- a/terracumber_config/tf_files/Uyuni-Master-tests-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-coverage.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["opensuse152o", "opensuse154o", "sles15sp2o", "sles15sp3o"]
+  images = ["opensuse154o", "sles15sp2o", "sles15sp3o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr8-"


### PR DESCRIPTION
All control nodes are running opensuse154o now.
Time to remove opensuse152o from the image definition