### PR TITLE
Add random wait before web interface calling stage during parallel

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -343,6 +343,7 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                             input 'Press any key to start adding Maintenance Update repositories'
                         }
                         echo 'Add custom channels and MU repositories'
+                        randomWait()
                         res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${node}'", returnStatus: true)
                         if (res_mu_repos != 0) {
                             mu_sync_status[node] = 'FAIL'
@@ -369,6 +370,7 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                             input 'Press any key to start adding common channels'
                         }
                         echo 'Add non MU Repositories'
+                        randomWait()
                         res_non_MU_repositories = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:${build_validation_non_MU_script}'", returnStatus: true)
                         echo "Non MU Repositories status code: ${res_non_MU_repositories}"
                         if (res_non_MU_repositories != 0) {
@@ -388,6 +390,7 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         input 'Press any key to start adding activation keys'
                     }
                     echo 'Add Activation Keys'
+                    randomWait()
                     res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_${node}'", returnStatus: true)
                     echo "Add Activation Keys status code: ${res_add_keys}"
                     if (res_add_keys != 0) {


### PR DESCRIPTION
bootstrap and run smoke tests look stable now in term of login page failing.
I have login page failing or server not responding during add MU stages now.
I would like to add randomWait() to all parallel stages calling the web interface to see if it's improve the stability.
It will spread a little more the web interface callls and probably stabilize the test.