### PR TITLE
Re-enable rocky9 now the official image was fixed

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -172,9 +172,7 @@ module "base_res" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-// Disabling rocky9 while there are problems with deployment
-//   images      = [ "centos7o", "rocky8o", "rocky9o" ]
-  images      = [ "centos7o", "rocky8o" ]
+  images      = [ "centos7o", "rocky8o", "rocky9o" ]
 
   mirror = "minima-mirror-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -768,30 +766,29 @@ module "rocky8-minion" {
 
 }
 
-// Disabling rocky9 while there are problems with deployment
-// module "rocky9-minion" {
-//   providers = {
-//     libvirt = libvirt.endor
-//   }
-//   source             = "./modules/minion"
-//   base_configuration = module.base_res.configuration
-//   product_version    = "4.3-released"
-//   name               = "min-rocky9"
-//   image              = "rocky9o"
-//   provider_settings = {
-//     mac                = "aa:b2:92:42:00:c1"
-//     memory             = 4096
-//   }
-//   server_configuration = {
-//     hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-//   }
-//   auto_connect_to_master  = false
-//   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//   //rocky9-minion_additional_repos
-//
-// }
+module "rocky9-minion" {
+  providers = {
+    libvirt = libvirt.endor
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_res.configuration
+  product_version    = "4.3-released"
+  name               = "min-rocky9"
+  image              = "rocky9o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:c1"
+    memory             = 4096
+  }
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  //rocky9-minion_additional_repos
+
+}
 
 module "ubuntu1804-minion" {
   providers = {
@@ -1125,23 +1122,22 @@ module "rocky8-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-// Disabling rocky9 while there are problems with deployment
-// module "rocky9-sshminion" {
-//   providers = {
-//     libvirt = libvirt.endor
-//   }
-//   source             = "./modules/sshminion"
-//   base_configuration = module.base_res.configuration
-//   product_version    = "4.3-released"
-//   name               = "minssh-rocky9"
-//   image              = "rocky9o"
-//   provider_settings = {
-//     mac                = "aa:b2:92:42:00:e1"
-//     memory             = 4096
-//   }
-//   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
-// }
+module "rocky9-sshminion" {
+  providers = {
+    libvirt = libvirt.endor
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_res.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-rocky9"
+  image              = "rocky9o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:e1"
+    memory             = 4096
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "ubuntu1804-sshminion" {
   providers = {
@@ -1370,9 +1366,8 @@ module "controller" {
   rocky8_minion_configuration    = module.rocky8-minion.configuration
   rocky8_sshminion_configuration = module.rocky8-sshminion.configuration
 
-// Disabling rocky9 while there are problems with deployment
-//   rocky9_minion_configuration    = module.rocky9-minion.configuration
-//   rocky9_sshminion_configuration = module.rocky9-sshminion.configuration
+  rocky9_minion_configuration    = module.rocky9-minion.configuration
+  rocky9_sshminion_configuration = module.rocky9-sshminion.configuration
 
   sle12sp4_client_configuration    = module.sles12sp4-client.configuration
   sle12sp4_minion_configuration    = module.sles12sp4-minion.configuration


### PR DESCRIPTION
Upstream rocky 9 bug has been fixed, we can resume testing support for rocky9 in 4.3.3 BV test suite