### PR TITLE
Add rhel8 to aws BV

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -181,9 +181,9 @@ def run(params) {
                             sh "ssh ${ssh_option} ${user}@${mirror_hostname_local} 'scp ${ssh_option} -i /root/testing-suma.pem /root/mirror.tar.gz ec2-user@${mirror_hostname_aws_public}:/home/ec2-user/' "
                             sh "ssh ${ssh_option} -i ${params.key_file} ec2-user@${mirror_hostname_aws_public} 'sudo tar -xvf /home/ec2-user/mirror.tar.gz -C /srv/mirror/' "
                             sh "ssh ${ssh_option} -i ${params.key_file} ec2-user@${mirror_hostname_aws_public} 'sudo rsync -a /srv/mirror/ibs/ /srv/mirror' "
-                            sh "ssh ${ssh_option} -i ${params.key_file} ec2-user@${mirror_hostname_aws_public} 'sudo rsync -a /srv/mirror/download/ibs/ /srv/mirror' "
+//                            sh "ssh ${ssh_option} -i ${params.key_file} ec2-user@${mirror_hostname_aws_public} 'sudo rsync -a /srv/mirror/download/ibs/ /srv/mirror' "
                             sh "ssh ${ssh_option} -i ${params.key_file} ec2-user@${mirror_hostname_aws_public} 'sudo rm -rf /srv/mirror/ibs' "
-                            sh "ssh ${ssh_option} -i ${params.key_file} ec2-user@${mirror_hostname_aws_public} 'sudo rm -rf /srv/mirror/download/ibs' "
+//                            sh "ssh ${ssh_option} -i ${params.key_file} ec2-user@${mirror_hostname_aws_public} 'sudo rm -rf /srv/mirror/download/ibs' "
                         }
 
                     }

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -11,6 +11,7 @@ node('sumaform-cucumber-provo') {
             'centos7_client, centos7_minion, centos7_ssh_minion, ' +
             'liberty9_minion, liberty9_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
+            'rhel9_minion, rhel9_ssh_minion, rhel8_minion, rhel8_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu1804_minion, ubuntu1804_ssh_minion, ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -38,7 +38,6 @@ node('sumaform-cucumber-provo') {
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
             string(name: 'monitoring_sle_version', defaultValue: 'sle15sp4', description: 'Server version used by monitoring server'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'prepare_aws_env', defaultValue: true, description: 'Create local and AWS mirror and upload data to AWS mirror'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'generate_feature', defaultValue: true, description: 'Generate Rakefile for features'),

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -233,6 +233,7 @@ module "sles12sp4-client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
+  additional_packages = [ "chrony" ]
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"
@@ -249,6 +250,7 @@ module "sles12sp5-client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
+  additional_packages = [ "chrony" ]
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -634,14 +634,11 @@ module "rhel9-sshminion" {
 
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
-  server_configuration = module.server.configuration
   product_version    = "4.3-released"
   name               = "min-sshrhel9"
   image              = "rhel9"
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -651,14 +648,11 @@ module "rhel8-sshminion" {
 
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
-  server_configuration = module.server.configuration
   product_version    = "4.3-released"
   name               = "min-sshrhel8"
   image              = "rhel8"
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
   }

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -594,6 +594,26 @@ module "sles15sp3-sshminion" {
 
 }
 
+module "rhel8-minion" {
+
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  server_configuration = module.server.configuration
+  product_version    = "4.3-released"
+  name               = "min-rhel8"
+  image              = "rhel8"
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = true
+  provider_settings = {
+    instance_type = "t3a.medium"
+  }
+
+  //rhel8-minion_additional_repos
+
+}
+
 module "rhel9-minion" {
 
   source             = "./modules/minion"
@@ -611,6 +631,42 @@ module "rhel9-minion" {
   }
 
   //rhel9-minion_additional_repos
+
+}
+
+module "rhel9-sshminion" {
+
+  source             = "./modules/sshminion"
+  base_configuration = module.base.configuration
+  server_configuration = module.server.configuration
+  product_version    = "4.3-released"
+  name               = "min-sshrhel9"
+  image              = "rhel9"
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = true
+  provider_settings = {
+    instance_type = "t3a.medium"
+  }
+
+}
+
+module "rhel8-sshminion" {
+
+  source             = "./modules/sshminion"
+  base_configuration = module.base.configuration
+  server_configuration = module.server.configuration
+  product_version    = "4.3-released"
+  name               = "min-sshrhel8"
+  image              = "rhel8"
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = true
+  provider_settings = {
+    instance_type = "t3a.medium"
+  }
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -751,8 +751,8 @@ module "controller" {
 //  debian11_minion_configuration    = module.debian11-minion.configuration
 //  debian11_sshminion_configuration = module.debian11-sshminion.configuration
 
-  rhel8_minion_configuration         = module.rhel8-minion.configuration
-  rhel8_sshminion_configuration      = module.rhel8-sshminion.configuration
+//  rhel8_minion_configuration         = module.rhel8-minion.configuration
+//  rhel8_sshminion_configuration      = module.rhel8-sshminion.configuration
 
   rhel9_minion_configuration          = module.rhel9-minion.configuration
   rhel9_sshminion_configuration       = module.rhel9-sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -181,8 +181,9 @@ module "server" {
   create_sample_activation_key   = false
   create_sample_bootstrap_script = false
   publish_private_ssl_key        = false
-  use_os_released_updates        = false
+  use_os_released_updates        = true
   disable_download_tokens        = false
+  accept_all_ssl_protocols       = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "m6a.xlarge"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -609,7 +609,6 @@ module "rhel8-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -657,7 +656,6 @@ module "rhel8-sshminion" {
   name               = "min-sshrhel8"
   image              = "rhel8"
   use_os_released_updates = false
-  install_salt_bundle = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -184,6 +184,8 @@ module "server" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   accept_all_ssl_protocols       = true
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "m6a.xlarge"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -609,6 +609,7 @@ module "rhel8-minion" {
   image              = "rhel8"
   auto_connect_to_master  = false
   use_os_released_updates = false
+  install_salt_bundle = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"
@@ -657,6 +658,7 @@ module "rhel8-sshminion" {
   name               = "min-sshrhel8"
   image              = "rhel8"
   use_os_released_updates = false
+  install_salt_bundle = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -383,6 +383,7 @@ module "sles12sp4-minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
+  additional_packages = [ "chrony" ]
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"
@@ -399,6 +400,7 @@ module "sles12sp5-minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
+  additional_packages = [ "chrony" ]
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"
@@ -527,6 +529,7 @@ module "sles12sp4-sshminion" {
   image              = "sles12sp4"
   use_os_released_updates = false
   sles_registration_code = var.SLES_REGISTRATION_CODE
+  additional_packages = [ "chrony" ]
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   provider_settings = {
@@ -542,6 +545,7 @@ module "sles12sp5-sshminion" {
   image              = "sles12sp5"
   use_os_released_updates = false
   sles_registration_code = var.SLES_REGISTRATION_CODE
+  additional_packages = [ "chrony" ]
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   provider_settings = {
@@ -638,6 +642,7 @@ module "rhel9-sshminion" {
   name               = "min-sshrhel9"
   image              = "rhel9"
   use_os_released_updates = false
+  install_salt_bundle = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"
@@ -652,6 +657,7 @@ module "rhel8-sshminion" {
   name               = "min-sshrhel8"
   image              = "rhel8"
   use_os_released_updates = false
+  install_salt_bundle = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   provider_settings = {
     instance_type = "t3a.medium"
@@ -747,7 +753,11 @@ module "controller" {
 //  debian11_minion_configuration    = module.debian11-minion.configuration
 //  debian11_sshminion_configuration = module.debian11-sshminion.configuration
 
+  rhel8_minion_configuration         = module.rhel8-minion.configuration
+  rhel8_sshminion_configuration      = module.rhel8-sshminion.configuration
+
   rhel9_minion_configuration          = module.rhel9-minion.configuration
+  rhel9_sshminion_configuration       = module.rhel9-sshminion.configuration
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -609,9 +609,7 @@ module "rhel8-minion" {
   provider_settings = {
     instance_type = "t3a.medium"
   }
-
   //rhel8-minion_additional_repos
-
 }
 
 module "rhel9-minion" {
@@ -629,9 +627,7 @@ module "rhel9-minion" {
   provider_settings = {
     instance_type = "t3a.medium"
   }
-
   //rhel9-minion_additional_repos
-
 }
 
 module "rhel9-sshminion" {
@@ -649,7 +645,6 @@ module "rhel9-sshminion" {
   provider_settings = {
     instance_type = "t3a.medium"
   }
-
 }
 
 module "rhel8-sshminion" {
@@ -667,7 +662,6 @@ module "rhel8-sshminion" {
   provider_settings = {
     instance_type = "t3a.medium"
   }
-
 }
 
 module "ubuntu2204-sshminion" {


### PR DESCRIPTION
Add rhel9 ssh minion and both rhel8 minion and ssh minion to AWS BV.


Also add workaround for chrony issue on sles12spX ( chrony not found during salt call )
```
  ID: chrony_pkg
Function: pkg.installed
Name: chrony
Result: False
Comment: An error was encountered while installing package(s): Zypper command failure: Running scope as unit run-r178450a37f784afa8e6c1d75db734148.scope.
Package 'chrony' not found.Loading repository data...
Reading installed packages...
Started: 02:41:24.816125
Duration: 141.623 ms
 Changes: 
```