### PR TITLE
BV: Make minions/clients selectable

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -396,7 +396,7 @@ def getMinionList() {
     String[] moduleList = modules.split("\n")
     moduleList.each { lane ->
         def instanceList = lane.tokenize(".")
-        if (instanceList[1].contains('minion') or instanceList[1].contains('client')) {
+        if (instanceList[1].contains('minion') || instanceList[1].contains('client')) {
             nodeList.add(instanceList[1].replaceAll("-", "_").replaceAll("sshminion", "ssh_minion").replaceAll("sles", "sle"))
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -401,9 +401,9 @@ def getMinionList() {
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }
-    println ("Minion list from jenkins ${params.declareMinionList}" )
-    def minionToDisableList = nodeList - params.declareMinionList
-    def minionNotDeployList = params.declareMinionList - nodeList
+    println ("Minion list from jenkins : ${params.declareMinionList.split(", ")}" )
+    def minionToDisableList = nodeList - params.declareMinionList.split(", ")
+    def minionNotDeployList = params.declareMinionList.split(", ") - nodeList
 
     println "This minions are not deployed ! ${minionNotDeployList}"
 

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -392,8 +392,8 @@ def getMinionList() {
     moduleList.each { lane ->
         def instanceList = lane.tokenize(".")
         if (instanceList[1].contains('minion') || instanceList[1].contains('client')) {
-            nodeList.add(instanceList[1].replaceAll("-", "_").replaceAll("sshminion", "ssh_minion").replaceAll("sles", "sle"))
-            envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
+            nodeList.add(instanceList[1].replaceAll('-', '_').replaceAll('sshminion', 'ssh_minion').replaceAll('sles', 'sle'))
+            envVar.add(instanceList[1].replaceAll('-', '_').replaceAll('sles', 'sle').toUpperCase())
         }
     }
     // Convert jenkins minions list parameter to list
@@ -405,7 +405,7 @@ def getMinionList() {
     // This difference will be the nodes to disable
     def disabledNodes = nodeList.findAll { !nodesToRun.contains(it) }
     // Convert this list to cucumber compatible environment variable
-    def envVarDisabledNodes = disabledNodes.collect { it.replaceAll("ssh_minion", "sshminion").toUpperCase() }
+    def envVarDisabledNodes = disabledNodes.collect { it.replaceAll('ssh_minion', 'sshminion').toUpperCase() }
     // Create a node list without the disabled nodes. ( use to configure the client stage )
     def nodeListWithDisabledNodes = nodeList - disabledNodes
     return [nodeList:nodeListWithDisabledNodes, envVariableList:envVar, envVariableListToDisable:envVarDisabledNodes]

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -396,7 +396,7 @@ def getMinionList() {
     String[] moduleList = modules.split("\n")
     moduleList.each { lane ->
         def instanceList = lane.tokenize(".")
-        if (instanceList[1].contains('minion')) {
+        if (instanceList[1].contains('minion') or instanceList[1].contains('client')) {
             nodeList.add(instanceList[1].replaceAll("-", "_").replaceAll("sshminion", "ssh_minion").replaceAll("sles", "sle"))
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -54,9 +54,7 @@ def run(params) {
 
             stage('Sanity check') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
-                minionList = getMinionList()
-                println minionList.envVar
-                println minionList.nodeList
+                env.minionList = getMinionList()
             }
 
             stage('Run core features') {
@@ -260,13 +258,12 @@ def clientTestingStages() {
     // Load JSON matching non MU repositories data
     def json_matching_non_MU_data = readJSON(file: params.non_MU_channels_tasks_file)
 
-    minionList = getMinionList()
     // Construct a list of stages for every node.
-    minionList.nodeList.each { minion ->
+    env.minionList.nodeList.each { minion ->
         tests["${minion}"] = {
             // Generate a temporary list that comprises of all the minions except the one currently undergoing testing.
             // This list is utilized to establish an SSH session exclusively with the minion undergoing testing.
-            def temporaryList = minionList.envVar.toList() - minion.replaceAll("ssh_minion", "sshminion").toUpperCase()
+            def temporaryList = env.minionList.envVar.toList() - minion.replaceAll("ssh_minion", "sshminion").toUpperCase()
             stage("${minion}") {
                 echo "Testing ${minion}"
             }
@@ -391,9 +388,7 @@ def getMinionList() {
     moduleList.each { lane ->
         def instanceList = lane.tokenize(".")
         if (instanceList[1].contains('minion')) {
-            echo instanceList[1].replaceAll("-", "_").replaceAll("sshminion", "ssh_minion").replaceAll("sles", "sle")
             nodeList.add(instanceList[1].replaceAll("-", "_").replaceAll("sshminion", "ssh_minion").replaceAll("sles", "sle"))
-            echo instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase()
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -404,8 +404,10 @@ def getMinionList() {
     def declareMinionList = params.minions_to_run.split(", ")
 
     println ("Minion list from jenkins : ${declareMinionList}" )
-    def minionNotDeployList = declareMinionList - nodeList
-    minionToDisableList = nodeList - ( declareMinionList - minionNotDeployList )
+//    def minionNotDeployList = declareMinionList - nodeList
+    def minionNotDeployList = declareMinionList.findAll { !nodeList.contains(it) }
+//    def minionToDisableList = nodeList - ( declareMinionList - minionNotDeployList )
+    def minionToDisableList = nodeList.findAll { !declareMinionList.contains(it) }
 
     println "This minions are not deployed ! ${minionNotDeployList}"
     println "Minion to disable : ${minionToDisableList}"

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -214,42 +214,42 @@ def run(params) {
                 archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
             }
 
-            stage('Get results') {
-                def error = 0
-                if (deployed || !params.must_deploy) {
-                    try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
-                    } catch(Exception ex) {
-                        println("ERROR: rake cucumber:build_validation_finishing failed")
-                        error = 1
-                    }
-                    try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
-                    } catch(Exception ex) {
-                        println("ERROR: rake utils:generate_test_report failed")
-                        error = 1
-                    }
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
-                    publishHTML( target: [
-                            allowMissing: true,
-                            alwaysLinkToLastBuild: false,
-                            keepAll: true,
-                            reportDir: "${resultdirbuild}/cucumber_report/",
-                            reportFiles: 'cucumber_report.html',
-                            reportName: "Build Validation report"]
-                    )
-                    // junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
-                }
-                // Send email
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
-                // Clean up old results
-                sh "./clean-old-results -r ${resultdir}"
-                // Fail pipeline if client stages failed
-                if (env.client_stage_result_fail) {
-                    error("Client stage failed")
-                }
-                sh "exit ${error}"
-            }
+//            stage('Get results') {
+//                def error = 0
+//                if (deployed || !params.must_deploy) {
+//                    try {
+//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
+//                    } catch(Exception ex) {
+//                        println("ERROR: rake cucumber:build_validation_finishing failed")
+//                        error = 1
+//                    }
+//                    try {
+//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+//                    } catch(Exception ex) {
+//                        println("ERROR: rake utils:generate_test_report failed")
+//                        error = 1
+//                    }
+//                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+//                    publishHTML( target: [
+//                            allowMissing: true,
+//                            alwaysLinkToLastBuild: false,
+//                            keepAll: true,
+//                            reportDir: "${resultdirbuild}/cucumber_report/",
+//                            reportFiles: 'cucumber_report.html',
+//                            reportName: "Build Validation report"]
+//                    )
+//                    // junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+//                }
+//                // Send email
+//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+//                // Clean up old results
+//                sh "./clean-old-results -r ${resultdir}"
+//                // Fail pipeline if client stages failed
+//                if (env.client_stage_result_fail) {
+//                    error("Client stage failed")
+//                }
+//                sh "exit ${error}"
+//            }
         }
     }
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -401,9 +401,11 @@ def getMinionList() {
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }
-    println ("Minion list from jenkins : ${params.declareMinionList.split(", ")}" )
-    def minionNotDeployList = params.declareMinionList.split(", ") - nodeList
-    def minionToDisableList = nodeList - params.declareMinionList.split(", ")
+    Set<String> declareMinionList = new HashSet<String>(params.minions_to_run.split(", "))
+
+    println ("Minion list from jenkins : ${declareMinionList}" )
+    minionNotDeployList = declareMinionList - nodeList
+    minionToDisableList = nodeList - declareMinionList
 
     println "This minions are not deployed ! ${minionNotDeployList}"
     println "Minion to disable : ${minionToDisableList}"

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -53,7 +53,7 @@ def run(params) {
             }
 
             stage('Sanity check') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
+//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
                 minionList = getMinionList()
                 println minionList.nodeList
                 println minionList.envVariableList

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -24,7 +24,7 @@ def run(params) {
                     checkout scm
                 }
                 // Clone sumaform
-                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
+                sh "set +x; source /home/maxime/jenkinsslave/credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
 
                 // Restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
@@ -43,11 +43,11 @@ def run(params) {
                     // Generate json file in the workspace
                     writeFile file: 'custom_repositories.json', text: params.custom_repositories, encoding: "UTF-8"
                     // Run Terracumber to deploy the environment
-                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk|data_disk|server_extra_nfs_mounts).*' --custom-repositories ${WORKSPACE}/custom_repositories.json --sumaform-backend ${params.sumaform_backend} --runstep provision"
+                    sh "set +x; source /home/maxime/jenkinsslave/credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk|data_disk|server_extra_nfs_mounts).*' --custom-repositories ${WORKSPACE}/custom_repositories.json --sumaform-backend ${params.sumaform_backend} --runstep provision"
                     // Generate features
                     sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_build_validation_features'"
                     // Generate rake files
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake jenkins:generate_rake_files_build_validation'"
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake :generate_rake_files_build_validation'"
                     deployed = true
                 }
             }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -58,6 +58,7 @@ def run(params) {
                 println "Node list from terraform ${minionList.nodeList}"
                 println "Env variable for cucumber ${minionList.envVariableList}"
                 println "Minion to disable : ${minionList.minionToDisableList}"
+                println "Env varaible to disable : ${minionList.envVariableListToDisable}"
 
             }
 
@@ -401,18 +402,15 @@ def getMinionList() {
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }
+
     def declareMinionList = params.minions_to_run.split(", ")
-
     println ("Minion list from jenkins : ${declareMinionList}" )
-//    def minionNotDeployList = declareMinionList - nodeList
-    def minionNotDeployList = declareMinionList.findAll { !nodeList.contains(it) }
-//    def minionToDisableList = nodeList - ( declareMinionList - minionNotDeployList )
+    def notDeployedMinionList = declareMinionList.findAll { !nodeList.contains(it) }
     def minionToDisableList = nodeList.findAll { !declareMinionList.contains(it) }
+    def envVariableListToDisable = minionToDisableList.replaceAll("ssh_minion", "sshminion").toUpperCase()
+    println "This minions are declared in jenkins but not deployed ! ${notDeployedMinionList}"
 
-    println "This minions are not deployed ! ${minionNotDeployList}"
-    println "Minion to disable : ${minionToDisableList}"
-
-    return [nodeList:nodeList, envVariableList:envVar, minionToDisableList:minionToDisableList]
+    return [nodeList:nodeList, envVariableList:envVar, minionToDisableList:minionToDisableList, envVariableListToDisable:envVariableListToDisable]
 }
 
 return this

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -401,6 +401,7 @@ def getMinionList() {
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }
+    println ("Minion list from jenkins ${params.declareMinionList}" )
     def minionToDisableList = nodeList - params.declareMinionList
     def minionNotDeployList = params.declareMinionList - nodeList
 

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -401,10 +401,10 @@ def getMinionList() {
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }
-    declareMinionList = params.minions_to_run.split(", ")
+    def declareMinionList = params.minions_to_run.split(", ")
 
     println ("Minion list from jenkins : ${declareMinionList}" )
-    minionNotDeployList = declareMinionList - nodeList
+    def minionNotDeployList = declareMinionList - nodeList
     minionToDisableList = nodeList - ( declareMinionList - minionNotDeployList )
 
     println "This minions are not deployed ! ${minionNotDeployList}"

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -55,9 +55,9 @@ def run(params) {
             stage('Sanity check') {
 //                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
                 minionList = getMinionList()
-                println minionList.nodeList
-                println minionList.envVariableList
-                println minionList.minionToDisableList
+                println "Node list from terraform ${minionList.nodeList}"
+                println "Env variable for cucumber ${minionList.envVariableList}"
+                println "Minion to disable : ${minionList.minionToDisableList}"
 
             }
 

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -53,12 +53,7 @@ def run(params) {
             }
 
             stage('Sanity check') {
-//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
-                minionList = getMinionList()
-                println "Node list from terraform ${minionList.nodeList}"
-                println "Env variable for cucumber ${minionList.envVariableList}"
-                println "Env varaible to disable : ${minionList.envVariableListToDisable}"
-
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
             }
 
             stage('Run core features') {
@@ -214,42 +209,42 @@ def run(params) {
                 archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
             }
 
-//            stage('Get results') {
-//                def error = 0
-//                if (deployed || !params.must_deploy) {
-//                    try {
-//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
-//                    } catch(Exception ex) {
-//                        println("ERROR: rake cucumber:build_validation_finishing failed")
-//                        error = 1
-//                    }
-//                    try {
-//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
-//                    } catch(Exception ex) {
-//                        println("ERROR: rake utils:generate_test_report failed")
-//                        error = 1
-//                    }
-//                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
-//                    publishHTML( target: [
-//                            allowMissing: true,
-//                            alwaysLinkToLastBuild: false,
-//                            keepAll: true,
-//                            reportDir: "${resultdirbuild}/cucumber_report/",
-//                            reportFiles: 'cucumber_report.html',
-//                            reportName: "Build Validation report"]
-//                    )
-//                    // junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
-//                }
-//                // Send email
-//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
-//                // Clean up old results
-//                sh "./clean-old-results -r ${resultdir}"
-//                // Fail pipeline if client stages failed
-//                if (env.client_stage_result_fail) {
-//                    error("Client stage failed")
-//                }
-//                sh "exit ${error}"
-//            }
+            stage('Get results') {
+                def error = 0
+                if (deployed || !params.must_deploy) {
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake cucumber:build_validation_finishing failed")
+                        error = 1
+                    }
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake utils:generate_test_report failed")
+                        error = 1
+                    }
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+                    publishHTML( target: [
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: false,
+                            keepAll: true,
+                            reportDir: "${resultdirbuild}/cucumber_report/",
+                            reportFiles: 'cucumber_report.html',
+                            reportName: "Build Validation report"]
+                    )
+                    // junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+                }
+                // Send email
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                // Clean up old results
+                sh "./clean-old-results -r ${resultdir}"
+                // Fail pipeline if client stages failed
+                if (env.client_stage_result_fail) {
+                    error("Client stage failed")
+                }
+                sh "exit ${error}"
+            }
         }
     }
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -401,7 +401,7 @@ def getMinionList() {
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }
-    Set<String> declareMinionList = new HashSet<String>(params.minions_to_run.split(", "))
+    declareMinionList = params.minions_to_run.split(", ")
 
     println ("Minion list from jenkins : ${declareMinionList}" )
     minionNotDeployList = declareMinionList - nodeList

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -405,7 +405,7 @@ def getMinionList() {
 
     println ("Minion list from jenkins : ${declareMinionList}" )
     minionNotDeployList = declareMinionList - nodeList
-    minionToDisableList = nodeList - declareMinionList
+    minionToDisableList = nodeList - ( declareMinionList - minionNotDeployList )
 
     println "This minions are not deployed ! ${minionNotDeployList}"
     println "Minion to disable : ${minionToDisableList}"

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -47,7 +47,7 @@ def run(params) {
                     // Generate features
                     sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_build_validation_features'"
                     // Generate rake files
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake :generate_rake_files_build_validation'"
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake jenkins:generate_rake_files_build_validation'"
                     deployed = true
                 }
             }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -406,6 +406,7 @@ def getMinionList() {
     def minionToDisableList = nodeList - params.declareMinionList.split(", ")
 
     println "This minions are not deployed ! ${minionNotDeployList}"
+    println "Minion to disable : ${minionToDisableList}"
 
     return [nodeList:nodeList, envVariableList:envVar, minionToDisableList:minionToDisableList]
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -402,8 +402,8 @@ def getMinionList() {
         }
     }
     println ("Minion list from jenkins : ${params.declareMinionList.split(", ")}" )
-    def minionToDisableList = nodeList - params.declareMinionList.split(", ")
     def minionNotDeployList = params.declareMinionList.split(", ") - nodeList
+    def minionToDisableList = nodeList - params.declareMinionList.split(", ")
 
     println "This minions are not deployed ! ${minionNotDeployList}"
 

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -407,7 +407,7 @@ def getMinionList() {
     println ("Minion list from jenkins : ${declareMinionList}" )
     def notDeployedMinionList = declareMinionList.findAll { !nodeList.contains(it) }
     def minionToDisableList = nodeList.findAll { !declareMinionList.contains(it) }
-    def envVariableListToDisable = minionToDisableList.replaceAll("ssh_minion", "sshminion").toUpperCase()
+    def envVariableListToDisable = minionToDisableList.collect { it.replaceAll("ssh_minion", "sshminion").toUpperCase() }
     println "This minions are declared in jenkins but not deployed ! ${notDeployedMinionList}"
 
     return [nodeList:nodeList, envVariableList:envVar, minionToDisableList:minionToDisableList, envVariableListToDisable:envVariableListToDisable]

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -401,12 +401,10 @@ def getMinionList() {
             envVar.add(instanceList[1].replaceAll("-", "_").replaceAll("sles", "sle").toUpperCase())
         }
     }
-    def minionToDisableList = nodeList
-    def minionsMissingFromParameters = params.declareMinionList
+    def minionToDisableList = nodeList - params.declareMinionList
+    def minionNotDeployList = params.declareMinionList - nodeList
 
-    minionToDisableList.removeAll(params.declareMinionList)
-    minionsMissingFromParameters.removeAll(nodeList)
-    println "This minions are not declared in the build validation list ! ${minionsMissingFromParameters}"
+    println "This minions are not deployed ! ${minionNotDeployList}"
 
     return [nodeList:nodeList, envVariableList:envVar, minionToDisableList:minionToDisableList]
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -24,7 +24,7 @@ def run(params) {
                     checkout scm
                 }
                 // Clone sumaform
-                sh "set +x; source /home/maxime/jenkinsslave/credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
+                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
 
                 // Restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
@@ -43,7 +43,7 @@ def run(params) {
                     // Generate json file in the workspace
                     writeFile file: 'custom_repositories.json', text: params.custom_repositories, encoding: "UTF-8"
                     // Run Terracumber to deploy the environment
-                    sh "set +x; source /home/maxime/jenkinsslave/credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk|data_disk|server_extra_nfs_mounts).*' --custom-repositories ${WORKSPACE}/custom_repositories.json --sumaform-backend ${params.sumaform_backend} --runstep provision"
+                    sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.terraform_bin}; export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk|data_disk|server_extra_nfs_mounts).*' --custom-repositories ${WORKSPACE}/custom_repositories.json --sumaform-backend ${params.sumaform_backend} --runstep provision"
                     // Generate features
                     sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake utils:generate_build_validation_features'"
                     // Generate rake files

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -54,6 +54,9 @@ def run(params) {
 
             stage('Sanity check') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:build_validation_sanity_check'"
+                minionList = getMinionList()
+                println minionList.envVar
+                println minionList.nodeList
             }
 
             stage('Run core features') {

--- a/jenkins_pipelines/environments/manager-4.2-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.2-qe-build-validation
@@ -1,6 +1,18 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber-provo') {
+    def minionList = 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
+            'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
+            'sle15sp1_client, sle15sp1_minion, sle15sp1_ssh_minion, ' +
+            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
+            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
+            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
+            'alma9_minion, alma9_ssh_minion, ' +
+            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
+            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
+            'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ' +
+            'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
+            'opensuse154arm_minion, opensuse154arm_ssh_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
@@ -18,6 +30,10 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
+            extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
+                    value: minionList,
+                    defaultValue: minionList,
+                    description: 'List of minions to be run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/manager-4.2-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.2-qe-build-validation
@@ -33,7 +33,7 @@ node('sumaform-cucumber-provo') {
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
-                    description: 'List of minions to be run during BV'),
+                    description: 'Node list to run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -1,7 +1,21 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber-provo') {
-    def minionList = 'essai'
+    def minionList = 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
+            'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
+            'sle15sp1_client, sle15sp1_minion, sle15sp1_ssh_minion, ' +
+            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
+            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
+            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
+            'alma9_minion, alma9_ssh_minion, ' +
+            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
+            'liberty9_minion, liberty9_ssh_minion, ' +
+            'oracle9_minion, oracle9_ssh_minion, ' +
+            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
+            'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+            'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
+            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
+            'slemicro51_minion, slemicro51_ssh_minion, slemicro52_minion, slemicro52_ssh_minion, slemicro53_minion, slemicro53_ssh_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
@@ -19,38 +33,9 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
-            string(name: 'test', defaultValue: "${minionList}", description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
-                    value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
-                            'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
-                            'sle15sp1_client, sle15sp1_minion, sle15sp1_ssh_minion, ' +
-                            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
-                            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
-                            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
-                            'alma9_minion, alma9_ssh_minion, ' +
-                            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
-                            'liberty9_minion, liberty9_ssh_minion, ' +
-                            'oracle9_minion, oracle9_ssh_minion, ' +
-                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-                            'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-                            'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
-                            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
-                            'slemicro51_minion, slemicro51_ssh_minion, slemicro52_minion, slemicro52_ssh_minion, slemicro53_minion, slemicro53_ssh_minion',
-                    defaultValue: 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
-                            'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
-                            'sle15sp1_client, sle15sp1_minion, sle15sp1_ssh_minion, ' +
-                            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
-                            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
-                            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
-                            'alma9_minion, alma9_ssh_minion, ' +
-                            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
-                            'liberty9_minion, liberty9_ssh_minion, ' +
-                            'oracle9_minion, oracle9_ssh_minion, ' +
-                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-                            'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-                            'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
-                            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
-                            'slemicro51_minion, slemicro51_ssh_minion, slemicro52_minion, slemicro52_ssh_minion, slemicro53_minion, slemicro53_ssh_minion',
+                    value: minionList,
+                    defaultValue: minionList,
                     description: 'List of minions to be run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
-            extendedChoice(name: 'minions',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30,
+            extendedChoice(name: 'minions',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: true, type: 'PT_CHECKBOX', visibleItemCount: 30,
                     value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
                             'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
                             'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +
@@ -52,7 +52,8 @@ node('sumaform-cucumber-provo') {
                             'opensuse154arm_minion, opensuse154arm_sshminion, ' +
                             'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion, ' +
                             'sle12sp5_buildhost, sle15sp4_buildhost, sle12sp5_terminal, sle15sp4_terminal, ' +
-                            'monitoringserver', 'List of minions to be run during BV'),
+                            'monitoringserver',
+                    description: 'List of minions to be run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
-            extendedChoice(name: 'declareMinionList',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
+            extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
                             'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
                             'sle15sp1_client, sle15sp1_minion, sle15sp1_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
-            extendedChoice(name: 'minions',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: true, type: 'PT_CHECKBOX', visibleItemCount: 30,
+            extendedChoice(name: 'minions',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: true, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
                             'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
                             'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber-provo') {
+    def minionList = 'essai'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
@@ -18,6 +19,7 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
+            string(name: 'test', defaultValue: "${minionList}", description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
                             'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -18,6 +18,41 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
+            extendedChoice(name: 'minions',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30,
+                    value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
+                            'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
+                            'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +
+                            'sle15sp2_client, sle15sp2_minion, sle15sp2_sshminion, ' +
+                            'sle15sp3_client, sle15sp3_minion, sle15sp3_sshminion, ' +
+                            'sle15sp4_client, sle15sp4_minion, sle15sp4_sshminion, ' +
+                            'alma9_minion, alma9_sshminion, ' +
+                            'centos7_client, centos7_minion, centos7_sshminion, ' +
+                            'liberty9_minion, liberty9_sshminion, ' +
+                            'oracle9_minion, oracle9_sshminion, ' +
+                            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion ' +
+                            'ubuntu1804_minion, ubuntu1804_sshminion, ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+                            'debian10_minion, debian10_sshminion, debian11_minion, debian11_sshminion, ' +
+                            'opensuse154arm_minion, opensuse154arm_sshminion, ' +
+                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion, ' +
+                            'sle12sp5_buildhost, sle15sp4_buildhost, sle12sp5_terminal, sle15sp4_terminal, ' +
+                            'monitoringserver',
+                    defaultValue: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
+                            'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
+                            'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +
+                            'sle15sp2_client, sle15sp2_minion, sle15sp2_sshminion, ' +
+                            'sle15sp3_client, sle15sp3_minion, sle15sp3_sshminion, ' +
+                            'sle15sp4_client, sle15sp4_minion, sle15sp4_sshminion, ' +
+                            'alma9_minion, alma9_sshminion, ' +
+                            'centos7_client, centos7_minion, centos7_sshminion, ' +
+                            'liberty9_minion, liberty9_sshminion, ' +
+                            'oracle9_minion, oracle9_sshminion, ' +
+                            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion ' +
+                            'ubuntu1804_minion, ubuntu1804_sshminion, ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+                            'debian10_minion, debian10_sshminion, debian11_minion, debian11_sshminion, ' +
+                            'opensuse154arm_minion, opensuse154arm_sshminion, ' +
+                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion, ' +
+                            'sle12sp5_buildhost, sle15sp4_buildhost, sle12sp5_terminal, sle15sp4_terminal, ' +
+                            'monitoringserver', 'List of minions to be run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
-            extendedChoice(name: 'minions',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: true, type: 'PT_CHECKBOX', visibleItemCount: 15,
+            extendedChoice(name: 'declareMinionList',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: true, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
                             'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
                             'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -19,36 +19,36 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'declareMinionList',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
-                    value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
-                            'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
-                            'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +
-                            'sle15sp2_client, sle15sp2_minion, sle15sp2_sshminion, ' +
-                            'sle15sp3_client, sle15sp3_minion, sle15sp3_sshminion, ' +
-                            'sle15sp4_client, sle15sp4_minion, sle15sp4_sshminion, ' +
-                            'alma9_minion, alma9_sshminion, ' +
-                            'centos7_client, centos7_minion, centos7_sshminion, ' +
-                            'liberty9_minion, liberty9_sshminion, ' +
-                            'oracle9_minion, oracle9_sshminion, ' +
-                            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion ' +
-                            'ubuntu1804_minion, ubuntu1804_sshminion, ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
-                            'debian10_minion, debian10_sshminion, debian11_minion, debian11_sshminion, ' +
-                            'opensuse154arm_minion, opensuse154arm_sshminion, ' +
-                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion',
-                    defaultValue: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
-                            'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
-                            'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +
-                            'sle15sp2_client, sle15sp2_minion, sle15sp2_sshminion, ' +
-                            'sle15sp3_client, sle15sp3_minion, sle15sp3_sshminion, ' +
-                            'sle15sp4_client, sle15sp4_minion, sle15sp4_sshminion, ' +
-                            'alma9_minion, alma9_sshminion, ' +
-                            'centos7_client, centos7_minion, centos7_sshminion, ' +
-                            'liberty9_minion, liberty9_sshminion, ' +
-                            'oracle9_minion, oracle9_sshminion, ' +
-                            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion ' +
-                            'ubuntu1804_minion, ubuntu1804_sshminion, ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
-                            'debian10_minion, debian10_sshminion, debian11_minion, debian11_sshminion, ' +
-                            'opensuse154arm_minion, opensuse154arm_sshminion, ' +
-                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion',
+                    value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
+                            'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
+                            'sle15sp1_client, sle15sp1_minion, sle15sp1_ssh_minion, ' +
+                            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
+                            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
+                            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
+                            'alma9_minion, alma9_ssh_minion, ' +
+                            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
+                            'liberty9_minion, liberty9_ssh_minion, ' +
+                            'oracle9_minion, oracle9_ssh_minion, ' +
+                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion ' +
+                            'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+                            'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
+                            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
+                            'slemicro51_minion, slemicro51_ssh_minion, slemicro52_minion, slemicro52_ssh_minion, slemicro53_minion, slemicro53_ssh_minion',
+                    defaultValue: 'sle12sp4_client, sle12sp4_minion, sle12sp4_ssh_minion, ' +
+                            'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
+                            'sle15sp1_client, sle15sp1_minion, sle15sp1_ssh_minion, ' +
+                            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
+                            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
+                            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
+                            'alma9_minion, alma9_ssh_minion, ' +
+                            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
+                            'liberty9_minion, liberty9_ssh_minion, ' +
+                            'oracle9_minion, oracle9_ssh_minion, ' +
+                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion ' +
+                            'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+                            'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
+                            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
+                            'slemicro51_minion, slemicro51_ssh_minion, slemicro52_minion, slemicro52_ssh_minion, slemicro53_minion, slemicro53_ssh_minion',
                     description: 'List of minions to be run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
-            extendedChoice(name: 'declareMinionList',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: true, type: 'PT_CHECKBOX', visibleItemCount: 15,
+            extendedChoice(name: 'declareMinionList',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
                             'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
                             'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -33,9 +33,7 @@ node('sumaform-cucumber-provo') {
                             'ubuntu1804_minion, ubuntu1804_sshminion, ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
                             'debian10_minion, debian10_sshminion, debian11_minion, debian11_sshminion, ' +
                             'opensuse154arm_minion, opensuse154arm_sshminion, ' +
-                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion, ' +
-                            'sle12sp5_buildhost, sle15sp4_buildhost, sle12sp5_terminal, sle15sp4_terminal, ' +
-                            'monitoringserver',
+                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion',
                     defaultValue: 'sle12sp4_client, sle12sp4_minion, sle12sp4_sshminion, ' +
                             'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
                             'sle15sp1_client, sle15sp1_minion, sle15sp1_sshminion, ' +
@@ -50,9 +48,7 @@ node('sumaform-cucumber-provo') {
                             'ubuntu1804_minion, ubuntu1804_sshminion, ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
                             'debian10_minion, debian10_sshminion, debian11_minion, debian11_sshminion, ' +
                             'opensuse154arm_minion, opensuse154arm_sshminion, ' +
-                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion, ' +
-                            'sle12sp5_buildhost, sle15sp4_buildhost, sle12sp5_terminal, sle15sp4_terminal, ' +
-                            'monitoringserver',
+                            'slemicro51_minion, slemicro51_sshminion, slemicro52_minion, slemicro52_sshminion, slemicro53_minion, slemicro53_sshminion',
                     description: 'List of minions to be run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -36,7 +36,7 @@ node('sumaform-cucumber-provo') {
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
-                    description: 'List of minions to be run during BV'),
+                    description: 'Node list to run during BV'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -29,7 +29,7 @@ node('sumaform-cucumber-provo') {
                             'centos7_client, centos7_minion, centos7_ssh_minion, ' +
                             'liberty9_minion, liberty9_ssh_minion, ' +
                             'oracle9_minion, oracle9_ssh_minion, ' +
-                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion ' +
+                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
                             'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
                             'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
                             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
@@ -44,7 +44,7 @@ node('sumaform-cucumber-provo') {
                             'centos7_client, centos7_minion, centos7_ssh_minion, ' +
                             'liberty9_minion, liberty9_ssh_minion, ' +
                             'oracle9_minion, oracle9_ssh_minion, ' +
-                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion ' +
+                            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
                             'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
                             'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +
                             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +


### PR DESCRIPTION
**What does this PR do?**

Add a new parameter for build validation allowing to disable some nodes during a run.
Build with this new parameter : https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-qe-build-validation-parallel/build?delay=0sec


I attempted to use both the `ExtendedChoice` and `Active Choice` Jenkins plugins to build the list of nodes, but unfortunately, the latter requires a plugin that is not currently installed on CI.
 Active Choice allows to create more complex list ( with sub-list or sub-choices depending on a first choice). It also add a Filter feature. To describe the parameters, Active Choice is using Groovy script. The limit is the script will be executed on Jenkins Master and so we will not have access to our test environment.

![filterActiveChoice](https://user-images.githubusercontent.com/55169628/229009995-c3ba2c4f-75c3-4bb3-b630-b7b63ee8f3c0.png)

I was unable with both plugins to use a file to describe the node list. Both plugins require to have this file on Jenkins Master. Since it is not possible to find this file in Jenkins agents (workers), we would need to manually upload and maintain it on the Jenkins master, which is not ideal. To address this, I have directly included the list description in the Jenkins parameter file.

**How does it work ?**

To disable the minions, change need to be made in two places during the pipeline: Sync repositories stage and the client stage. To accomplish this, I will use an environment variable with the disabled nodes and call the unset command during the repository sync feature call. For example, if all `sles15sp3_ssh_minion`, `sles15sp3_minion`, and `sles15sp3_client` nodes are disabled, `sles15sp3` will not be synchronized.

For the testing client stage, I will remove the disabled nodes from the nodeList, ensuring that stages for these clients will not be created. Since the minion list is now needed in two stages, I have created a new function getMinionList that retrieves the minion list from the Terraform plan list and Jenkins parameter, and creates a new node list with the information required for the stages.


**To be discuss**

**1 ) More nodes declared on Jenkins side** 
I have encountered a scenario where more nodes are declared in Jenkins than are actually deployed. Currently, I am only logging a message about this discrepancy. However, we should consider whether this should cause the pipeline to fail instead. What action should we take in this situation?

**2 ) ssh minion naming**
We are facing a naming inconsistency between our testsuite and cucumber bashrc, which is causing unnecessary complexity in our pipeline. While the naming conventions are similar, there is a difference in the use of underscores. This is leading to complexity in our pipeline scripts. We need to decide on a standardized naming convention to be used across both our testsuite and cucumber bashrc.

**3 ) sle and sles naming**

We also have a difference between sumaform and testsuite about sle and sles naming.




Issue: Fixes https://github.com/SUSE/spacewalk/issues/20856