### PR TITLE
Add the Leap 15.5 image to the Reference environment for Master

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse154o", "ubuntu2204o", "sles15sp4o"]
+  images = ["rocky8o", "opensuse154o", "opensuse155o", "ubuntu2204o", "sles15sp4o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-refmaster-"


### PR DESCRIPTION
Seems https://github.com/SUSE/susemanager-ci/pull/951 took care of the acceptance test environment for master, but didn't change refmaster.

So refmaster fails  with:

```
07:44:40  │ Error: Can't retrieve base volume with name 'uyuni-refmaster-opensuse155o': virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching name 'uyuni-refmaster-opensuse155o'')