### PR TITLE
Bv hard simplication

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -79,6 +79,9 @@ def run(params) {
             stage('Add MUs Proxy') {
                 if (params.must_add_MU_repositories && params.enable_proxy_stages) {
                     echo 'Add proxy MUs'
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start adding Maintenance Update repositories'
+                    }
                     echo 'Add custom channels and MU repositories'
                     res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_proxy'")
                     echo "Custom channels and MU repositories status code: ${res_mu_repos}"
@@ -91,6 +94,9 @@ def run(params) {
             stage('Add Activation Keys Proxy') {
                 if (params.must_add_keys && params.enable_proxy_stages) {
                     echo 'Add proxy activation key'
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start adding activation keys'
+                    }
                     res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_proxy'")
                     echo "Add Proxy Activation Key status code: ${res_add_keys}"
                 }
@@ -98,12 +104,18 @@ def run(params) {
             stage('Create bootstrap repository Proxy') {
                 if (params.must_create_bootstrap_repos && params.enable_proxy_stages) {
                     echo 'Create bootstrap repository ${node}'
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start creating the proxy bootstrap repository'
+                    }
                     res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_proxy'")
                     echo "Create Proxy bootstrap repository status code: ${res_create_bootstrap_repos}"
                 }
             }
             stage('Bootstrap Proxy') {
                 if (params.must_boot_node && params.enable_proxy_stages) {
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start bootstraping the Proxy'
+                    }
                     res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_proxy'")
                     echo "Init Proxy status code: ${res_init_proxy}"
                 }
@@ -117,6 +129,9 @@ def run(params) {
                 if (params.enable_monitoring_stages) {
                     stage('Add MUs Monitoring') {
                         if (params.must_add_MU_repositories && params.enable_monitoring_stages) {
+                            if (params.confirm_before_continue) {
+                                input 'Press any key to start adding Maintenance Update repositories'
+                            }
                             echo 'Add custom channels and MU repositories'
                             res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${params.monitoring_sle_version}_minion'")
                             echo "Custom channels and MU repositories status code: ${res_mu_repos}"
@@ -129,6 +144,9 @@ def run(params) {
                     stage('Add Activation Keys Monitoring') {
                         if (params.must_add_keys && params.enable_monitoring_stages) {
                             echo 'Add server monitoring activation key'
+                            if (params.confirm_before_continue) {
+                                input 'Press any key to start adding activation keys'
+                            }
                             res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_monitoring_server'")
                             echo "Add Server Monitoring Activation Key status code: ${res_add_keys}"
                         }
@@ -136,15 +154,23 @@ def run(params) {
                     stage('Create bootstrap repository Monitoring') {
                         if (params.must_create_bootstrap_repos && params.enable_monitoring_stages) {
                             echo 'Create server monitoring bootstrap repository'
+                            if (params.confirm_before_continue) {
+                                input 'Press any key to start creating the Server Monitoring bootstrap repository'
+                            }
                             res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_monitoring_server'")
                             echo "Create Server Monitoring bootstrap repository status code: ${res_create_bootstrap_repos}"
                         }
                     }
                     stage('Bootstrap Monitoring Server') {
                         if (params.must_boot_node && params.enable_monitoring_stages) {
-                            echo 'Register monitoring server as minion with gui'
-                            res_init_monitoring = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_monitoring'")
-                            echo "Init Monitoring Server status code: ${res_init_monitoring}"
+                            if (params.must_boot_monitoring && params.enable_monitoring_stages) {
+                                if (params.confirm_before_continue) {
+                                    input 'Press any key to start bootstraping the Monitoring Server'
+                                }
+                                echo 'Register monitoring server as minion with gui'
+                                res_init_monitoring = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_monitoring'")
+                                echo "Init Monitoring Server status code: ${res_init_monitoring}"
+                            }
                         }
                     }
                 }
@@ -168,6 +194,9 @@ def run(params) {
 
             stage('Prepare and run Retail') {
                 if (params.must_prepare_retail) {
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start running the retail tests'
+                    }
                     echo 'Prepare Proxy for Retail'
                     res_retail_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_retail_proxy'", returnStatus: true)
                     echo "Retail proxy status code: ${res_retail_proxy}"
@@ -181,6 +210,9 @@ def run(params) {
             }
 
             stage('Containerization') {
+                if (params.confirm_before_continue) {
+                    input 'Press any key to start running the containerization tests'
+                }
                 if (params.must_run_containerization_tests) {
                     echo 'Prepare Proxy as Pod and run basic tests'
                     res_container_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_containerization'", returnStatus: true)
@@ -269,6 +301,9 @@ def clientTestingStages() {
                     } else if (node == "${params.monitoring_sle_version}_minion" && params.enable_monitoring_stages) {
                         mu_sync_status[node] = true
                     } else {
+                        if (params.confirm_before_continue) {
+                            input 'Press any key to start adding Maintenance Update repositories'
+                        }
                         echo 'Add custom channels and MU repositories'
                         res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${node}'", returnStatus: true)
                         if (res_mu_repos != 0) {
@@ -290,6 +325,9 @@ def clientTestingStages() {
                     // We have this condition inside the stage to see in Jenkins which minion is skipped
                     if (json_matching_non_MU_data.containsKey(node)) {
                         def build_validation_non_MU_script = json_matching_non_MU_data["${node}"]
+                        if (params.confirm_before_continue) {
+                            input 'Press any key to start adding common channels'
+                        }
                         echo 'Add non MU Repositories'
                         res_non_MU_repositories = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:${build_validation_non_MU_script}'", returnStatus: true)
                         echo "Non MU Repositories status code: ${res_non_MU_repositories}"
@@ -306,6 +344,9 @@ def clientTestingStages() {
             }
             stage("Add Activation Keys ${node}") {
                 if (params.must_add_keys) {
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start adding activation keys'
+                    }
                     echo 'Add Activation Keys'
                     res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_${node}'", returnStatus: true)
                     echo "Add Activation Keys status code: ${res_add_keys}"
@@ -317,6 +358,9 @@ def clientTestingStages() {
             stage("Create bootstrap repository ${node}") {
                 if (params.must_create_bootstrap_repos) {
                     if (!node.contains('ssh')) {
+                        if (params.confirm_before_continue) {
+                            input 'Press any key to start creating bootstrap repositories'
+                        }
                         // Employ a lock resource to prevent concurrent calls to create the bootstrap repository in the manager.
                         // Utilize a try-catch mechanism to release the resource for other nodes in the event of a failed bootstrap.
                         lock(resource: mgrCreateBootstrapRepo, timeout: 320) {
@@ -336,6 +380,9 @@ def clientTestingStages() {
             }
             stage("Bootstrap client ${node}") {
                 if (params.must_boot_node) {
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start bootstraping the clients'
+                    }
                     randomWait()
                     echo 'Bootstrap clients'
                     res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
@@ -347,6 +394,9 @@ def clientTestingStages() {
             }
             stage("Run Smoke Tests ${node}") {
                 if (params.must_run_tests) {
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start running the smoke tests'
+                    }
                     randomWait()
                     echo 'Run Smoke tests'
                     res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export BUILD_VALIDATION=true; cd /root/spacewalk/testsuite; rake cucumber:build_validation_smoke_tests_${node}'", returnStatus: true)

--- a/jenkins_pipelines/environments/manager-4.2-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.2-qe-build-validation-NUE
@@ -29,13 +29,11 @@ node('sumaform-cucumber') {
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp3', description: 'Server version used by monitoring server'),
-            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
@@ -47,15 +45,11 @@ node('sumaform-cucumber') {
             booleanParam(name: 'must_add_non_MU_repositories', defaultValue: true, description: 'Add non MU channels'),
             booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
             booleanParam(name: 'must_create_bootstrap_repos', defaultValue: true, description: 'Create bootstrap repositories'),
-            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
-            booleanParam(name: 'must_boot_monitoring', defaultValue: true, description: 'Bootstrap Monitoring Server'),
-            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_boot_node', defaultValue: true, description: 'Bootstrap Node'),
             booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
             booleanParam(name: 'must_prepare_retail', defaultValue: true, description: 'Prepare and run Retail'),
             booleanParam(name: 'must_run_containerization_tests', defaultValue: true, description: 'Run Containerization Tests'),
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
-            string(name: 'capybara_timeout', defaultValue: '30', description: 'Capybara max. waiting time'),
-            string(name: 'default_timeout', defaultValue: '300', description: 'Default timeout used in our Test Framework'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools MU Repositories for each client, in json format')
             ])
     ])

--- a/jenkins_pipelines/environments/manager-4.2-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.2-qe-build-validation-PRV
@@ -29,13 +29,11 @@ node('sumaform-cucumber-provo') {
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp3', description: 'Server version used by monitoring server'),
-            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
@@ -47,15 +45,11 @@ node('sumaform-cucumber-provo') {
             booleanParam(name: 'must_add_non_MU_repositories', defaultValue: true, description: 'Add non MU channels'),
             booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
             booleanParam(name: 'must_create_bootstrap_repos', defaultValue: true, description: 'Create bootstrap repositories'),
-            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
-            booleanParam(name: 'must_boot_monitoring', defaultValue: true, description: 'Bootstrap Monitoring Server'),
-            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_boot_node', defaultValue: true, description: 'Bootstrap Node'),
             booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
             booleanParam(name: 'must_prepare_retail', defaultValue: true, description: 'Prepare and run Retail'),
             booleanParam(name: 'must_run_containerization_tests', defaultValue: true, description: 'Run Containerization Tests'),
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
-            string(name: 'capybara_timeout', defaultValue: '30', description: 'Capybara max. waiting time'),
-            string(name: 'default_timeout', defaultValue: '300', description: 'Default timeout used in our Test Framework'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools MU Repositories for each client, in json format')
             ])
     ])

--- a/jenkins_pipelines/environments/manager-4.2-qe-sle-update
+++ b/jenkins_pipelines/environments/manager-4.2-qe-sle-update
@@ -29,13 +29,11 @@ node('sumaform-cucumber-provo') {
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp3', description: 'Server version used by monitoring server'),
-            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
@@ -47,14 +45,10 @@ node('sumaform-cucumber-provo') {
             booleanParam(name: 'must_add_non_MU_repositories', defaultValue: true, description: 'Add non MU channels'),
             booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
             booleanParam(name: 'must_create_bootstrap_repos', defaultValue: true, description: 'Create bootstrap repositories'),
-            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
-            booleanParam(name: 'must_boot_monitoring', defaultValue: false, description: 'Bootstrap Monitoring Server'),
-            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_boot_node', defaultValue: true, description: 'Bootstrap Node'),
             booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
             booleanParam(name: 'must_prepare_retail', defaultValue: false, description: 'Prepare and run Retail'),
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
-            string(name: 'capybara_timeout', defaultValue: '30', description: 'Capybara max. waiting time'),
-            string(name: 'default_timeout', defaultValue: '300', description: 'Default timeout used in our Test Framework'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools SLE Update Repositories for each client, in json format')
             ])
     ])

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -32,14 +32,11 @@ node('sumaform-cucumber-provo') {
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp4', description: 'Server version used by monitoring server'),
-            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
             booleanParam(name: 'must_sync', defaultValue: true, description: 'Sync. products and channels'),
@@ -50,15 +47,10 @@ node('sumaform-cucumber-provo') {
             booleanParam(name: 'must_add_non_MU_repositories', defaultValue: true, description: 'Add non MU channels'),
             booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
             booleanParam(name: 'must_create_bootstrap_repos', defaultValue: true, description: 'Create bootstrap repositories'),
-            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
-            booleanParam(name: 'must_boot_monitoring', defaultValue: true, description: 'Bootstrap Monitoring Server'),
-            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_boot_node', defaultValue: true, description: 'Bootstrap Node'),
             booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
             booleanParam(name: 'must_prepare_retail', defaultValue: true, description: 'Prepare and run Retail'),
             booleanParam(name: 'must_run_containerization_tests', defaultValue: true, description: 'Run Containerization Tests'),
-            booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
-            string(name: 'capybara_timeout', defaultValue: '30', description: 'Capybara max. waiting time'),
-            string(name: 'default_timeout', defaultValue: '300', description: 'Default timeout used in our Test Framework'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools MU Repositories for each client, in json format')
             ])
     ])

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -37,6 +37,7 @@ node('sumaform-cucumber-provo') {
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp4', description: 'Server version used by monitoring server'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
             booleanParam(name: 'must_sync', defaultValue: true, description: 'Sync. products and channels'),
@@ -51,6 +52,7 @@ node('sumaform-cucumber-provo') {
             booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
             booleanParam(name: 'must_prepare_retail', defaultValue: true, description: 'Prepare and run Retail'),
             booleanParam(name: 'must_run_containerization_tests', defaultValue: true, description: 'Run Containerization Tests'),
+            booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools MU Repositories for each client, in json format')
             ])
     ])

--- a/jenkins_pipelines/environments/manager-4.3-qe-sle-update
+++ b/jenkins_pipelines/environments/manager-4.3-qe-sle-update
@@ -32,13 +32,11 @@ node('sumaform-cucumber-provo') {
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp4', description: 'Server version used by monitoring server'),
-            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
@@ -50,15 +48,11 @@ node('sumaform-cucumber-provo') {
             booleanParam(name: 'must_add_non_MU_repositories', defaultValue: true, description: 'Add non MU channels'),
             booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
             booleanParam(name: 'must_create_bootstrap_repos', defaultValue: true, description: 'Create bootstrap repositories'),
-            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
-            booleanParam(name: 'must_boot_monitoring', defaultValue: false, description: 'Bootstrap Monitoring Server'),
-            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_boot_node', defaultValue: true, description: 'Bootstrap Node'),
             booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
             booleanParam(name: 'must_prepare_retail', defaultValue: false, description: 'Prepare and run Retail'),
             booleanParam(name: 'must_run_containerization_tests', defaultValue: false, description: 'Run Containerization Tests'),
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
-            string(name: 'capybara_timeout', defaultValue: '30', description: 'Capybara max. waiting time'),
-            string(name: 'default_timeout', defaultValue: '300', description: 'Default timeout used in our Test Framework'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools SLE Update Repositories for each client, in json format')
             ])
     ])

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -32,13 +32,11 @@ node('sumaform-cucumber') {
             // Temporary: should move to uyuni-project
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            string(name: 'non_MU_channels_tasks_file', defaultValue: 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks.json', description: 'Path to JSON run set file for non MU repositories'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp4', description: 'Server version used by monitoring server'),
-            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
@@ -50,15 +48,11 @@ node('sumaform-cucumber') {
             booleanParam(name: 'must_add_non_MU_repositories', defaultValue: true, description: 'Add non MU channels'),
             booleanParam(name: 'must_add_keys', defaultValue: true, description: 'Add Activation Keys'),
             booleanParam(name: 'must_create_bootstrap_repos', defaultValue: true, description: 'Create bootstrap repositories'),
-            booleanParam(name: 'must_boot_proxy', defaultValue: true, description: 'Bootstrap Proxy'),
-            booleanParam(name: 'must_boot_monitoring', defaultValue: true, description: 'Bootstrap Monitoring Server'),
-            booleanParam(name: 'must_boot_clients', defaultValue: true, description: 'Bootstrap clients'),
+            booleanParam(name: 'must_boot_node', defaultValue: true, description: 'Bootstrap Node'),
             booleanParam(name: 'must_run_tests', defaultValue: true, description: 'Run Smoke Tests'),
             booleanParam(name: 'must_prepare_retail', defaultValue: true, description: 'Prepare and run Retail'),
             booleanParam(name: 'must_run_containerization_tests', defaultValue: true, description: 'Run Containerization Tests'),
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
-            string(name: 'capybara_timeout', defaultValue: '30', description: 'Capybara max. waiting time'),
-            string(name: 'default_timeout', defaultValue: '300', description: 'Default timeout used in our Test Framework'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools MU Repositories for each client, in json format')
             ])
     ])


### PR DESCRIPTION
This PR is the next step after https://github.com/SUSE/susemanager-ci/pull/854. So you will also have the changes from this PR.

### What does this PR change ?
After discussion with Eric, we start to have too many options to select when using BV.
In this PR I try to simplify as much as I can the parameters ( 9 will be removed and one added with this PR ). It's just an idea open to discussion ! 

**Move some Jenkins parameters to pipeline variables ( common parameter to 4.2 and 4.3 ):** 
 - `non_MU_channels_tasks_file` : path to Non Mu correspondence file. Same for 4.2 and 4.3.
 - `capybara_timeout` : is it something we are changing when starting a pipeline ?  Should always be the same for stability I think. 
 - `default_timeout` : same than capybara timeout

**Remove parameters useless or not use :** 
 - `terraform_init` : --init could be use all the time without impact. Remove this parameter
 - `confirm_before_continue` : was added by Oscar, it is not used by Eric or me. Should we keep it Oscar ?
 - `use_previous_terraform_state` : not working ? Needed ?

**Double entry parameters :** 
 - `must_boot_proxy`
 - `must_boot_monitoring`
 - `must_boot_clients`

I created a new `must_boot_node` unique parameter. If we want to only boot proxy or monitoring or client, we just need to enable / disable node stages using `enable_XXX_stages`. It creates a little bit of complexity but remove 3 parameters.
Example : 
 - must_boot_proxy ONLY : 
     - [x]  enable_proxy_stages
     - [ ] enable_monitoring_stages
     - [ ] enable_client_stages
     - [x] must_boot_node
 - must_boot_monitoring ONLY : 
     - [ ]  enable_proxy_stages
     - [x] enable_monitoring_stages
     - [ ] enable_client_stages
     - [x] must_boot_node
 - must_boot_clients ONLY : 
     - [ ]  enable_proxy_stages
     - [ ] enable_monitoring_stages
     - [x] enable_client_stages
     - [x] must_boot_node
 - boot Proxy => monitoring => clients  : 
     - [x]  enable_proxy_stages
     - [x] enable_monitoring_stages
     - [x] enable_client_stages
     - [x] must_boot_node