### PR TITLE
Fix install venv-salt-minion to opensuse server and proxy vms.

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pr", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse154o", "opensuse154-ci-pro", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"
@@ -201,7 +201,9 @@ module "cucumber_testsuite" {
         os_additional_repo = var.ADDITIONAL_REPO_URL,
         testing_overlay_devel = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/",
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
       server_mounted_mirror = "minima-mirror.mgr.prv.suse.net"
     }
     proxy = {
@@ -223,7 +225,7 @@ module "cucumber_testsuite" {
         proxy_pool = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/",
         tools_update = var.OPENSUSE_CLIENT_REPO
       }
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -301,7 +303,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     kvm-host = {
-      image = "opensuse154-ci-pr"
+      image = "opensuse154-ci-pro"
       name = "min-kvm"
       additional_grains = {
         hvm_disk_image = {


### PR DESCRIPTION
cloud-init will only run on images that end with 'o'. Thus, we need to append 'o' to opensuse-ci-pr image name.

We need to force installation of venv-salt-minion into server, so that we can use salt+sumaform to configure it.

Fixes https://github.com/SUSE/spacewalk/issues/21704