### PR TITLE
Raise available memory on Uyuni NUE server to 12GB

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -132,7 +132,7 @@ module "cucumber_testsuite" {
     server = {
       provider_settings = {
         mac = "aa:b2:93:01:00:d1"
-        memory = 10240
+        memory = 12288
       }
       login_timeout = 28800
     }


### PR DESCRIPTION
Raise (temporarily or not) the available memory on the Uyuni-NUE test server to solve an OOM issue occurring from time to time.  