### PR TITLE
Availability zone in Uyuni AWS changed to eu-central-1c

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -81,7 +81,7 @@ variable "REGION" {
 
 variable "AVAILABILITY_ZONE" {
   type = string
-  default = "eu-central-1a"
+  default = "eu-central-1c"
 }
 
 variable "KEY_FILE" {


### PR DESCRIPTION
This PR aims to prevent that kind of issues in AWS due to not available resources in the current availability zone.
```
14:25:21  │ Error: Error launching source instance: InsufficientInstanceCapacity: We currently do not have sufficient c6a.xlarge capacity in the Availability Zone you requested (eu-central-1a). Our system will be working on provisioning additional capacity. You can currently get c6a.xlarge capacity by not specifying an Availability Zone in your request or choosing eu-central-1b, eu-central-1c.
```

There is three uncertain possible issues:
- What happen with old instances? They are clean up?
- If that change implies a different subnet, will sumaform handle this change properly so we can continue using the mirror in the other subnet?
- What happen with the hardcoded resource for our mirror, will that cause a not desired kind of traffic?