### PR TITLE
TEST: Use proper name for rocky8 minion

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-NUE.tf
@@ -166,6 +166,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
+      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:93:01:00:49"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM


### PR DESCRIPTION
This PR fixes the issue we see atm in TEST environment: https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-acceptance-tests/1426/console

```console
14:16:32  No hostname for 'suma-test-min-rocky8.mgr.suse.de'. Response code: 0 (RuntimeError)
```