### PR TITLE
Fix wrong module for some SSH minions

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -851,7 +851,7 @@ module "sles15sp4-sshminion" {
 }
 
 module "alma9-sshminion" {
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
   name               = "minssh-alma9"
@@ -888,7 +888,7 @@ module "centos7-sshminion" {
 }
 
 module "liberty9-sshminion" {
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
   name               = "minssh-liberty9"
@@ -908,7 +908,7 @@ module "liberty9-sshminion" {
 }
 
 module "oracle9-sshminion" {
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
   name               = "minssh-oracle9"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1105,7 +1105,7 @@ module "alma9-sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
   product_version    = "4.3-released"
   name               = "minssh-alma9"
@@ -1148,7 +1148,7 @@ module "liberty9-sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
   product_version    = "4.3-released"
   name               = "minssh-liberty9"
@@ -1171,7 +1171,7 @@ module "oracle9-sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
   product_version    = "4.3-released"
   name               = "minssh-oracle9"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -852,7 +852,7 @@ module "sles15sp4-sshminion" {
 }
 
 module "alma9-sshminion" {
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-released"
   name               = "minssh-alma9"
@@ -889,7 +889,7 @@ module "centos7-sshminion" {
 }
 
 module "liberty9-sshminion" {
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-released"
   name               = "minssh-liberty9"
@@ -909,7 +909,7 @@ module "liberty9-sshminion" {
 }
 
 module "oracle9-sshminion" {
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-released"
   name               = "minssh-oracle9"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1105,7 +1105,7 @@ module "alma9-sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
   product_version    = "uyuni-released"
   name               = "minssh-alma9"
@@ -1148,7 +1148,7 @@ module "liberty9-sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
   product_version    = "uyuni-released"
   name               = "minssh-liberty9"
@@ -1171,7 +1171,7 @@ module "oracle9-sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
-  source             = "./modules/minion"
+  source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
   product_version    = "uyuni-released"
   name               = "minssh-oracle9"


### PR DESCRIPTION
This will fix the wrong module assignments for some of the newly added Red Hat-like SSH minions like Liberty 9, Oracle 9 and Alma 9.