### PR TITLE
Use openSUSE Leap for monitoring in Uyuni BV

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -1123,7 +1123,7 @@ module "monitoring-server" {
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-released"
   name               = "monitoring"
-  image              = "sles15sp4o"
+  image              = "opensuse154o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:a3"
     memory             = 2048

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1413,7 +1413,7 @@ module "monitoring-server" {
   base_configuration = module.base_retail.configuration
   product_version    = "uyuni-released"
   name               = "monitoring"
-  image              = "sles15sp4o"
+  image              = "opensuse154o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:6f"
     memory             = 2048


### PR DESCRIPTION
This will also use openSUSE Leap 15.4 for the monitoring server in the Uyuni BV.