### PR TITLE
Allow more disk space for /var/spacewalk on server

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation-NUE.tf
@@ -153,7 +153,7 @@ module "server" {
   }
 
   # server_mounted_mirror = "minima-mirror-bv.mgr.suse.de"
-  repository_disk_size = 2000
+  repository_disk_size = 2048
 
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation-PRV.tf
@@ -299,7 +299,7 @@ module "server" {
   }
 
   server_mounted_mirror = "minima-mirror-bv.mgr.prv.suse.net"
-  repository_disk_size = 1500
+  repository_disk_size = 2048
 
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -154,7 +154,7 @@ module "server" {
   }
 
   # server_mounted_mirror = "minima-mirror-bv.mgr.suse.de"
-  repository_disk_size = 2000
+  repository_disk_size = 2048
 
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -300,7 +300,7 @@ module "server" {
   }
 
   server_mounted_mirror = "minima-mirror-bv.mgr.prv.suse.net"
-  repository_disk_size = 1700
+  repository_disk_size = 2048
 
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -153,7 +153,7 @@ module "server" {
   }
 
   # server_mounted_mirror = "minima-mirror-bv.mgr.suse.de"
-  repository_disk_size = 2000
+  repository_disk_size = 2048
 
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -299,7 +299,7 @@ module "server" {
   }
 
   server_mounted_mirror = "minima-mirror-bv.mgr.prv.suse.net"
-  repository_disk_size = 1700
+  repository_disk_size = 2048
 
   auto_accept                    = false
   monitored                      = true


### PR DESCRIPTION
Switch to 2 TB on every branch.

I checked on arrakis, caladan, suma-06, and suma-07: we have enough room for that.
