### PR TITLE
Disable java_debugging in BV environments

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation-NUE.tf
@@ -156,6 +156,7 @@ module "server" {
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
   repository_disk_size = 2048
 
+  java_debugging                 = false
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false

--- a/terracumber_config/tf_files/SUSEManager-4.2-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-build-validation-PRV.tf
@@ -301,6 +301,7 @@ module "server" {
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   repository_disk_size = 2048
 
+  java_debugging                 = false
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -170,6 +170,7 @@ module "server" {
   repository_disk_size       = 1500
   server_registration_code   = var.SERVER_REGISTRATION_CODE
 
+  java_debugging                 = false
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -156,6 +156,7 @@ module "server" {
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
   repository_disk_size = 2048
 
+  java_debugging                 = false
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -301,6 +301,7 @@ module "server" {
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   repository_disk_size = 2048
 
+  java_debugging                 = false
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -156,6 +156,7 @@ module "server" {
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
   repository_disk_size = 2048
 
+  java_debugging                 = false
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -301,6 +301,7 @@ module "server" {
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   repository_disk_size = 2048
 
+  java_debugging                 = false
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false


### PR DESCRIPTION
This is just a proposal to speed up our BV tests.
Currently we have extra java logs printed out by default. With this PR, we will disable those extra debugging logs.