### PR TITLE
Raising available memory for SUMA server to 10GB on 4.2 CI

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -126,12 +126,12 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:92:03:00:c0"
-        memory = 10240
       }
     }
     server = {
       provider_settings = {
         mac = "aa:b2:92:03:00:c1"
+        memory = 10240
       }
     }
     proxy = {

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -126,6 +126,7 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:92:03:00:c0"
+        memory = 10240
       }
     }
     server = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -133,6 +133,7 @@ module "cucumber_testsuite" {
     server = {
       provider_settings = {
         mac = "aa:b2:92:03:00:81"
+        memory = 10240
       }
     }
     proxy = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -128,7 +128,7 @@ module "cucumber_testsuite" {
     server = {
       provider_settings = {
         mac = "aa:b2:93:01:00:b1"
-        memory = 10240
+        memory = 12288
       }
     }
     proxy = {


### PR DESCRIPTION
Following https://github.com/SUSE/spacewalk/issues/19666, raising the available memory on the 4.2 SUSE Manager CI server from default 8GB to 10GB.

4.3 raised to 10GB as well
Head raised to 12GB to mirror Uyuni config