### PR TITLE
Use hyperion for running acceptance tests at PR for SUMA 4.3

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -25,6 +25,6 @@ if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
     additional_repo_url = "http://minima-mirror.mgr.prv.suse.net/jordi/reference_job_additional_repo";
 } else { //regular ci test
     first_env = 1;
-    last_env = 8;
+    last_env = 4;
 }
 


### PR DESCRIPTION
This removes environments 5 and 6 from the uyuni-prs-ci-test . Environments 5 and 6 use hyperion. This way, we can use hyperion for suma 4.3 tests.

related to https://github.com/SUSE/spacewalk/issues/21471

