### PR TITLE
Fix `nested_vm_mac` addresses for PR tests

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr1-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:0b"
+  nested_vm_mac =  "aa:b2:92:04:00:0b"
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr10-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:9b"
+  nested_vm_mac =  "aa:b2:92:04:00:9b"
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr2-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:1b"
+  nested_vm_mac =  "aa:b2:92:04:00:1b"
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr3-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:2b"
+  nested_vm_mac =  "aa:b2:92:04:00:2b"
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr4-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:3b"
+  nested_vm_mac =  "aa:b2:92:04:00:3b"
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr5-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:4b"
+  nested_vm_mac =  "aa:b2:92:04:00:4b"
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr6-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:5b"
+  nested_vm_mac =  "aa:b2:92:04:00:5b"
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr7-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:6b"
+  nested_vm_mac =  "aa:b2:92:04:00:6b"
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr8-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:7b"
+  nested_vm_mac =  "aa:b2:92:04:00:7b"
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -331,7 +331,7 @@ module "cucumber_testsuite" {
     }
   }
   nested_vm_host = "suma-pr9-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:8b"
+  nested_vm_mac =  "aa:b2:92:04:00:8b"
   provider_settings = {
     pool               = "default"
     network_name       = null


### PR DESCRIPTION
It seems the MAC addresses of the nested VMs in the PR test files were outdated. This PR fixes this.

See https://gitlab.suse.de/galaxy/infrastructure/-/blob/master/srv/salt/dhcpd-server/mgr_prv_suse_net/dhcpd.conf

```bash
grep -rin "nested_vm_mac"
./terracumber_config/tf_files/Uyuni-PR-tests-env4.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:3b"
./terracumber_config/tf_files/Uyuni-PR-tests-env1.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:0b"
./terracumber_config/tf_files/Uyuni-PR-tests-env5.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:4b"
./terracumber_config/tf_files/Uyuni-PR-tests-env8.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:7b"
./terracumber_config/tf_files/Uyuni-PR-tests-env9.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:8b"
./terracumber_config/tf_files/Uyuni-PR-tests-env2.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:1b"
./terracumber_config/tf_files/Uyuni-PR-tests-env6.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:5b"
./terracumber_config/tf_files/Uyuni-PR-tests-env7.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:6b"
./terracumber_config/tf_files/Uyuni-PR-tests-env3.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:2b"
./terracumber_config/tf_files/Uyuni-PR-tests-env10.tf:334:  nested_vm_mac =  "aa:b2:92:04:00:9b"
```