### PR TITLE
Add CI MAC addresses for nested VM

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -216,6 +216,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-head-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:bf"]
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -226,6 +226,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["uyuni-master-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:df"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr1-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:0b"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr10-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:9b"]
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr2-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:1b"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr3-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:2b"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr4-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:3b"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr5-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:4b"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr6-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:5b"]
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr7-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:6b"]
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr8-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:7b"]
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -331,6 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_hosts = ["suma-pr9-min-nested"]
+  nested_vm_macs =  ["aa:b2:93:01:00:8b"]
   provider_settings = {
     pool               = "default"
     network_name       = null


### PR DESCRIPTION
This will specify the MAC addresses of the nested VM in the Salt bundle migration test. Before they were defined in an array in the test suite code which is not optimal.

### Links

- https://github.com/SUSE/spacewalk/issues/17238
- https://github.com/uyuni-project/sumaform/pull/1278