### PR TITLE
Add salt bundle for centos7 on suma42

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -167,7 +167,6 @@ module "cucumber_testsuite" {
         // Openscap cannot run with less than 1.25 GB of RAM
         memory = 1280
       }
-      additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     debian-minion = {

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -167,6 +167,8 @@ module "cucumber_testsuite" {
         // Openscap cannot run with less than 1.25 GB of RAM
         memory = 1280
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     debian-minion = {
       name = "min-ubuntu2004"


### PR DESCRIPTION
salt is not supported anymore for centos7. We need to use venv-salt.
Update suma4.2 dev acceptance terraform file to use salt-bundle during sumaform deployment.