### PR TITLE
Adjust the Uyuni BV

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -10,7 +10,6 @@ node('sumaform-cucumber') {
             'sle15sp5_minion, sle15sp5_ssh_minion, ' +
             'alma9_minion, alma9_ssh_minion, ' +
             'centos7_minion, centos7_ssh_minion, ' +
-            'liberty9_minion, liberty9_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -10,7 +10,6 @@ node('sumaform-cucumber-provo') {
             'sle15sp5_minion, sle15sp5_ssh_minion, ' +
             'alma9_minion, alma9_ssh_minion, ' +
             'centos7_client, centos7_minion, centos7_ssh_minion, ' +
-            'liberty9_minion, liberty9_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -101,7 +101,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "opensuse154o" ]
+  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "opensuse154o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -365,27 +365,6 @@ module "centos7-minion" {
   image              = "centos7o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:b7"
-    memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
-
-module "liberty9-minion" {
-  source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
-  name               = "min-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:c5"
     memory             = 4096
   }
   server_configuration = {
@@ -800,23 +779,6 @@ module "centos7-sshminion" {
   install_salt_bundle = true
 }
 
-module "liberty9-sshminion" {
-  source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
-  name               = "minssh-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:e5"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
-
 module "oracle9-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
@@ -1151,9 +1113,6 @@ module "controller" {
 
   centos7_minion_configuration    = module.centos7-minion.configuration
   centos7_sshminion_configuration = module.centos7-sshminion.configuration
-
-  liberty9_minion_configuration    = module.liberty9-minion.configuration
-  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9-minion.configuration
   oracle9_sshminion_configuration = module.oracle9-sshminion.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -144,7 +144,7 @@ module "base_core" {
 module "server" {
   source             = "./modules/server"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "srv"
   provider_settings = {
     mac                = "aa:b2:93:02:01:a1"
@@ -181,7 +181,7 @@ module "server" {
 module "proxy" {
   source             = "./modules/proxy"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "pxy"
   provider_settings = {
     mac                = "aa:b2:93:02:01:a2"
@@ -208,7 +208,7 @@ module "proxy" {
 module "sles12sp4-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
@@ -226,7 +226,7 @@ module "sles12sp4-minion" {
 module "sles12sp5-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -244,7 +244,7 @@ module "sles12sp5-minion" {
 module "sles15sp1-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
@@ -263,7 +263,7 @@ module "sles15sp1-minion" {
 module "sles15sp2-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp2"
   image              = "sles15sp2o"
   provider_settings = {
@@ -282,7 +282,7 @@ module "sles15sp2-minion" {
 module "sles15sp3-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp3"
   image              = "sles15sp3o"
   provider_settings = {
@@ -301,7 +301,7 @@ module "sles15sp3-minion" {
 module "sles15sp4-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -320,7 +320,7 @@ module "sles15sp4-minion" {
 module "sles15sp5-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp5"
   image              = "sles15sp5o"
   provider_settings = {
@@ -339,7 +339,7 @@ module "sles15sp5-minion" {
 module "alma9-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-alma9"
   image              = "almalinux9o"
   provider_settings = {
@@ -360,7 +360,7 @@ module "alma9-minion" {
 module "centos7-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-centos7"
   image              = "centos7o"
   provider_settings = {
@@ -381,7 +381,7 @@ module "centos7-minion" {
 module "oracle9-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-oracle9"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -402,7 +402,7 @@ module "oracle9-minion" {
 module "rocky8-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-rocky8"
   image              = "rocky8o"
   provider_settings = {
@@ -424,7 +424,7 @@ module "rocky8-minion" {
 module "rocky9-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-rocky9"
   image              = "rocky9o"
   provider_settings = {
@@ -445,7 +445,7 @@ module "rocky9-minion" {
 module "ubuntu2004-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -463,7 +463,7 @@ module "ubuntu2004-minion" {
 module "ubuntu2204-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-ubuntu2204"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -483,7 +483,7 @@ module "ubuntu2204-minion" {
 module "debian10-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-debian10"
   image              = "debian10o"
   provider_settings = {
@@ -502,7 +502,7 @@ module "debian10-minion" {
 module "debian11-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-debian11"
   image              = "debian11o"
   provider_settings = {
@@ -525,7 +525,7 @@ module "debian11-minion" {
 //  }
 //  source             = "./modules/minion"
 //  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-released"
+//  product_version    = "uyuni-master"
 //  name               = "min-opensuse154arm"
 //  image              = "opensuse154armo"
 //  provider_settings = {
@@ -549,7 +549,7 @@ module "debian11-minion" {
 //  }
 //  source             = "./modules/minion"
 //  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-released"
+//  product_version    = "uyuni-master"
 //  name               = "min-opensuse155arm"
 //  image              = "opensuse155armo"
 //  provider_settings = {
@@ -569,7 +569,7 @@ module "debian11-minion" {
 module "slemicro51-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro51"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -588,7 +588,7 @@ module "slemicro51-minion" {
 module "slemicro52-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro52"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -607,7 +607,7 @@ module "slemicro52-minion" {
 module "slemicro53-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro53"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -626,7 +626,7 @@ module "slemicro53-minion" {
 module "slemicro54-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro54"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -645,7 +645,7 @@ module "slemicro54-minion" {
 module "sles12sp4-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
@@ -661,7 +661,7 @@ module "sles12sp4-sshminion" {
 module "sles12sp5-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -677,7 +677,7 @@ module "sles12sp5-sshminion" {
 module "sles15sp1-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
@@ -692,7 +692,7 @@ module "sles15sp1-sshminion" {
 module "sles15sp2-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp2"
   image              = "sles15sp2o"
   provider_settings = {
@@ -706,7 +706,7 @@ module "sles15sp2-sshminion" {
 module "sles15sp3-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp3"
   image              = "sles15sp3o"
   provider_settings = {
@@ -720,7 +720,7 @@ module "sles15sp3-sshminion" {
 module "sles15sp4-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -734,7 +734,7 @@ module "sles15sp4-sshminion" {
 module "sles15sp5-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp5"
   image              = "sles15sp5o"
   provider_settings = {
@@ -748,7 +748,7 @@ module "sles15sp5-sshminion" {
 module "alma9-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-alma9"
   image              = "almalinux9o"
   provider_settings = {
@@ -765,7 +765,7 @@ module "alma9-sshminion" {
 module "centos7-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-centos7"
   image              = "centos7o"
   provider_settings = {
@@ -782,7 +782,7 @@ module "centos7-sshminion" {
 module "oracle9-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-oracle9"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -799,7 +799,7 @@ module "oracle9-sshminion" {
 module "rocky8-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-rocky8"
   image              = "rocky8o"
   provider_settings = {
@@ -816,7 +816,7 @@ module "rocky8-sshminion" {
 module "rocky9-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-rocky9"
   image              = "rocky9o"
   provider_settings = {
@@ -833,7 +833,7 @@ module "rocky9-sshminion" {
 module "ubuntu2004-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -847,7 +847,7 @@ module "ubuntu2004-sshminion" {
 module "ubuntu2204-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-ubuntu2204"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -863,7 +863,7 @@ module "ubuntu2204-sshminion" {
 module "debian10-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-debian10"
   image              = "debian10o"
   provider_settings = {
@@ -877,7 +877,7 @@ module "debian10-sshminion" {
 module "debian11-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-debian11"
   image              = "debian11o"
   provider_settings = {
@@ -895,7 +895,7 @@ module "debian11-sshminion" {
 //  }
 //  source             = "./modules/sshminion"
 //  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-released"
+//  product_version    = "uyuni-master"
 //  name               = "minssh-opensuse154arm"
 //  image              = "opensuse154armo"
 //  provider_settings = {
@@ -915,7 +915,7 @@ module "debian11-sshminion" {
 //  }
 //  source             = "./modules/sshminion"
 //  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-released"
+//  product_version    = "uyuni-master"
 //  name               = "minssh-opensuse155arm"
 //  image              = "opensuse155armo"
 //  provider_settings = {
@@ -931,7 +931,7 @@ module "debian11-sshminion" {
 module "slemicro51-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro51"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -945,7 +945,7 @@ module "slemicro51-sshminion" {
 module "slemicro52-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro52"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -959,7 +959,7 @@ module "slemicro52-sshminion" {
 module "slemicro53-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro53"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -973,7 +973,7 @@ module "slemicro53-sshminion" {
 module "slemicro54-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro54"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -987,7 +987,7 @@ module "slemicro54-sshminion" {
 module "sles12sp5-buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "build-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1019,7 +1019,7 @@ module "sles12sp5-terminal" {
 module "sles15sp4-buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "build-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1051,7 +1051,7 @@ module "sles15sp4-terminal" {
 module "monitoring-server" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "monitoring"
   image              = "opensuse154o"
   provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -289,7 +289,7 @@ module "base_arm" {
 module "server" {
   source             = "./modules/server"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "srv"
   provider_settings = {
     mac                = "aa:b2:93:02:01:6d"
@@ -329,7 +329,7 @@ module "proxy" {
   }
   source             = "./modules/proxy"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "pxy"
   provider_settings = {
     mac                = "aa:b2:93:02:01:6e"
@@ -359,7 +359,7 @@ module "sles12sp4-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
@@ -380,7 +380,7 @@ module "sles12sp5-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -401,7 +401,7 @@ module "sles15sp1-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
@@ -423,7 +423,7 @@ module "sles15sp2-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp2"
   image              = "sles15sp2o"
   provider_settings = {
@@ -445,7 +445,7 @@ module "sles15sp3-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp3"
   image              = "sles15sp3o"
   provider_settings = {
@@ -467,7 +467,7 @@ module "sles15sp4-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -489,7 +489,7 @@ module "sles15sp5-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-sles15sp5"
   image              = "sles15sp5o"
   provider_settings = {
@@ -511,7 +511,7 @@ module "alma9-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-alma9"
   image              = "almalinux9o"
   provider_settings = {
@@ -535,7 +535,7 @@ module "centos7-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-centos7"
   image              = "centos7o"
   provider_settings = {
@@ -560,7 +560,7 @@ module "oracle9-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-oracle9"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -584,7 +584,7 @@ module "rocky8-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-rocky8"
   image              = "rocky8o"
   provider_settings = {
@@ -608,7 +608,7 @@ module "rocky9-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-rocky9"
   image              = "rocky9o"
   provider_settings = {
@@ -632,7 +632,7 @@ module "ubuntu2004-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -653,7 +653,7 @@ module "ubuntu2204-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-ubuntu2204"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -676,7 +676,7 @@ module "debian10-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-debian10"
   image              = "debian10o"
   provider_settings = {
@@ -698,7 +698,7 @@ module "debian11-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-debian11"
   image              = "debian11o"
   provider_settings = {
@@ -720,7 +720,7 @@ module "opensuse154arm-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-opensuse154arm"
   image              = "opensuse154armo"
   provider_settings = {
@@ -743,7 +743,7 @@ module "opensuse155arm-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-opensuse155arm"
   image              = "opensuse155armo"
   provider_settings = {
@@ -766,7 +766,7 @@ module "slemicro51-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro51"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -788,7 +788,7 @@ module "slemicro52-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro52"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -810,7 +810,7 @@ module "slemicro53-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro53"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -832,7 +832,7 @@ module "slemicro54-minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "min-slemicro54"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -854,7 +854,7 @@ module "sles12sp4-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles12sp4"
   image              = "sles12sp4o"
   provider_settings = {
@@ -873,7 +873,7 @@ module "sles12sp5-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -892,7 +892,7 @@ module "sles15sp1-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp1"
   image              = "sles15sp1o"
   provider_settings = {
@@ -910,7 +910,7 @@ module "sles15sp2-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp2"
   image              = "sles15sp2o"
   provider_settings = {
@@ -927,7 +927,7 @@ module "sles15sp3-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp3"
   image              = "sles15sp3o"
   provider_settings = {
@@ -944,7 +944,7 @@ module "sles15sp4-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -961,7 +961,7 @@ module "sles15sp5-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-sles15sp5"
   image              = "sles15sp5o"
   provider_settings = {
@@ -978,7 +978,7 @@ module "alma9-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-alma9"
   image              = "almalinux9o"
   provider_settings = {
@@ -998,7 +998,7 @@ module "centos7-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-centos7"
   image              = "centos7o"
   provider_settings = {
@@ -1018,7 +1018,7 @@ module "oracle9-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-oracle9"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -1038,7 +1038,7 @@ module "rocky8-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-rocky8"
   image              = "rocky8o"
   provider_settings = {
@@ -1058,7 +1058,7 @@ module "rocky9-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-rocky9"
   image              = "rocky9o"
   provider_settings = {
@@ -1078,7 +1078,7 @@ module "ubuntu2004-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1095,7 +1095,7 @@ module "ubuntu2204-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-ubuntu2204"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1114,7 +1114,7 @@ module "debian10-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-debian10"
   image              = "debian10o"
   provider_settings = {
@@ -1131,7 +1131,7 @@ module "debian11-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-debian11"
   image              = "debian11o"
   provider_settings = {
@@ -1148,7 +1148,7 @@ module "opensuse154arm-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-opensuse154arm"
   image              = "opensuse154armo"
   provider_settings = {
@@ -1167,7 +1167,7 @@ module "opensuse155arm-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-opensuse155arm"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1186,7 +1186,7 @@ module "slemicro51-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro51"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -1203,7 +1203,7 @@ module "slemicro52-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro52"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -1220,7 +1220,7 @@ module "slemicro53-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro53"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -1237,7 +1237,7 @@ module "slemicro54-sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "minssh-slemicro54"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -1254,7 +1254,7 @@ module "sles12sp5-buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "build-sles12sp5"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1292,7 +1292,7 @@ module "sles15sp4-buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "build-sles15sp4"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1330,7 +1330,7 @@ module "monitoring-server" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-released"
+  product_version    = "uyuni-master"
   name               = "monitoring"
   image              = "opensuse154o"
   provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -172,7 +172,7 @@ module "base_res" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o" ]
+  images      = [ "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -553,29 +553,6 @@ module "centos7-minion" {
   install_salt_bundle = true
 }
 
-module "liberty9-minion" {
-  providers = {
-    libvirt = libvirt.cosmopolitan
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
-  name               = "min-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:91"
-    memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
 
 module "oracle9-minion" {
   providers = {
@@ -1035,26 +1012,6 @@ module "centos7-sshminion" {
   install_salt_bundle = true
 }
 
-module "liberty9-sshminion" {
-  providers = {
-    libvirt = libvirt.cosmopolitan
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_res.configuration
-  product_version    = "uyuni-released"
-  name               = "minssh-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:b1"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
-
 module "oracle9-sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
@@ -1435,9 +1392,6 @@ module "controller" {
 
   centos7_minion_configuration    = module.centos7-minion.configuration
   centos7_sshminion_configuration = module.centos7-sshminion.configuration
-
-  liberty9_minion_configuration    = module.liberty9-minion.configuration
-  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9-minion.configuration
   oracle9_sshminion_configuration = module.oracle9-sshminion.configuration


### PR DESCRIPTION
This will

- remove Liberty Linux 9 (no support, yet)
- switch from `uyuni-released` to `uyuni-master`
