### PR TITLE
temporary fix: use sles15sp4o instead of opensuse154o

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse154o"]
+  images = ["rocky8o", "opensuse154o", "sles15sp4o"]
 
   use_avahi    = false
   name_prefix  = "suma-testhexagon-"
@@ -151,7 +151,7 @@ module "cucumber_testsuite" {
     }
 
     suse-minion = {
-      image = "opensuse154o"
+      image = "sles15sp4o"
       name = "min-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:56"
@@ -160,7 +160,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     suse-sshminion = {
-      image = "opensuse154o"
+      image = "sles15sp4o"
       name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:58"
@@ -182,12 +182,12 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     pxeboot-minion = {
-      image = "opensuse154o"
+      image = "sles15sp4o"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
     build-host = {
-      image = "opensuse154o"
+      image = "sles15sp4o"
       name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:00:5d"


### PR DESCRIPTION
use sles15sp4 image instead of opensuse154o, to fix quickly podman tests. We should remove it once master acceptance tests will be green again.

```
    "comment": "An error was encountered while installing package(s): Zypper command failure: Running scope as unit: run-r3fab6dc3997e4c4c807c15d793b15a9e.scopeLoading repository data...\nReading installed packages...\nResolving package dependencies...\n2 Problems:\nProblem: the installed product:Leap-15.4-1.x86_64 conflicts with 'namespace:otherproviders(distribution-release)' provided by the to be installed product:SLES-15.4-0.x86_64\nProblem: the to be installed product:SLES-15.4-0.x86_64 requires 'product(SLES) = 15.4-0', but this requirement cannot be provided\n\nProblem: the installed product:Leap-15.4-1.x86_64 conflicts with 'namespace:otherproviders(distribution-release)' provided by the to be installed product:SLES-15.4-0.x86_64\n Solution 1: Following actions will be done:\n  do not install product:SLES-15.4-0.x86_64\n  do not install product:sle-module-server-applications-15.4-0.x86_64\n  do not install product:sle-module-server-applications-15.4-0.x86_64\n  do not install product:sle-module-development-tools-15.4-0.x86_64\n  do not install product:sle-module-development-tools-15.4-0.x86_64\n  do not install product:sle-module-desktop-applications-15.4-0.x86_64\n  do not install product:sle-module-desktop-applications-15.4-0.x86_64\n  do not install product:sle-module-containers-15.4-0.x86_64\n  do not install product:sle-module-containers-15.4-0.x86_64\n  do not install product:sle-module-basesystem-15.4-0.x86_64\n  do not install product:sle-module-basesystem-15.4-0.x86_64\n Solution 2: deinstallation of product:Leap-15.4-1.x86_64\n\nChoose from above solutions by number or skip, retry or cancel [1/2/s/r/c/d/?] (c): c",
```