### PR TITLE
Uyuni: Switch from SLES to openSUSE Leap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ image for testing Pull Requests built with the open build service. This needs to
 
 | Version | Minion      | SSH minion  | Client      | RH-like  | Deb-like     | Virthosts   | Buildhost   | Terminal    | Controller | Server      | Proxy       |
 | ------- | ----------- | ----------- | ----------- | -------- | ------------ | ----------- | ----------- | ----------- | ---------- | ----------- | ----------- |
-|  PR test| SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | Leap 15.4   | Leap 15.4   |
-|  Uyuni  | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.4   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | Leap 15.4   | Leap 15.4   |
+|  PR test| Leap 15.4   | Leap 15.4   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.4   | Leap 15.4   | Leap 15.4   | Leap 15.4  | Leap 15.4   | Leap 15.4   |
+|  Uyuni  | Leap 15.4   | Leap 15.4   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.4   | Leap 15.4   | Leap 15.4   | Leap 15.4  | Leap 15.4   | Leap 15.4   |
 |  HEAD   | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | SLES 15 SP4 | SLES 15 SP4 |
 |  4.3    | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | SLES 15 SP4 | SLES 15 SP4 |
 |  4.2    | SLES 15 SP3 | SLES 15 SP3 | SLES 15 SP3 | CentOS 7 | Ubuntu 20.04 | SLES 15 SP3 | SLES 15 SP3 | SLES 15 SP3 | Leap 15.4  | SLES 15 SP3 | SLES 15 SP3 |

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -150,7 +150,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:d6"
         vcpu = 2
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:d8"
         vcpu = 2

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"
@@ -149,8 +149,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:93:01:00:d6"
         vcpu = 2
@@ -160,8 +160,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:93:01:00:d8"
         vcpu = 2
@@ -198,7 +198,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:00:dd"
@@ -209,7 +209,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -149,7 +149,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:e6"
         vcpu = 2
@@ -160,7 +160,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:e8"
         vcpu = 2

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-refmaster-"
@@ -148,8 +148,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:93:01:00:e6"
         vcpu = 2
@@ -159,8 +159,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:93:01:00:e8"
         vcpu = 2
@@ -194,7 +194,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       provider_settings = {
         mac = "aa:b2:93:01:00:ed"
         vcpu = 2
@@ -204,7 +204,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-kvm"
       provider_settings = {
         mac = "aa:b2:93:01:00:ee"

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -145,7 +145,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:f4"
         memory = 4096
@@ -155,7 +155,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:f5"
         memory = 4096

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-codecov-"
@@ -144,8 +144,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:f4"
         memory = 4096
@@ -154,8 +154,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:f5"
         memory = 4096
@@ -185,7 +185,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:f9"
@@ -195,7 +195,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:04"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:05"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:09"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:04"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:05"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:94"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:95"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:94"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:95"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:99"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:14"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:15"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:19"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:14"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:15"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:24"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:25"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:24"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:25"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:29"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:34"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:35"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:39"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:34"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:35"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:44"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:45"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:49"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:44"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:45"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:54"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:55"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:54"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:55"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:59"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:64"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:65"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:64"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:65"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:69"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:74"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:75"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:79"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:74"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:75"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -230,8 +230,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-minion = {
-      image = "sles15sp4o"
-      name = "min-sles15"
+      image = "opensuse154o"
+      name = "min-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:84"
       }
@@ -242,8 +242,8 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "sles15sp4o"
-      name = "minssh-sles15"
+      image = "opensuse154o"
+      name = "minssh-leap15"
       provider_settings = {
         mac = "aa:b2:92:04:00:85"
       }
@@ -282,7 +282,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = false
     }
     build-host = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:04:00:89"
@@ -295,7 +295,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "sles15sp4o"
+      image = "opensuse154o"
       additional_repos = {
         tools_update = var.SLE_CLIENT_REPO,
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -231,7 +231,7 @@ module "cucumber_testsuite" {
     }
     suse-minion = {
       image = "opensuse154o"
-      name = "min-leap15"
+      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:84"
       }
@@ -243,7 +243,7 @@ module "cucumber_testsuite" {
     }
     suse-sshminion = {
       image = "opensuse154o"
-      name = "minssh-leap15"
+      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:04:00:85"
       }


### PR DESCRIPTION
This will move all minions from SLES to openSUSE Leap 15.4 on Uyuni and the pull request tests.

See:
- https://github.com/SUSE/spacewalk/issues/20945
- https://github.com/SUSE/spacewalk/issues/10235