### PR TITLE
Set up new openqa installation jobs

### DIFF
--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -3,19 +3,19 @@ def run(params) {
         stage('Installation') {
             script {
               if (params.Installation_Type == 'online') {
-                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_online.json params-run-installation-43.json;"
+                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation && cp params-run-installation-43_online.json params-run-installation-43.json;"
               } else {
-                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_full.json params-run-installation-43.json;"
+                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation && cp params-run-installation-43_full.json params-run-installation-43.json;"
               }
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"
+            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"
         }
 
         stage('Run') {
-            // sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"
-            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; cat params-run-installation-43.json;"
+            // sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation/ && /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"
+            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation/ && cat params-run-installation-43.json;"
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -1,21 +1,16 @@
 def run(params) {
     timestamps {
-            stage('Installation') {
-              steps {
-                script {
-                  if (params.Installation_Type == 'online') {
-                    sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_online.json params-run-installation-43.json;"
-                  } else {
-                    sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_full.json params-run-installation-43.json;"
-                  }
-                }
+        stage('Installation') {
+            script {
+              if (params.Installation_Type == 'online') {
+                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_online.json params-run-installation-43.json;"
+              } else {
+                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_full.json params-run-installation-43.json;"
               }
             }
-            stage('Configuration of ISO_URL') {
-              steps {
-                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"
-              }
-            }
+        }
+        stage('Configuration of ISO_URL') {
+            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"
         }
 
         stage('Run') {
@@ -23,6 +18,7 @@ def run(params) {
             sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; cat params-run-installation-43.json;"
         }
     }
+}
 
 
 return this

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -10,7 +10,7 @@ def run(params) {
             }
         }
         stage('Configuration of ISO_URL') {
-            sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"'
+            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cat params-run-installation-43.json | jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' > params-run-installation-43.json\""
         }
 
         stage('Run') {

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -10,12 +10,11 @@ def run(params) {
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43.json\""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43.json; cat params-run-installation-43.json;\""
         }
 
         stage('Run') {
-            // sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/;/root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"'
-            sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/;  cat params-run-installation-43.json;"'
+            sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"'
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -1,20 +1,21 @@
 def run(params) {
     timestamps {
+
         stage('Installation') {
             script {
               if (params.Installation_Type == 'online') {
-                sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_online.json params-run-installation-43.json;"'
-              } else {
-                sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_full.json params-run-installation-43.json;"'
+                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43-online.json; cat params-run-installation-43-online.json;\""
+                    sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 online\n"'
+              }
+              else {
+                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43-offline.json; cat params-run-installation-43-offline.json;\""
+                    sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 offline\n"'
               }
             }
         }
-        stage('Configuration of ISO_URL') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43.json; cat params-run-installation-43.json;\""
-        }
 
         stage('Run') {
-            sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"'
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type} \n""
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -10,7 +10,7 @@ def run(params) {
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43.json\""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && cat params-run-installation-43.json.tmp; cat params-run-installation-43.json\""
         }
 
         stage('Run') {

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -10,7 +10,7 @@ def run(params) {
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cat params-run-installation-43.json | jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' > params-run-installation-43.json\""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43.json\""
         }
 
         stage('Run') {

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -5,11 +5,9 @@ def run(params) {
             script {
               if (params.Installation_Type == 'online') {
                     sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-online.json > params-run-installation-43-online.json.tmp && mv params-run-installation-43-online.json.tmp params-run-installation-43-online.json; cat params-run-installation-43-online.json;\""
-                    sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 online\n"'
               }
               else {
                     sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-offline.json > params-run-installation-43-offline.json.tmp && mv params-run-installation-43-offline.json.tmp params-run-installation-43-offline.json; cat params-run-installation-43-offline.json;\""
-                    sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 offline\n"'
               }
             }
         }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -1,6 +1,5 @@
 def run(params) {
     timestamps {
-          stages {
             stage('Installation') {
               steps {
                 script {
@@ -17,7 +16,6 @@ def run(params) {
                 sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"
               }
             }
-          }
         }
 
         stage('Run') {

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -15,7 +15,7 @@ def run(params) {
         }
 
         stage('Run') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type} \n""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; # /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type} \n""
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -5,9 +5,9 @@ def run(params) {
               steps {
                 script {
                   if (params.Installation_Type == 'online') {
-                    sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_online.json params-run-installation-43.json;'
+                    sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_online.json params-run-installation-43.json;"
                   } else {
-                    sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_full.json params-run-installation-43.json;'
+                    sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_full.json params-run-installation-43.json;"
                   }
                 }
               }
@@ -22,7 +22,7 @@ def run(params) {
 
         stage('Run') {
             // sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"
-            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; cat params-run-installation-43.json;
+            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; cat params-run-installation-43.json;"
         }
     }
 

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -1,0 +1,30 @@
+def run(params) {
+    timestamps {
+          stages {
+            stage('Installation') {
+              steps {
+                script {
+                  if (params['Installation Type'] == 'Online') {
+                    sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_online.json params-run-installation-43.json;'
+                  } else {
+                    sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_full.json params-run-installation-43.json;'
+                  }
+                }
+              }
+            }
+            stage('Configuration of ISO_URL') {
+              steps {
+                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"
+              }
+            }
+          }
+        }
+
+        stage('Run') {
+            // sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"
+            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de ; cd /root/openqa-suma-installation/; cat params-run-installation-43.json;
+        }
+    }
+
+
+return this

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -15,7 +15,7 @@ def run(params) {
         }
 
         stage('Run') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; # /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type}\n""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; # /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type}\n\""
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -2,13 +2,7 @@ def run(params) {
     timestamps {
 
         stage('Parameterize') {
-            script {
-              if (params.Installation_Type == 'online') {
-                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-online.json > params-run-installation-43-online.json.tmp && mv params-run-installation-43-online.json.tmp params-run-installation-43-online.json; cat params-run-installation-43-online.json;\""
-              }
-              else {
-                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-offline.json > params-run-installation-43-offline.json.tmp && mv params-run-installation-43-offline.json.tmp params-run-installation-43-offline.json; cat params-run-installation-43-offline.json;\""
-              }
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-${params.Installation_Type}.json > params-run-installation-43-${params.Installation_Type}.json.tmp && mv params-run-installation-43-${params.Installation_Type}.json.tmp params-run-installation-43-${params.Installation_Type}.json; cat params-run-installation-43-${params.Installation_Type}.json;\""
             }
         }
 

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -10,7 +10,7 @@ def run(params) {
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && cat params-run-installation-43.json.tmp; cat params-run-installation-43.json\""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && cat params-run-installation-43.json.tmp; cat params-run-installation-43.json\""
         }
 
         stage('Run') {

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -1,21 +1,21 @@
 def run(params) {
     timestamps {
 
-        stage('Installation') {
+        stage('Parameterize') {
             script {
               if (params.Installation_Type == 'online') {
-                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43-online.json; cat params-run-installation-43-online.json;\""
+                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-online.json > params-run-installation-43-online.json.tmp && mv params-run-installation-43-online.json.tmp params-run-installation-43-online.json; cat params-run-installation-43-online.json;\""
                     sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 online\n"'
               }
               else {
-                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43-offline.json; cat params-run-installation-43-offline.json;\""
+                    sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-offline.json > params-run-installation-43-offline.json.tmp && mv params-run-installation-43-offline.json.tmp params-run-installation-43-offline.json; cat params-run-installation-43-offline.json;\""
                     sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 offline\n"'
               }
             }
         }
 
         stage('Run') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; # /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type}\n\""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type}\n\""
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -3,7 +3,6 @@ def run(params) {
 
         stage('Parameterize') {
             sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43-${params.Installation_Type}.json > params-run-installation-43-${params.Installation_Type}.json.tmp && mv params-run-installation-43-${params.Installation_Type}.json.tmp params-run-installation-43-${params.Installation_Type}.json; cat params-run-installation-43-${params.Installation_Type}.json;\""
-            }
         }
 
         stage('Run') {

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -15,7 +15,7 @@ def run(params) {
         }
 
         stage('Run') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; # /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type} \n""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation/; # /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43 ${params.Installation_Type}\n""
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -3,19 +3,19 @@ def run(params) {
         stage('Installation') {
             script {
               if (params.Installation_Type == 'online') {
-                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation && cp params-run-installation-43_online.json params-run-installation-43.json;"
+                sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_online.json params-run-installation-43.json;"'
               } else {
-                sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation && cp params-run-installation-43_full.json params-run-installation-43.json;"
+                sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_full.json params-run-installation-43.json;"'
               }
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"
+            sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cat params-run-installation-43.json | jq '. + {\"ISO_URL\": \"${params.ISO_URL}\" }' > params-run-installation-43.json"'
         }
 
         stage('Run') {
-            // sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation/ && /root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"
-            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de && cd /root/openqa-suma-installation/ && cat params-run-installation-43.json;"
+            // sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/;/root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"'
+            sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/;  cat params-run-installation-43.json;"'
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -3,19 +3,19 @@ def run(params) {
         stage('Installation') {
             script {
               if (params.Installation_Type == 'online') {
-                sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_online.json params-run-installation-43.json;"'
+                sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_online.json params-run-installation-43.json;"'
               } else {
-                sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_full.json params-run-installation-43.json;"'
+                sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation ;cp params-run-installation-43_full.json params-run-installation-43.json;"'
               }
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cat params-run-installation-43.json | jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' > params-run-installation-43.json\""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cat params-run-installation-43.json | jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' > params-run-installation-43.json\""
         }
 
         stage('Run') {
             // sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/;/root/openqa-suma-installation/run-openqa-test.sh $BUILD_NUMBER 43\n"'
-            sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/;  cat params-run-installation-43.json;"'
+            sh 'ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de "cd /root/openqa-suma-installation/;  cat params-run-installation-43.json;"'
         }
     }
 }

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -4,7 +4,7 @@ def run(params) {
             stage('Installation') {
               steps {
                 script {
-                  if (params['Installation Type'] == 'Online') {
+                  if (params.Installation_Type == 'online') {
                     sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_online.json params-run-installation-43.json;'
                   } else {
                     sh 'ssh -v -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de; cd /root/openqa-suma-installation; cp params-run-installation-43_full.json params-run-installation-43.json;'

--- a/jenkins_pipelines/environments/common/openqa.groovy
+++ b/jenkins_pipelines/environments/common/openqa.groovy
@@ -10,7 +10,7 @@ def run(params) {
             }
         }
         stage('Configuration of ISO_URL') {
-            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && cat params-run-installation-43.json.tmp; cat params-run-installation-43.json\""
+            sh "ssh -o StrictHostKeyChecking=no root@openqa-executor.mgr.suse.de \"cd /root/openqa-suma-installation; jq '. + {\\\"ISO_URL\\\": \\\"${params.ISO_URL}\\\" }' params-run-installation-43.json > params-run-installation-43.json.tmp && mv params-run-installation-43.json.tmp params-run-installation-43.json\""
         }
 
         stage('Run') {

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
@@ -9,6 +9,7 @@ node('sumaform-cucumber') {
               name: 'Installation_Type',
               defaultValue: 'offline',
               description: 'online or offline, do not touch'
+            )
             string(
               name: 'ISO_URL',
               defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
@@ -8,7 +8,7 @@ node('sumaform-cucumber') {
             string(
               name: 'Installation_Type',
               defaultValue: 'offline',
-              description: 'online or offline, do not touch'
+              description: 'online or offline, do not touch, this depends on which job you are running'
             ),
             string(
               name: 'ISO_URL',

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
@@ -1,0 +1,25 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        parameters([
+            string(
+              name: 'Installation_Type',
+              defaultValue: 'offline',
+              description: 'online or offline, do not touch'
+            string(
+              name: 'ISO_URL',
+              defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',
+              description: 'Enter the URL of the image you want to test in http, NOT https'
+            )
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/openqa.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
@@ -9,7 +9,7 @@ node('sumaform-cucumber') {
               name: 'Installation_Type',
               defaultValue: 'offline',
               description: 'online or offline, do not touch'
-            )
+            ),
             string(
               name: 'ISO_URL',
               defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
@@ -5,7 +5,10 @@ node('sumaform-cucumber') {
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
-            choice(name: 'Installation_Type', choices: ['online', 'offline'], description: 'Select the type of installation you want, with SCC registration it uses Online, without SCC it uses Offline'),
+            string(
+              name: 'Installation_Type',
+              defaultValue: 'online',
+              description: 'online or offline, do not touch'
             string(
               name: 'ISO_URL',
               defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
@@ -8,7 +8,7 @@ node('sumaform-cucumber') {
             string(
               name: 'Installation_Type',
               defaultValue: 'online',
-              description: 'online or offline, do not touch'
+              description: 'online or offline, do not touch, this depends on which job you are running'
             ),
             string(
               name: 'ISO_URL',

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
@@ -12,7 +12,7 @@ node('sumaform-cucumber') {
             ),
             string(
               name: 'ISO_URL',
-              defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',
+              defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Online-x86_64-Media1.iso',
               description: 'Enter the URL of the image you want to test in http, NOT https'
             )
         ])

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
@@ -9,7 +9,7 @@ node('sumaform-cucumber') {
               name: 'Installation_Type',
               defaultValue: 'online',
               description: 'online or offline, do not touch'
-            )
+            ),
             string(
               name: 'ISO_URL',
               defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
@@ -9,6 +9,7 @@ node('sumaform-cucumber') {
               name: 'Installation_Type',
               defaultValue: 'online',
               description: 'online or offline, do not touch'
+            )
             string(
               name: 'ISO_URL',
               defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',

--- a/jenkins_pipelines/environments/openqa
+++ b/jenkins_pipelines/environments/openqa
@@ -8,7 +8,7 @@ node('sumaform-cucumber') {
             choice(name: 'Installation_Type', choices: ['online', 'offline'], description: 'Select the type of installation you want, with SCC registration it uses Online, without SCC it uses Offline'),
             string(
               name: 'ISO_URL',
-              defaultValue: '',
+              defaultValue: 'http://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/SLE-15-SP4-Full-x86_64-Media1.iso',
               description: 'Enter the URL of the image you want to test in http, NOT https'
             )
         ])

--- a/jenkins_pipelines/environments/openqa
+++ b/jenkins_pipelines/environments/openqa
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber-provo') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        parameters([
+          parameters {
+            choice(
+              name: 'Installation Type',
+              choices: ['Online', 'Offline'],
+              description: 'Select the type of installation'
+            )
+            string(
+              name: 'ISO_URL',
+              defaultValue: '',
+              description: 'Enter the URL of the image you want to test in http, NOT https'
+            )
+          }
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    def pipeline = load "jenkins_pipelines/environments/common/openqa.groovy"
+    pipeline.run(params)
+}

--- a/jenkins_pipelines/environments/openqa
+++ b/jenkins_pipelines/environments/openqa
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber-provo') {
+node('sumaform-cucumber') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/openqa
+++ b/jenkins_pipelines/environments/openqa
@@ -5,9 +5,8 @@ node('sumaform-cucumber') {
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
-          parameters {
             string(
-              name: 'Installation Type',
+              name: 'Installation_Type',
               defaultValue: 'Online',
               description: 'Select the type of installation'
             )
@@ -16,7 +15,6 @@ node('sumaform-cucumber') {
               defaultValue: '',
               description: 'Enter the URL of the image you want to test in http, NOT https'
             )
-          }
         ])
     ])
 

--- a/jenkins_pipelines/environments/openqa
+++ b/jenkins_pipelines/environments/openqa
@@ -6,9 +6,9 @@ node('sumaform-cucumber') {
         disableConcurrentBuilds(),
         parameters([
           parameters {
-            choice(
+            string(
               name: 'Installation Type',
-              choices: ['Online', 'Offline'],
+              defaultValue: 'Online',
               description: 'Select the type of installation'
             )
             string(

--- a/jenkins_pipelines/environments/openqa
+++ b/jenkins_pipelines/environments/openqa
@@ -5,11 +5,7 @@ node('sumaform-cucumber') {
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
-            string(
-              name: 'Installation_Type',
-              defaultValue: 'Online',
-              description: 'Select the type of installation'
-            )
+            choice(name: 'Installation_Type', choices: ['online', 'offline'], description: 'Select the type of installation you want, with SCC registration it uses Online, without SCC it uses Offline'),
             string(
               name: 'ISO_URL',
               defaultValue: '',


### PR DESCRIPTION
This creates 2 pipelines, one for online and one for offline installation in openqa.

Essentially we are setting up a json file that contains the variables we want to override/send to openQA and then we use that json with running the script from the openqa-executor. 

The only actual variable that you can customize is the ISO_URL for now the default it the latest from https://download.suse.de/ibs/SUSE:/SLE-15-SP4:/Update:/QR:/TEST/images/iso/

Both these jobs are running from my fork currently here:

Online: https://ci.suse.de/view/Manager/view/Manager-qe/job/openqa-installation_TEST2/ (already have a ticket with infra to rename)
Offline: https://ci.suse.de/view/Manager/view/Manager-qe/job/manager-4.3-qe-openqa-offline-installation/