### PR TITLE
[BV] Add a random wait for boostrap and smoke test

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -365,6 +365,7 @@ def clientTestingStages() {
                     if (params.confirm_before_continue) {
                         input 'Press any key to start bootstraping the clients'
                     }
+                    randomWait()
                     echo 'Bootstrap clients'
                     res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
                     echo "Init clients status code: ${res_init_clients}"
@@ -378,6 +379,7 @@ def clientTestingStages() {
                     if (params.confirm_before_continue) {
                         input 'Press any key to start running the smoke tests'
                     }
+                    randomWait()
                     echo 'Run Smoke tests'
                     res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_smoke_tests_${node}'", returnStatus: true)
                     echo "Smoke tests status code: ${res_smoke_tests}"
@@ -426,6 +428,12 @@ def getNodesHandler() {
         MUSyncStatus[node] = false
     }
     return [nodeList:nodeListWithDisabledNodes, envVariableList:envVar, envVariableListToDisable:envVarDisabledNodes, MUSyncStatus:MUSyncStatus]
+}
+
+def randomWait() {
+    def randomWait = new Random().nextInt(30)
+    println "Waiting for ${randomWait} seconds"
+    sleep randomWait
 }
 
 return this


### PR DESCRIPTION
**What does this PR do ?**

During BV pipeline, some nodes bootstrap and smoke test will fail because of UI issues.
This UI issues could come from the server side or controller side.
In my tests, the bootstrap and smoke test were more spread out ( and less users ) because I was running all the stages ( add MU / activation Key / boostrap reposync). So my nodes were not bootstrapping all at the same time.

To avoid having all the nodes ( 30 ~ ) to create a session and try to bootstrap at the same time add a random sleep ranging from 0 to 30 seconds.

This solution is not tested yet. We don't know if it will improve stability.

**Other solution**
We could also create a resource when bootstrapping saying only [2-10] nodes can bootstrap at the same time.

This solution is still open to discussion.