### PR TITLE
Revert memory raise for suma CIs

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -131,7 +131,6 @@ module "cucumber_testsuite" {
     server = {
       provider_settings = {
         mac = "aa:b2:92:03:00:c1"
-        memory = 10240
       }
     }
     proxy = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -133,7 +133,6 @@ module "cucumber_testsuite" {
     server = {
       provider_settings = {
         mac = "aa:b2:92:03:00:81"
-        memory = 10240
       }
     }
     proxy = {


### PR DESCRIPTION
Since raising the memory to 10GB did not bring an expected fix to some issues on 4.2 , reverting to default memory attribution on 4.2 and 4.3 (8GB) to avoid raising it for no reason.
Original PR: https://github.com/SUSE/susemanager-ci/pull/713

Related card: https://github.com/SUSE/spacewalk/issues/19666