### PR TITLE
QE: switch uyuni-bv to uyuni-released

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-build-validation.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation.tf
@@ -289,7 +289,7 @@ module "base_arm" {
 module "server" {
   source             = "./modules/server"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "srv"
   provider_settings = {
     mac                = "aa:b2:93:02:01:6d"
@@ -328,7 +328,7 @@ module "proxy" {
   }
   source             = "./modules/proxy"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "pxy"
   provider_settings = {
     mac                = "aa:b2:93:02:01:6e"
@@ -359,7 +359,7 @@ module "sles12sp4-client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "cli-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
@@ -383,7 +383,7 @@ module "sles12sp5-client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "cli-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -407,7 +407,7 @@ module "sles15sp1-client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "cli-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
@@ -431,7 +431,7 @@ module "sles15sp2-client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "cli-sles15sp2"
   image              = "sles15sp2o"
   provider_settings = {
@@ -455,7 +455,7 @@ module "sles15sp3-client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "cli-sles15sp3"
   image              = "sles15sp3o"
   provider_settings = {
@@ -479,7 +479,7 @@ module "sles15sp4-client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "cli-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -503,7 +503,7 @@ module "centos7-client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "cli-centos7"
   image              = "centos7o"
   provider_settings = {
@@ -529,7 +529,7 @@ module "sles12sp4-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
@@ -553,7 +553,7 @@ module "sles12sp5-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -577,7 +577,7 @@ module "sles15sp1-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
@@ -602,7 +602,7 @@ module "sles15sp2-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-sles15sp2"
   image              = "sles15sp2o"
   provider_settings = {
@@ -627,7 +627,7 @@ module "sles15sp3-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-sles15sp3"
   image              = "sles15sp3o"
   provider_settings = {
@@ -652,7 +652,7 @@ module "sles15sp4-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -677,7 +677,7 @@ module "alma9-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-alma9"
   image              = "almalinux9o"
   provider_settings = {
@@ -701,7 +701,7 @@ module "centos7-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-centos7"
   image              = "centos7o"
   provider_settings = {
@@ -727,7 +727,7 @@ module "liberty9-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-liberty9"
   image              = "libertylinux9o"
   provider_settings = {
@@ -751,7 +751,7 @@ module "oracle9-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-oracle9"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -775,7 +775,7 @@ module "rocky8-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-rocky8"
   image              = "rocky8o"
   provider_settings = {
@@ -799,7 +799,7 @@ module "rocky9-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-rocky9"
   image              = "rocky9o"
   provider_settings = {
@@ -823,7 +823,7 @@ module "ubuntu1804-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
@@ -847,7 +847,7 @@ module "ubuntu2004-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -871,7 +871,7 @@ module "ubuntu2204-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-ubuntu2204"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -894,7 +894,7 @@ module "debian10-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-debian10"
   image              = "debian10o"
   provider_settings = {
@@ -919,7 +919,7 @@ module "debian11-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-debian11"
   image              = "debian11o"
   provider_settings = {
@@ -944,7 +944,7 @@ module "opensuse154arm-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-opensuse154arm"
   image              = "opensuse154armo"
   provider_settings = {
@@ -970,7 +970,7 @@ module "slemicro51-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-slemicro51"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -995,7 +995,7 @@ module "slemicro52-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-slemicro52"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -1020,7 +1020,7 @@ module "slemicro53-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "min-slemicro53"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -1045,7 +1045,7 @@ module "sles12sp4-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
@@ -1064,7 +1064,7 @@ module "sles12sp5-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1083,7 +1083,7 @@ module "sles15sp1-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
@@ -1101,7 +1101,7 @@ module "sles15sp2-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-sles15sp2"
   image              = "sles15sp2o"
   provider_settings = {
@@ -1118,7 +1118,7 @@ module "sles15sp3-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-sles15sp3"
   image              = "sles15sp3o"
   provider_settings = {
@@ -1135,7 +1135,7 @@ module "sles15sp4-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1152,7 +1152,7 @@ module "alma9-sshminion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-alma9"
   image              = "almalinux9o"
   provider_settings = {
@@ -1175,7 +1175,7 @@ module "centos7-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-centos7"
   image              = "centos7o"
   provider_settings = {
@@ -1195,7 +1195,7 @@ module "liberty9-sshminion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-liberty9"
   image              = "libertylinux9o"
   provider_settings = {
@@ -1218,7 +1218,7 @@ module "oracle9-sshminion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-oracle9"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -1241,7 +1241,7 @@ module "rocky8-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-rocky8"
   image              = "rocky8o"
   provider_settings = {
@@ -1258,7 +1258,7 @@ module "rocky9-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-rocky9"
   image              = "rocky9o"
   provider_settings = {
@@ -1275,7 +1275,7 @@ module "ubuntu1804-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-ubuntu1804"
   image              = "ubuntu1804o"
   provider_settings = {
@@ -1292,7 +1292,7 @@ module "ubuntu2004-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1309,7 +1309,7 @@ module "ubuntu2204-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-ubuntu2204"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1328,7 +1328,7 @@ module "debian10-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-debian10"
   image              = "debian10o"
   provider_settings = {
@@ -1345,7 +1345,7 @@ module "debian11-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-debian11"
   image              = "debian11o"
   provider_settings = {
@@ -1362,7 +1362,7 @@ module "opensuse154arm-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-opensuse154arm"
   image              = "opensuse154armo"
   provider_settings = {
@@ -1381,7 +1381,7 @@ module "slemicro51-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-slemicro51"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -1398,7 +1398,7 @@ module "slemicro52-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-slemicro52"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -1415,7 +1415,7 @@ module "slemicro53-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "minssh-slemicro53"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -1432,7 +1432,7 @@ module "sles12sp5-buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "build-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1470,7 +1470,7 @@ module "sles15sp4-buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "build-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1508,7 +1508,7 @@ module "monitoring-server" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
+  product_version    = "uyuni-released"
   name               = "monitoring"
   image              = "sles15sp4o"
   provider_settings = {


### PR DESCRIPTION
As discussed with @juliogonzalez and @srbarrios, we will use `uyuni-released`. When a new Uyuni version will be released and Julio prepared everything, we use a JSON to inject the new code changes from `uyuni-master` as we do for example in our SUMA BV with the MU/MIs.