### PR TITLE
Disable mirror in Uyuni-Master-K3S

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -115,8 +115,8 @@ module "cucumber_testsuite" {
   auth_registry_password = "cucusecret"
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
-  mirror      = "minima-mirror.mgr.prv.suse.net"
-  use_mirror_images = true
+  // mirror      = "minima-mirror.mgr.prv.suse.net"
+  // use_mirror_images = true
 
   server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
   custom_download_endpoint = "ftp://minima-mirror.mgr.prv.suse.net:445"


### PR DESCRIPTION
The PRV mirror is giving problems, let's temporary disable it in our K3S Uyuni Test suite