### PR TITLE
Disable liberty in 4.3 BV PRV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -678,29 +678,29 @@ module "centos7-minion" {
   install_salt_bundle = true
 }
 
-module "liberty9-minion" {
-  providers = {
-    libvirt = libvirt.endor
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
-  name               = "min-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:c5"
-    memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
+//module "liberty9-minion" {
+//  providers = {
+//    libvirt = libvirt.endor
+//  }
+//  source             = "./modules/minion"
+//  base_configuration = module.base_res.configuration
+//  product_version    = "4.3-released"
+//  name               = "min-liberty9"
+//  image              = "libertylinux9o"
+//  provider_settings = {
+//    mac                = "aa:b2:92:42:00:c5"
+//    memory             = 4096
+//  }
+//  server_configuration = {
+//    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+//  }
+//  auto_connect_to_master  = false
+//  use_os_released_updates = false
+//  ssh_key_path            = "./salt/controller/id_rsa.pub"
+//
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+//}
 
 module "oracle9-minion" {
   providers = {
@@ -1144,28 +1144,28 @@ module "centos7-sshminion" {
   install_salt_bundle = true
 }
 
-module "liberty9-sshminion" {
-  providers = {
-    libvirt = libvirt.endor
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
-  name               = "minssh-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:e5"
-    memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
+//module "liberty9-sshminion" {
+//  providers = {
+//    libvirt = libvirt.endor
+//  }
+//  source             = "./modules/minion"
+//  base_configuration = module.base_res.configuration
+//  product_version    = "4.3-released"
+//  name               = "minssh-liberty9"
+//  image              = "libertylinux9o"
+//  provider_settings = {
+//    mac                = "aa:b2:92:42:00:e5"
+//    memory             = 4096
+//  }
+//  server_configuration = {
+//    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+//  }
+//  use_os_released_updates = false
+//  ssh_key_path            = "./salt/controller/id_rsa.pub"
+//
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+//}
 
 module "oracle9-sshminion" {
   providers = {
@@ -1553,8 +1553,8 @@ module "controller" {
   centos7_minion_configuration    = module.centos7-minion.configuration
   centos7_sshminion_configuration = module.centos7-sshminion.configuration
 
-  liberty9_minion_configuration    = module.liberty9-minion.configuration
-  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
+//liberty9_minion_configuration    = module.liberty9-minion.configuration
+//liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9-minion.configuration
   oracle9_sshminion_configuration = module.oracle9-sshminion.configuration


### PR DESCRIPTION
Disable liberty in 4.3 BV PRV because of this error:

```
[root@suma-bv-43-min-liberty9 log]# /usr/sbin/SUSEConnect --write-config --url https://rmt.scc.suse.de
Registering system to registration proxy https://rmt.scc.suse.de

Announcing system to https://rmt.scc.suse.de ...
SUSEConnect error: Post "https://rmt.scc.suse.de/connect/subscriptions/systems": x509: certificate has expired or is not yet valid: current time 2023-05-09T11:51:26-04:00 is after 2023-05-06T10:05:01Z
```