### PR TITLE
Add SLE Micro 5.2 and 5.3 to 4.3 BV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -197,7 +197,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "slemicro52-ign", "slemicro53-ign" ]
 
   mirror = "minima-mirror-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -888,31 +888,30 @@ module "opensuse154arm-minion" {
 
 }
 
-// Disabled until hexagon has the bootstrap process ready for SLE Micro
-//module "slemicro52-minion" {
-//  providers = {
-//    libvirt = libvirt.giediprime
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_new_sle.configuration
-//  product_version    = "4.3-released"
-//  name               = "min-slemicro52"
-//  image              = "slemicro52-ign"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:c0"
-//   memory             = 4096
-//  }
-//
-//  server_configuration = {
-//    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-//  }
-// auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  //slemicro52-minion_additional_repos
-//
-//}
+module "slemicro52-minion" {
+  providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro52"
+  image              = "slemicro52-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:c0"
+   memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  //slemicro52-minion_additional_repos
+
+}
 
 module "alma9-minion" {
   providers = {
@@ -959,6 +958,31 @@ module "oracle9-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
   //oracle9-minion_additional_repos
+
+}
+
+module "slemicro53-minion" {
+  providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro53"
+  image              = "slemicro53-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:c4"
+   memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  //slemicro52-minion_additional_repos
 
 }
 
@@ -1226,23 +1250,22 @@ module "opensuse154arm-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-// Disabled until hexagon has the bootstrap process ready for SLE Micro
-//module "slemicro52-sshminion" {
-// providers = {
-//    libvirt = libvirt.giediprime
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_new_sle.configuration
-//  product_version    = "4.3-released"
-//  name               = "minssh-slemicro52"
-//  image              = "slemicro52-ign"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:e0"
-//    memory             = 4096
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "slemicro52-sshminion" {
+ providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-slemicro52"
+  image              = "slemicro52-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:e0"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "alma9-sshminion" {
   providers = {
@@ -1288,6 +1311,23 @@ module "oracle9-sshminion" {
 
   //oracle9-sshminion_additional_repos
 
+}
+
+module "slemicro53-sshminion" {
+ providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-slemicro53"
+  image              = "slemicro53-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:e4"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
 module "sles12sp5-buildhost" {
@@ -1468,9 +1508,11 @@ module "controller" {
   opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
   opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
 
-// Disabled until hexagon has the bootstrap process ready for SLE Micro
-//  slemicro52_minion_configuration    = module.slemicro52-minion.configuration
-//  slemicro52_sshminion_configuration = module.slemicro52-sshminion.configuration
+  slemicro52_minion_configuration    = module.slemicro52-minion.configuration
+  slemicro52_sshminion_configuration = module.slemicro52-sshminion.configuration
+
+  slemicro53_minion_configuration    = module.slemicro53-minion.configuration
+  slemicro53_sshminion_configuration = module.slemicro53-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration


### PR DESCRIPTION
This will enable SLE Micro 5.2 and 5.3 for our 4.3 BV. It will only get merged once the test suite changes are ready.

### Links

- https://github.com/SUSE/spacewalk/issues/17352