### PR TITLE
Fix Undelivered Mail Returned to Sender error

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.2-AWS-uyuni.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-AWS-uyuni.tf
@@ -48,7 +48,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-PRV.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-4.2-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.2-refenv-PRV.tf
@@ -51,7 +51,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -51,7 +51,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
@@ -51,7 +51,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -51,7 +51,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
@@ -46,7 +46,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -51,7 +51,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -47,7 +47,7 @@ variable "MAIL_TEMPLATE_ENV_FAIL" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -57,7 +57,7 @@ variable "HYPER" {
 
 variable "MAIL_FROM" {
   type = string
-  default = "galaxy-ci@suse.de"
+  default = "jenkins@suse.de"
 }
 
 variable "MAIL_TO" {


### PR DESCRIPTION
Recently, we saw the following issue on our `galaxy-ci` mailing list:

```bash
Diagnostic-Code: smtp; 554 5.7.1 <galaxy-ci@suse.de>: Sender address rejected:
    We don't accept our own addresses as sender address on this host!
```