### PR TITLE
Fix Red Hat-like SSH minion configuration

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -860,9 +860,6 @@ module "alma9-sshminion" {
     mac                = "aa:b2:92:42:00:e2"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.suse.de"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -897,9 +894,6 @@ module "liberty9-sshminion" {
     mac                = "aa:b2:92:42:00:e5"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.suse.de"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -916,9 +910,6 @@ module "oracle9-sshminion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:e3"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.suse.de"
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1114,9 +1114,6 @@ module "alma9-sshminion" {
     mac                = "aa:b2:92:42:00:e2"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -1157,9 +1154,6 @@ module "liberty9-sshminion" {
     mac                = "aa:b2:92:42:00:e5"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -1179,9 +1173,6 @@ module "oracle9-sshminion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:e3"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -861,9 +861,6 @@ module "alma9-sshminion" {
     mac                = "aa:b2:93:02:01:e2"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -898,9 +895,6 @@ module "liberty9-sshminion" {
     mac                = "aa:b2:93:02:01:e5"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -917,9 +911,6 @@ module "oracle9-sshminion" {
   provider_settings = {
     mac                = "aa:b2:93:02:01:e3"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1114,9 +1114,6 @@ module "alma9-sshminion" {
     mac                = "aa:b2:93:02:01:ae"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -1157,9 +1154,6 @@ module "liberty9-sshminion" {
     mac                = "aa:b2:93:02:01:b1"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
-  }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
@@ -1179,9 +1173,6 @@ module "oracle9-sshminion" {
   provider_settings = {
     mac                = "aa:b2:93:02:01:af"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"


### PR DESCRIPTION
Remove `server_configuration` for Red Hat-like SSH minions. We do not have it for other SSH minions, too.

```bash
14:02:15  ╷
14:02:15  │ Error: Unsupported argument
14:02:15  │ 
14:02:15  │   on main.tf line 864, in module "alma9-sshminion":
14:02:15  │  864:   server_configuration = {
14:02:15  │ 
14:02:15  │ An argument named "server_configuration" is not expected here.
14:02:15  ╵
```