### PR TITLE
Create activation key for ssh minion

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -327,7 +327,7 @@ def clientTestingStages() {
             }
             stage("Add MUs ${node}") {
                 if (params.must_add_MU_repositories) {
-                      if (!node.contains('ssh')) {
+                    if (!node.contains('ssh')) {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start adding Maintenance Update repositories'
                         }
@@ -393,21 +393,17 @@ def clientTestingStages() {
                         }
                         if (required_custom_channel_status[minion_name_without_ssh] == 'FAIL') {
                             error("${minion_name_without_ssh} creates bootstrap repository failed")
-                        } else {
-                            println "Custom channel available for ${node} "
                         }
                     }
-                    else {
-                        if (params.confirm_before_continue) {
-                            input 'Press any key to start adding activation keys'
-                        }
-                        echo 'Add Activation Keys'
-                        res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_${node}'", returnStatus: true)
-                        echo "Add Activation Keys status code: ${res_add_keys}"
-                        if (res_add_keys != 0) {
-                            bootstrap_repository_status[node] = 'FAIL'
-                            error("Add Activation Keys failed with status code: ${res_add_keys}")
-                        }
+                    if (params.confirm_before_continue) {
+                        input 'Press any key to start adding activation keys'
+                    }
+                    echo 'Add Activation Keys'
+                    res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_${node}'", returnStatus: true)
+                    echo "Add Activation Keys status code: ${res_add_keys}"
+                    if (res_add_keys != 0) {
+                        bootstrap_repository_status[node] = 'FAIL'
+                        error("Add Activation Keys failed with status code: ${res_add_keys}")
                     }
                 }
             }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -309,9 +309,6 @@ def clientTestingStages() {
     // Load JSON matching non MU repositories data
     def json_matching_non_MU_data = readJSON(file: env.non_MU_channels_tasks_file)
 
-    // Variable use to sync minion and ssh minion
-    String minion_name_without_ssh
-
     //Get minion list from terraform state list command
     def nodesHandler = getNodesHandler()
     def bootstrap_repository_status = nodesHandler.BootstrapRepositoryStatus
@@ -386,7 +383,7 @@ def clientTestingStages() {
                     if (node.contains('ssh_minion')) {
                         // SSH minion need mandatory custom channel repository. The channel is created during minion stage.
                         // This section wait until minion creates custom channel.
-                        minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
+                        def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
                         println "Waiting for mandatory custom channel for ${node} to be created by ${minion_name_without_ssh}."
                         waitUntil {
                             required_custom_channel_status[minion_name_without_ssh] != 'NOT_CREATED'
@@ -412,7 +409,7 @@ def clientTestingStages() {
                     if (node.contains('ssh_minion')) {
                         // SSH minion need bootstrap repository. The bootstrap repository is created during minion stage.
                         // This section wait until minion creates bootstrap repository
-                        minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
+                        def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
                         println "Waiting for bootstrap repository creation by ${minion_name_without_ssh} for ${node}."
                         waitUntil {
                             bootstrap_repository_status[minion_name_without_ssh] != 'NOT_CREATED'


### PR DESCRIPTION
Change BV pipeline to correctly create activation for ssh minion after waiting for MU and no MU channel has been created.
minion_name_without_ssh needs to be declared locally or it will be replaced dynamically by the last updated value.