### PR TITLE
Revert "Switch Head to salzbreze"

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -85,7 +85,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://salzbreze.mgr.suse.de/system"
+  uri = "qemu+tcp://ramrod.mgr.suse.de/system"
 }
 
 module "cucumber_testsuite" {


### PR DESCRIPTION
Reverts SUSE/susemanager-ci#776 so we have uyuni running instead of head