### PR TITLE
Use the bundle everywhere again for 4.2

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
@@ -151,6 +151,8 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-minion = {
       image = "sles15sp3o"
@@ -160,6 +162,8 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-sshminion = {
       image = "sles15sp3o"
@@ -169,6 +173,8 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     redhat-minion = {
       image = "centos7o"
@@ -190,6 +196,8 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp3o"
@@ -199,6 +207,8 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     pxeboot-minion = {
       image = "sles15sp3o"
@@ -215,6 +225,8 @@ module "cucumber_testsuite" {
         vcpu = 4
         memory = 4096
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
   }
   nested_vm_host = "min-nested"

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -146,6 +146,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c4"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-minion = {
       image = "sles15sp3o"
@@ -153,6 +155,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c6"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     suse-sshminion = {
       image = "sles15sp3o"
@@ -160,6 +164,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c8"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     redhat-minion = {
       image = "centos7o"
@@ -178,6 +184,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:cc"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp3o"
@@ -186,6 +194,8 @@ module "cucumber_testsuite" {
         mac = "aa:b2:92:03:00:cd"
         memory = 2048
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
     pxeboot-minion = {
       image = "sles15sp3o"
@@ -204,6 +214,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:ce"
       }
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
     }
   }
   nested_vm_host = "min-nested"


### PR DESCRIPTION
Revert of partial revert of ca81feef1060ff8cb51dda6d12a2ec026fedeac6

Rationale is: bundle is now the default for bootstrapping on 4.2, so we want to test with bundle on every minion

Otherwise we get both `salt-minion` and `venv-salt-minion` running at same time