### PR TITLE
Remove unused alias in uyuni-bv config file

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-build-validation.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation.tf
@@ -85,7 +85,6 @@ terraform {
 }
 
 provider "libvirt" {
-  alias = "caipirinha"
   uri = "qemu+tcp://caipirinha.mgr.prv.suse.net/system"
 }
 


### PR DESCRIPTION
This alias is unnecessary and prevents the deployment from working. We need a default provider.

```bash
jenkins@jenkins-worker:~/jenkins-build/workspace/uyuni-master-qe-build-validation/results/sumaform> terraform plan
╷
│ Error: Missing required argument
│ 
│ The argument "uri" is required, but was not set.
```