### PR TITLE
QE: Add SLE Micro 5.1 to 4.3 BV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -197,7 +197,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "slemicro52-ign", "slemicro53-ign" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" ]
 
   mirror = "minima-mirror-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -964,6 +964,31 @@ module "opensuse154arm-minion" {
 
 }
 
+module "slemicro51-minion" {
+  providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro51"
+  image              = "slemicro51-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:c6"
+   memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  //slemicro51-minion_additional_repos
+
+}
+
 module "slemicro52-minion" {
   providers = {
     libvirt = libvirt.giediprime
@@ -1350,6 +1375,23 @@ module "opensuse154arm-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro51-sshminion" {
+ providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-slemicro51"
+  image              = "slemicro51-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:e6"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "slemicro52-sshminion" {
  providers = {
     libvirt = libvirt.giediprime
@@ -1564,6 +1606,9 @@ module "controller" {
 
   opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
   opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+
+  slemicro51_minion_configuration    = module.slemicro51-minion.configuration
+  slemicro51_sshminion_configuration = module.slemicro51-sshminion.configuration
 
   slemicro52_minion_configuration    = module.slemicro52-minion.configuration
   slemicro52_sshminion_configuration = module.slemicro52-sshminion.configuration


### PR DESCRIPTION
This will add SLE Micro 5.1 to our 4.3 build validation. See https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/702 for the MAC addresses. 