### PR TITLE
Add venv support to 4.2 minions

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -137,6 +137,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c2"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-client = {
       image = "sles15sp3o"
@@ -144,6 +146,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c4"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-minion = {
       image = "sles15sp3o"
@@ -151,6 +155,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c6"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-sshminion = {
       image = "sles15sp3o"
@@ -158,6 +164,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c8"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     redhat-minion = {
       image = "centos7o"
@@ -167,6 +175,7 @@ module "cucumber_testsuite" {
         // Openscap cannot run with less than 1.25 GB of RAM
         memory = 1280
       }
+      additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     debian-minion = {
@@ -175,6 +184,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:cc"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp3o"
@@ -183,6 +194,8 @@ module "cucumber_testsuite" {
         mac = "aa:b2:92:03:00:cd"
         memory = 2048
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     pxeboot-minion = {
       image = "sles15sp3o"
@@ -201,6 +214,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:ce"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
   }
   nested_vm_hosts = ["min-nested"]

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -137,8 +137,6 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c2"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     suse-client = {
       image = "sles15sp3o"

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -137,6 +137,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c2"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-client = {
       image = "sles15sp3o"


### PR DESCRIPTION
4.2 is now using venv-salt-minion.
Update main.tf 4.2 ci to support venv-salt-minion.