### PR TITLE
QE: Add new variables for nested VM tests

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -207,6 +207,7 @@ module "cucumber_testsuite" {
       }
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -227,6 +227,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -194,6 +194,20 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp4o"
       name = "min-kvm"
+      additional_grains = {
+        hvm_disk_image = {
+          leap = {
+            hostname = "leap-salt-migration"
+            image = "http://minima-mirror.mgr.suse.de/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+            hash = "http://minima-mirror.mgr.suse.de/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+          }
+          sles = {
+            hostname = "sles-salt-migration"
+            image = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
+            hash = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
+          }
+        }
+      }
       provider_settings = {
         mac = "aa:b2:93:01:00:be"
       }
@@ -201,6 +215,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -204,6 +204,20 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse154o"
       name = "min-kvm"
+      additional_grains = {
+        hvm_disk_image = {
+          leap = {
+            hostname = "leap-salt-migration"
+            image = "http://minima-mirror.mgr.suse.de/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+            hash = "http://minima-mirror.mgr.suse.de/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+          }
+          sles = {
+            hostname = "sles-salt-migration"
+            image = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
+            hash = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
+          }
+        }
+      }
       provider_settings = {
         mac = "aa:b2:93:01:00:de"
       }
@@ -211,6 +225,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -330,6 +330,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
+  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
   provider_settings = {
     pool               = "default"
     network_name       = null


### PR DESCRIPTION
This adds a new variable to our terraform configuration files necessary for the Salt bundle migration tests that uses nested VMs.

See
- https://github.com/SUSE/spacewalk/issues/17238
- https://github.com/uyuni-project/sumaform/pull/1229
- https://github.com/uyuni-project/uyuni/pull/5240