### PR TITLE
align podman and k3s env

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -143,13 +143,9 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:52"
       }
-      //additional_repos = {
-      //  Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Hexagon/SLE_15_SP4/"
-      //}
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-
     suse-minion = {
       image = "opensuse154o"
       name = "min-suse"
@@ -181,8 +177,12 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    pxeboot-minion = {
-      image = "opensuse154o"
+    debian-minion = {
+      name = "min-ubuntu2204"
+      image = "ubuntu2204o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:5b"
+      }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
@@ -196,6 +196,12 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
+    pxeboot-minion = {
+      image = "opensuse154o"
+      additional_packages = [ "venv-salt-minion" ]
+      install_salt_bundle = true
+    }
+  //TODO add kvm-host
   }
   provider_settings = {
     pool         = "ssd"

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -205,31 +205,32 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    kvm-host = {
-      image = "opensuse154o"
-      name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "uyuni-master-min-nested"
-            image = "http://minima-mirror.mgr.suse.de/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
-            hash = "http://minima-mirror.mgr.suse.de/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "uyuni-master-min-nested"
-            image = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
-      provider_settings = {
-        mac = "aa:b2:93:01:00:3e"
-      }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-    }
+    //TODO add kvm-host
+    //kvm-host = {
+    //  image = "opensuse154o"
+    //  name = "min-kvm"
+    //  additional_grains = {
+    //    hvm_disk_image = {
+    //      leap = {
+    //        hostname = "leap-salt-migration"
+    //        image = "http://minima-mirror.mgr.suse.de/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
+    //        hash = "http://minima-mirror.mgr.suse.de/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+    //      }
+    //      sles = {
+    //        hostname = "sles-salt-migration"
+    //        image = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
+    //        hash = "http://minima-mirror.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
+    //      }
+    //    }
+    //  }
+    //  provider_settings = {
+    //    mac = "aa:b2:93:01:00:3e"
+    //  }
+    //  additional_packages = [ "venv-salt-minion" ]
+    //  install_salt_bundle = true
+    //}
   }
-  nested_vm_host = "min-nested"
+  //nested_vm_host = "min-nested"
   provider_settings = {
     pool               = "ssd"
     network_name       = null


### PR DESCRIPTION
Since `The K3s testsuite report has less features than the podman one though they run the same tests.` https://github.com/SUSE/spacewalk/issues/22172 let s align the two environments, in order to have the same tested systems

