### PR TITLE
Use normalize name for rh and deb like minion in uyuni PR testing

### DIFF
--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:06"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:07"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:96"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:97"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:16"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:17"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:26"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:27"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:36"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:37"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env5.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:46"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:47"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env6.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:56"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:57"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:66"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:67"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:76"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:77"
       }

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -256,7 +256,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
+      name = "min-rhlike"
       provider_settings = {
         mac = "aa:b2:92:04:00:86"
         memory = 2048
@@ -270,7 +270,7 @@ module "cucumber_testsuite" {
     }
     debian-minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
+      name = "min-deblike"
       provider_settings = {
         mac = "aa:b2:92:04:00:87"
       }


### PR DESCRIPTION
I'm currently working on a main.tf template to be use accross all PR testing ( NUE / PRV and uyuni / manager ).
We are already using normalize name for suse minions but not for rh and deb like minions ( those normalize names are already used in CI ) .

This PR will normalize rh and deb minion name.

Require : https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/813
Related to : https://github.com/SUSE/susemanager-ci/pull/898