### PR TITLE
Revert "Use minima-mirror for 15.4 source"

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation.tf
@@ -118,7 +118,7 @@ module "base_core" {
   domain      = "mgr.prv.suse.net"
   images      = [ "sles15sp3o", "opensuse154o" ]
 
-  mirror = "minima-mirror.mgr.prv.suse.net"
+  mirror = "minima-mirror-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
   testsuite          = true


### PR DESCRIPTION
Reverts SUSE/susemanager-ci#685. Merge only after https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/630 got merged and the BV mirror was synced again.