### PR TITLE
Update uyuni-master-dev-acceptance-tests-code-coverage

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -1,4 +1,4 @@
-node('sumaform-cucumber') {
+node('sumaform-cucumber-provo') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '1', daysToKeepStr: '60', artifactNumToKeepStr: '1')),
         disableConcurrentBuilds(),


### PR DESCRIPTION
The jenkins worker must be in Provo as the hypervisor is in Provo.