### PR TITLE
QE: Align tf files

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -126,6 +126,8 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:92:03:00:c0"
+        vcpu = 2
+        memory = 2048
       }
     }
     server = {

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -131,11 +131,15 @@ module "cucumber_testsuite" {
     server = {
       provider_settings = {
         mac = "aa:b2:92:03:00:c1"
+        vcpu = 4
+        memory = 16384
       }
     }
     proxy = {
       provider_settings = {
         mac = "aa:b2:92:03:00:c2"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -145,6 +149,8 @@ module "cucumber_testsuite" {
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:c4"
+        vcpu = 2
+        memory = 2048
       }
     }
     suse-minion = {
@@ -152,6 +158,8 @@ module "cucumber_testsuite" {
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:c6"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -161,6 +169,8 @@ module "cucumber_testsuite" {
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:c8"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -171,7 +181,8 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:c9"
         // Openscap cannot run with less than 1.25 GB of RAM
-        memory = 1280
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -181,6 +192,8 @@ module "cucumber_testsuite" {
       image = "ubuntu2004o"
       provider_settings = {
         mac = "aa:b2:92:03:00:cc"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -190,6 +203,7 @@ module "cucumber_testsuite" {
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:03:00:cd"
+        vcpu = 2
         memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
@@ -197,6 +211,10 @@ module "cucumber_testsuite" {
     }
     pxeboot-minion = {
       image = "sles15sp3o"
+      provider_settings = {
+        vcpu = 2
+        memory = 2048
+      }
     }
     kvm-host = {
       image = "sles15sp3o"
@@ -211,6 +229,8 @@ module "cucumber_testsuite" {
       }
       provider_settings = {
         mac = "aa:b2:92:03:00:ce"
+        vcpu = 4
+        memory = 4096
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -128,16 +128,22 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:92:03:00:80"
+        vcpu = 2
+        memory = 2048
       }
     }
     server = {
       provider_settings = {
         mac = "aa:b2:92:03:00:81"
+        vcpu = 8
+        memory = 32768
       }
     }
     proxy = {
       provider_settings = {
         mac = "aa:b2:92:03:00:82"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -147,6 +153,8 @@ module "cucumber_testsuite" {
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:84"
+        vcpu = 2
+        memory = 2048
       }
     }
     suse-minion = {
@@ -154,6 +162,8 @@ module "cucumber_testsuite" {
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:86"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -163,6 +173,8 @@ module "cucumber_testsuite" {
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:88"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion", "iptables" ]
       install_salt_bundle = true
@@ -174,8 +186,8 @@ module "cucumber_testsuite" {
         mac = "aa:b2:92:03:00:89"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
         // Also, openscap cannot run with less than 1.25 GB of RAM
-        memory = 2048
         vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -185,6 +197,8 @@ module "cucumber_testsuite" {
       name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:92:03:00:8b"
+        vcpu = 2
+        memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
@@ -193,13 +207,18 @@ module "cucumber_testsuite" {
       image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:92:03:00:8d"
-        memory = 2048
+        vcpu = 4
+        memory = 8192
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     pxeboot-minion = {
       image = "sles15sp4o"
+      provider_settings = {
+        vcpu = 2
+        memory = 2048
+      }
     }
     kvm-host = {
       image = "sles15sp4o"
@@ -215,6 +234,8 @@ module "cucumber_testsuite" {
       }
       provider_settings = {
         mac = "aa:b2:92:03:00:8e"
+        vcpu = 4
+        memory = 8192
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -153,7 +153,6 @@ module "cucumber_testsuite" {
       name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:84"
-        vcpu = 2
         memory = 2048
       }
     }
@@ -162,7 +161,6 @@ module "cucumber_testsuite" {
       name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:86"
-        vcpu = 2
         memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
@@ -197,7 +195,6 @@ module "cucumber_testsuite" {
       name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:92:03:00:8b"
-        vcpu = 2
         memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
@@ -216,7 +213,6 @@ module "cucumber_testsuite" {
     pxeboot-minion = {
       image = "sles15sp4o"
       provider_settings = {
-        vcpu = 2
         memory = 2048
       }
     }

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -171,7 +171,6 @@ module "cucumber_testsuite" {
       name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:92:03:00:88"
-        vcpu = 2
         memory = 2048
       }
       additional_packages = [ "venv-salt-minion", "iptables" ]


### PR DESCRIPTION
Align the TF files for Provo 4.2 and 4.3 CI with their corresponding TF files from Nuremberg .

The following minions are not aligned vcpu-wise in order to avoid over-committing the amount of vcpus in 4.3:
- SLE client
- SLE minion
- SLE SSH minion
- Debian minion
- PXE boot minion