### PR TITLE
Make sonarcloud PR variables detection more robust

### DIFF
--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -76,8 +76,8 @@ pipeline {
             steps {
                 echo 'Run sonarcloud scanner'
                 sh "UYUNI_CLONE=`ls -d uyuni*`; " +
-                    "PR_BASE=`curl -n https://api.github.com/repos/uyuni-project/uyuni/pulls/${params.PR_NUMBER} | grep -A3 '\"base\"' | grep ref | sed 's/^ *\"ref\": \"\\([^\"]*\\)\",/\\1/'`; " +
-                    "PR_BRANCH=`curl -n https://api.github.com/repos/uyuni-project/uyuni/pulls/${params.PR_NUMBER} | grep -A3 '\"head\"' | grep ref | sed 's/^ *\"ref\": \"\\([^\"]*\\)\",/\\1/'`; " +
+                    "PR_BASE=`curl -n https://api.github.com/repos/uyuni-project/uyuni/pulls/${params.PR_NUMBER} | grep -A3 '\"base\"' | grep '\"ref\"' | sed 's/^ *\"ref\": \"\\([^\"]*\\)\",/\\1/'`; " +
+                    "PR_BRANCH=`curl -n https://api.github.com/repos/uyuni-project/uyuni/pulls/${params.PR_NUMBER} | grep -A3 '\"head\"' | grep '\"ref\"' | sed 's/^ *\"ref\": \"\\([^\"]*\\)\",/\\1/'`; " +
                     "cd \$UYUNI_CLONE; " +
                     "mkdir -p .sonar; " +
                     "source /var/lib/jenkins/.sonar-credentials; " +


### PR DESCRIPTION
Don't fail if there is the string `ref` in the PR label.