### PR TITLE
QE: Add Leap to the `base_retail` module in uyuni-bv

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-build-validation.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation.tf
@@ -222,7 +222,7 @@ module "base_retail" {
   name_prefix = "uyuni-bv-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o", "sles15sp3o", "sles15sp4o"]
+  images      = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "opensuse154o" ]
 
   mirror = "minima-mirror-bv.mgr.prv.suse.net"
   use_mirror_images = true


### PR DESCRIPTION
Since the Uyuni BV uses openSUSE Leap for the server and the proxy and the proxy is using the base_retail module, it is necessary to add the Leap image there.

https://github.com/SUSE/susemanager-ci/blob/0e617723e297a50f6de1e613dd94857a096714c0/terracumber_config/tf_files/Uyuni-Master-build-validation.tf#L325-L330

```bash
09:57:30  ╷
09:57:30  │ Error: Can't retrieve base volume with name 'uyuni-bv-opensuse154o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'uyuni-bv-opensuse154o'')
09:57:30  │ 
09:57:30  │   with module.proxy.module.proxy.module.host.libvirt_volume.main_disk[0],
09:57:30  │   on /home/jenkins/jenkins-build/workspace/uyuni-master-qe-build-validation/results/sumaform/backend_modules/libvirt/host/main.tf line 53, in resource "libvirt_volume" "main_disk":
09:57:30  │   53: resource "libvirt_volume" "main_disk" {
```