### PR TITLE
[BV] Fix monitoring bootstrap

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -274,7 +274,7 @@ def clientTestingStages() {
             stage("${node}") {
                 echo "Testing ${node}"
             }
-            if (params.must_add_MU_repositories && !(node == "${monitoring_sle_version}_minion" && params.must_boot_monitoring)) {
+            if (params.must_add_MU_repositories && !(node == "${monitoring_sle_version}_minion" && params.enable_monitoring_stages)) {
                 stage("Add_MUs_${node}") {
                     if (node.contains('ssh_minion')) {
                         // SSH minion need minion MU channel. This section wait until minion finish creating MU channel

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -147,7 +147,7 @@ def run(params) {
                             if (params.confirm_before_continue) {
                                 input 'Press any key to start creating the Server Monitoring bootstrap repository'
                             }
-                            res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_monitoring_server")
+                            res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_monitoring_server'")
                             echo "Create Server Monitoring bootstrap repository status code: ${res_create_bootstrap_repos}"
                         }
                     }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -12,9 +12,6 @@ def run(params) {
 
         env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform"
 
-        // Monitoring doesn't have MU channel and is reusing sle minion channel. Specify which one.
-        env.monitoring_sle_version = 'sle15sp3'
-
         if (params.terraform_parallelism) {
             env.common_params = "${env.common_params} --parallelism ${params.terraform_parallelism}"
         }
@@ -129,7 +126,7 @@ def run(params) {
                                 input 'Press any key to start adding Maintenance Update repositories'
                             }
                             echo 'Add custom channels and MU repositories'
-                            res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${monitoring_sle_version}_minion'")
+                            res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${params.monitoring_sle_version}_minion'")
                             echo "Custom channels and MU repositories status code: ${res_mu_repos}"
 
                             res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'")
@@ -287,6 +284,8 @@ def clientTestingStages() {
                             mu_sync_status[minion_name_without_ssh]
                         }
                         println "MU channel available for ${node} "
+                    } else if (node == "${params.monitoring_sle_version}_minion" && params.must_boot_monitoring) {
+                        mu_sync_status[node] = true
                     } else {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start adding Maintenance Update repositories'

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -274,7 +274,7 @@ def clientTestingStages() {
             stage("${node}") {
                 echo "Testing ${node}"
             }
-            if (params.must_add_MU_repositories && !(node == "${monitoring_sle_version}_minion" && params.enable_monitoring_stages)) {
+            if (params.must_add_MU_repositories) {
                 stage("Add_MUs_${node}") {
                     if (node.contains('ssh_minion')) {
                         // SSH minion need minion MU channel. This section wait until minion finish creating MU channel
@@ -284,7 +284,7 @@ def clientTestingStages() {
                             mu_sync_status[minion_name_without_ssh]
                         }
                         println "MU channel available for ${node} "
-                    } else if (node == "${params.monitoring_sle_version}_minion" && params.must_boot_monitoring) {
+                    } else if (node == "${params.monitoring_sle_version}_minion" && params.enable_monitoring_stages) {
                         mu_sync_status[node] = true
                     } else {
                         if (params.confirm_before_continue) {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -166,16 +166,17 @@ def run(params) {
                 println('Monitoring server bootstrap failed ')
             }
 
-            // Call the minion testing.
-            try {
-                if (params.enable_client_stages) {
+            if (params.enable_client_stages) {
+                // Call the minion testing.
+                try {
                     stage('Clients stages') {
                         clientTestingStages()
                     }
+
+                } catch (Exception ex) {
+                    println('ERROR: one or more clients have failed')
+                    env.client_stage_result_fail = true
                 }
-            } catch (Exception ex) {
-                println('ERROR: one or more clients have failed')
-                env.client_stage_result_fail = true
             }
 
             stage('Prepare and run Retail') {

--- a/jenkins_pipelines/environments/manager-4.2-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.2-qe-build-validation
@@ -34,6 +34,7 @@ node('sumaform-cucumber-provo') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
+            string(name: 'monitoring_sle_version', defaultValue: 'sle15sp3', description: 'Server version used by monitoring server'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation
@@ -37,6 +37,7 @@ node('sumaform-cucumber-provo') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
+            string(name: 'monitoring_sle_version', defaultValue: 'sle15sp4', description: 'Server version used by monitoring server'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -1523,7 +1523,7 @@ module "monitoring-server" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  //sle15sp3-minion_additional_repos
+  //sle15sp4-minion_additional_repos
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation.tf
@@ -1523,7 +1523,8 @@ module "monitoring-server" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  //monitoring_additional_repos
+  //sle15sp3-minion_additional_repos
+
 }
 
 module "controller" {


### PR DESCRIPTION
**What does this PR is doing ?**

Synchronized sle15sp3 MU during Monitoring Server bootstrap so the repository is available for monitoring bootstrap.
Because sles15sp3 channel will be created during Monitoring Server stage, skip Add MU stage during sle15sp3 minion stage.


Currently tested in : https://ci.suse.de/blue/organizations/jenkins/manager-4.3-qe-build-validation-parallel/detail/manager-4.3-qe-build-validation-parallel/157/pipeline

Uyuni PR : https://github.com/uyuni-project/uyuni/pull/6824