### PR TITLE
Revert: don't install the salt bundle on 4.3 BV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -350,7 +350,6 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = true
   ssh_key_path              = "./salt/controller/id_rsa.pub"
-  install_salt_bundle       = true
 
   //proxy_additional_repos
 
@@ -375,7 +374,6 @@ module "sles12sp4-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle12sp4-client_additional_repos
 
@@ -400,7 +398,6 @@ module "sles12sp5-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle12sp5-client_additional_repos
 
@@ -425,7 +422,6 @@ module "sles15-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15-client_additional_repos
 
@@ -450,7 +446,6 @@ module "sles15sp1-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp1-client_additional_repos
 
@@ -475,7 +470,6 @@ module "sles15sp2-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp2-client_additional_repos
 
@@ -500,7 +494,6 @@ module "sles15sp3-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp3-client_additional_repos
 
@@ -525,7 +518,6 @@ module "sles15sp4-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp4-client_additional_repos
 
@@ -550,7 +542,6 @@ module "centos7-client" {
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //ceos7-client_additional_repos
 
@@ -575,7 +566,6 @@ module "sles12sp4-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle12sp4-minion_additional_repos
 
@@ -600,7 +590,6 @@ module "sles12sp5-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle12sp5-minion_additional_repos
 
@@ -626,7 +615,6 @@ module "sles15-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15-minion_additional_repos
 
@@ -652,7 +640,6 @@ module "sles15sp1-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp1-minion_additional_repos
 
@@ -678,7 +665,6 @@ module "sles15sp2-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp2-minion_additional_repos
 
@@ -704,7 +690,6 @@ module "sles15sp3-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp3-minion_additional_repos
 
@@ -730,7 +715,6 @@ module "sles15sp4-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //sle15sp4-minion_additional_repos
 
@@ -755,7 +739,6 @@ module "centos7-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //ceos7-minion_additional_repos
 
@@ -780,7 +763,6 @@ module "rocky8-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //rocky8-minion_additional_repos
 
@@ -806,7 +788,6 @@ module "rocky8-minion" {
 //   auto_connect_to_master  = false
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//   install_salt_bundle     = true
 //
 //   //rocky9-minion_additional_repos
 //
@@ -831,7 +812,6 @@ module "ubuntu1804-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //ubuntu1804-minion_additional_repos
 
@@ -856,7 +836,6 @@ module "ubuntu2004-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //ubuntu2004-minion_additional_repos
 
@@ -881,7 +860,6 @@ module "ubuntu2204-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 // Debian 9 is not supported by 4.3
@@ -906,7 +884,6 @@ module "debian10-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //debian10-minion_additional_repos
 
@@ -932,7 +909,6 @@ module "debian11-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //debian11-minion_additional_repos
 
@@ -959,7 +935,6 @@ module "opensuse154arm-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
   //opensuse154arm-minion_additional_repos
 
@@ -986,7 +961,6 @@ module "opensuse154arm-minion" {
 // auto_connect_to_master  = false
 //  use_os_released_updates = false
 //  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//  install_salt_bundle     = true
 //
 //  //slemicro52-minion_additional_repos
 //
@@ -1008,7 +982,6 @@ module "sles12sp4-sshminion" {
 
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -1028,7 +1001,6 @@ module "sles12sp5-sshminion" {
 
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -1047,7 +1019,6 @@ module "sles15-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
 }
 
@@ -1066,7 +1037,6 @@ module "sles15sp1-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 
 }
 
@@ -1085,7 +1055,6 @@ module "sles15sp2-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "sles15sp3-sshminion" {
@@ -1103,7 +1072,6 @@ module "sles15sp3-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "sles15sp4-sshminion" {
@@ -1121,7 +1089,6 @@ module "sles15sp4-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "centos7-sshminion" {
@@ -1139,7 +1106,6 @@ module "centos7-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "rocky8-sshminion" {
@@ -1157,7 +1123,6 @@ module "rocky8-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 // Disabling rocky9 while there are problems with deployment
@@ -1176,7 +1141,6 @@ module "rocky8-sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//   install_salt_bundle     = true
 // }
 
 module "ubuntu1804-sshminion" {
@@ -1194,7 +1158,6 @@ module "ubuntu1804-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "ubuntu2004-sshminion" {
@@ -1212,7 +1175,6 @@ module "ubuntu2004-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "ubuntu2204-sshminion" {
@@ -1230,7 +1192,6 @@ module "ubuntu2204-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 // Debian 9 is not supported by 4.3
@@ -1250,7 +1211,6 @@ module "debian10-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "debian11-sshminion" {
@@ -1268,7 +1228,6 @@ module "debian11-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "opensuse154arm-sshminion" {
@@ -1288,7 +1247,6 @@ module "opensuse154arm-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 // Disabled until hexagon has the bootstrap process ready for SLE Micro
@@ -1307,7 +1265,6 @@ module "opensuse154arm-sshminion" {
 //  }
 //  use_os_released_updates = false
 //  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//  install_salt_bundle     = true
 //}
 
 module "sles12sp5-buildhost" {
@@ -1330,7 +1287,6 @@ module "sles12sp5-buildhost" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "sles12sp5-terminal" {
@@ -1369,7 +1325,6 @@ module "sles15sp4-buildhost" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle     = true
 }
 
 module "sles15sp4-terminal" {


### PR DESCRIPTION
Revert of #708. After detailed discussion with Pablo, it appears the original PR was at best useless:

* sumaform always uses salt-minion (no venv) to do its initial stuff
* BV test suite does its own stuff (first thing it does is remove all Salt stuff coming from sumaform)

The problem of absent salt-minion package on Rocky 9 might be an effect of https://bugs.rockylinux.org/view.php?id=1189 . If not, the reverted PR would not have solved the issue as sumaform always uses salt-minion, and we have to find something else.