### PR TITLE
[BV] Correctly fail add MU ssh minion stage if minion stage fails

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -294,9 +294,9 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
                         println "Waiting for the MU channel creation by ${minion_name_without_ssh} for ${node}."
                         waitUntil {
-                            if (mu_sync_status[minion_name_without_ssh] = "SYNC") {
+                            if (mu_sync_status[minion_name_without_ssh] == 'SYNC') {
                                 return true
-                            } else if (mu_sync_status[minion_name_without_ssh] = "FAIL") {
+                            } else if (mu_sync_status[minion_name_without_ssh] == 'FAIL') {
                                 error("${minion_name_without_ssh} MU synchronization failed")
                             }
                         }
@@ -310,14 +310,14 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         echo 'Add custom channels and MU repositories'
                         res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${node}'", returnStatus: true)
                         if (res_mu_repos != 0) {
-                            mu_sync_status[node] = "FAIL"
+                            mu_sync_status[node] = 'FAIL'
                             error("Add custom channels and MU repositories failed with status code: ${res_mu_repos}")
                         }
                         echo "Custom channels and MU repositories status code: ${res_mu_repos}"
                         res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export NODE=${node}; unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'", returnStatus: true)
                         echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
                         if (res_sync_mu_repos != 0) {
-                            mu_sync_status[node] = "FAIL"
+                            mu_sync_status[node] = 'FAIL'
                             error("Custom channels and MU repositories synchronization failed with status code: ${res_sync_mu_repos}")
                         }
                         // Update minion repo sync status variable once the MU channel is synchronized

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -294,11 +294,15 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
                         println "Waiting for the MU channel creation by ${minion_name_without_ssh} for ${node}."
                         waitUntil {
-                            mu_sync_status[minion_name_without_ssh]
+                            if (mu_sync_status[minion_name_without_ssh] = "SYNC") {
+                                return true
+                            } else if (mu_sync_status[minion_name_without_ssh] = "FAIL") {
+                                error("${minion_name_without_ssh} MU synchronization failed")
+                            }
                         }
                         println "MU channel available for ${node} "
                     } else if (node == "${params.monitoring_sle_version}_minion" && params.enable_monitoring_stages) {
-                        mu_sync_status[node] = true
+                        mu_sync_status[node] = 'SYNC'
                     } else {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start adding Maintenance Update repositories'
@@ -306,16 +310,18 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         echo 'Add custom channels and MU repositories'
                         res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${node}'", returnStatus: true)
                         if (res_mu_repos != 0) {
+                            mu_sync_status[node] = "FAIL"
                             error("Add custom channels and MU repositories failed with status code: ${res_mu_repos}")
                         }
                         echo "Custom channels and MU repositories status code: ${res_mu_repos}"
                         res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export NODE=${node}; unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'", returnStatus: true)
                         echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
                         if (res_sync_mu_repos != 0) {
+                            mu_sync_status[node] = "FAIL"
                             error("Custom channels and MU repositories synchronization failed with status code: ${res_sync_mu_repos}")
                         }
                         // Update minion repo sync status variable once the MU channel is synchronized
-                        mu_sync_status[node] = true
+                        mu_sync_status[node] = 'SYNC'
                     }
                 }
             }
@@ -407,7 +413,7 @@ def clientTestingStages(capybara_timeout, default_timeout) {
             }
         }
     }
-    // Once all the stages have been correctly configured, run in parallel
+// Once all the stages have been correctly configured, run in parallel
     parallel tests
 }
 
@@ -442,7 +448,7 @@ def getNodesHandler() {
     // Create a map storing mu synchronization state for each minion.
     // This map is to be sure ssh minions have the MU channel ready.
     for (node in nodeListWithDisabledNodes ) {
-        MUSyncStatus[node] = false
+        MUSyncStatus[node] = 'UNSYNC'
     }
     return [nodeList:nodeListWithDisabledNodes, envVariableList:envVar, envVariableListToDisable:envVarDisabledNodes, MUSyncStatus:MUSyncStatus]
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -294,7 +294,7 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
                         println "Waiting for the MU channel creation by ${minion_name_without_ssh} for ${node}."
                         waitUntil {
-                            (mu_sync_status[minion_name_without_ssh] == 'SYNC' || mu_sync_status[minion_name_without_ssh] == 'FAIL')
+                            mu_sync_status[minion_name_without_ssh] != 'UNSYNC'
                         }
                         if (mu_sync_status[minion_name_without_ssh] == 'FAIL') {
                             error("${minion_name_without_ssh} MU synchronization failed")

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -294,13 +294,13 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
                         println "Waiting for the MU channel creation by ${minion_name_without_ssh} for ${node}."
                         waitUntil {
-                            if (mu_sync_status[minion_name_without_ssh] == 'SYNC') {
-                                return true
-                            } else if (mu_sync_status[minion_name_without_ssh] == 'FAIL') {
-                                error("${minion_name_without_ssh} MU synchronization failed")
-                            }
+                            (mu_sync_status[minion_name_without_ssh] == 'SYNC' || mu_sync_status[minion_name_without_ssh] == 'FAIL')
                         }
-                        println "MU channel available for ${node} "
+                        if (mu_sync_status[minion_name_without_ssh] == 'FAIL') {
+                            error("${minion_name_without_ssh} MU synchronization failed")
+                        } else {
+                            println "MU channel available for ${node} "
+                        }
                     } else if (node == "${params.monitoring_sle_version}_minion" && params.enable_monitoring_stages) {
                         mu_sync_status[node] = 'SYNC'
                     } else {


### PR DESCRIPTION
## What does this PR ?

SSH Minion and minion both need the minion MU repository when testing in BV. But we only can sync MU repository once. To solve this situation, only minion stage is creating the MU channel and ssh minion will use it.
Because ssh minion and minion are running in parallel, during add MU stage ssh minion are using a Jenkins waitUntil to wait the minion add MU stage to finish.

If the add MU minion stage fails, the add MU minion stage will wait forever that the MU minion stage succeed. 

To solve this situation, I changed `mu_sync_status[node]`  variable to string so it can store three states : 
 - `NOSYNC`, set when creating the variable
 - `SYNC`, set after minion add MU stage succeed
 - `FAIL`, set if minion add MU stage failed.

The waitUntil will then wait for `SYNC` status or `FAIL`. And a condition after that will fail the stage if the status was `FAIL`