### PR TITLE
Increase disk size in 4.3 BV server

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -299,7 +299,7 @@ module "server" {
   }
 
   server_mounted_mirror = "minima-mirror-bv.mgr.prv.suse.net"
-  repository_disk_size = 2000
+  repository_disk_size = 1700
 
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -299,7 +299,7 @@ module "server" {
   }
 
   server_mounted_mirror = "minima-mirror-bv.mgr.prv.suse.net"
-  repository_disk_size = 1500
+  repository_disk_size = 2000
 
   auto_accept                    = false
   monitored                      = true


### PR DESCRIPTION
Increase disk size in 4.3 BV server because we are at the limit:

```
/dev/vdb1                                      1.5T  1.3T  119G  92% /var/spacewalk
```