### PR TITLE
Terraform validation: Use 'plan' instead of 'apply/destroy'

### DIFF
--- a/.github/workflows/sumaform-validation.yml
+++ b/.github/workflows/sumaform-validation.yml
@@ -50,7 +50,6 @@ jobs:
             # export TF_LOG=trace
             terraform init -input=false
             terraform validate
-            terraform apply -auto-approve -input=false
-            terraform destroy -auto-approve -input=false
+            terraform plan -input=false
             echo
           done


### PR DESCRIPTION
Some .tf files have post-deployment provisioning steps that try to ssh into deployed hosts. Since the 'null' provider doesn't actually deploy any hosts with 'apply', these provisioning steps fail.