### PR TITLE
Adding a confirmation step before each stage in BV

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -27,6 +27,7 @@ def run(params) {
                     copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
                 }
             }
+
             stage('Deploy') {
                 if(params.must_deploy) {
                     // Provision the environment
@@ -44,6 +45,7 @@ def run(params) {
                     deployed = true
                 }
             }
+
             stage('Sanity check') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
             }
@@ -65,6 +67,7 @@ def run(params) {
             }
 
             stage('Add MUs') {
+                input 'Press any key to start adding Maintenance Update repositories'
                 if(params.must_add_custom_channels) {
                     echo 'Add custom channels and MU repositories'
                     res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_add_custom_repositories'", returnStatus: true)
@@ -76,6 +79,7 @@ def run(params) {
             }
 
             stage('Add Common Channels') {
+                input 'Press any key to start adding common channels'
                 if(params.must_add_common_channels) {
                     echo 'Add common channels'
                     res_common_channels = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_add_common_channels'", returnStatus: true)
@@ -87,6 +91,7 @@ def run(params) {
             }
 
             stage('Add Activation Keys') {
+                input 'Press any key to start adding activation keys'
                 if(params.must_add_keys) {
                     echo 'Add Activation Keys'
                     res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_add_activation_keys'", returnStatus: true)
@@ -95,6 +100,7 @@ def run(params) {
             }
 
             stage('Create bootstrap repositories') {
+                input 'Press any key to start creating bootstrap repositories'
                 if(params.must_create_bootstrap_repos) {
                     echo 'Create bootstrap repositories'
                     res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repositories'", returnStatus: true)
@@ -103,6 +109,7 @@ def run(params) {
             }
 
             stage('Bootstrap Proxy') {
+                input 'Press any key to start bootstraping the Proxy'
                 if(params.must_boot_proxy) {
                     echo 'Proxy register as minion with gui'
                     res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_init_proxy'", returnStatus: true)
@@ -111,6 +118,7 @@ def run(params) {
             }
 
             stage('Bootstrap Monitoring Server') {
+                input 'Press any key to start bootstraping the Monitoring Server'
                 if(params.must_boot_monitoring) {
                     echo 'Register monitoring server as minion with gui'
                     res_init_monitoring = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_init_monitoring'", returnStatus: true)
@@ -119,6 +127,7 @@ def run(params) {
             }
 
             stage('Bootstrap clients') {
+                input 'Press any key to start bootstraping the clients'
                 if(params.must_boot_clients) {
                     echo 'Bootstrap clients'
                     res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_init_clients'", returnStatus: true)
@@ -127,6 +136,7 @@ def run(params) {
             }
 
             stage('Run Smoke Tests') {
+                input 'Press any key to start running the smoke tests'
                 if(params.must_run_tests) {
                         echo 'Run Smoke tests'
                         res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_smoke_tests'", returnStatus: true)
@@ -135,6 +145,7 @@ def run(params) {
             }
 
             stage('Prepare and run Retail') {
+                input 'Press any key to start running the retail tests'
                 if(params.must_prepare_retail) {
                     echo 'Prepare Proxy for Retail'
                     res_retail_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_retail_proxy'", returnStatus: true)
@@ -149,6 +160,7 @@ def run(params) {
             }
 
             stage('Containerization') {
+                input 'Press any key to start running the containerization tests'
                 if(params.must_run_containerization_tests) {
                     echo 'Prepare Proxy as Pod and run basic tests'
                     res_container_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:build_validation_containerization'", returnStatus: true)
@@ -160,6 +172,7 @@ def run(params) {
             stage('Save TF state') {
                     archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
             }
+            
             stage('Get results') {
                 def error = 0
                 if (deployed || !params.must_deploy) {


### PR DESCRIPTION
Most of us when running the BV, prefer to don't run it all at once, but run only some stages and verify all is good before moving to next stage. Or even, made some trick in between.

In order to facilitate having all in a unique job execution, I added confirmation messages that will wait until we type a key before running the next stage.