### PR TITLE
Debian 12 is bundle-only

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -354,6 +354,9 @@ module "ubuntu2004-minion" {
 //  provider_settings = {
 //    instance_type = "t3a.medium"
 //  }
+//
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 //}
 
 module "rocky8-minion" {
@@ -500,6 +503,9 @@ module "ubuntu2004-sshminion" {
 //  provider_settings = {
 //    instance_type = "t3a.medium"
 //  }
+//
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 //}
 
 module "rocky8-sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -701,6 +701,9 @@ module "debian12-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 // WORKAROUND: overdrive3 has been disconnected by mistake
@@ -1102,6 +1105,9 @@ module "debian12-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 // WORKAROUND: overdrive3 has been disconnected by mistake

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1407,6 +1407,9 @@ module "debian12-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "opensuse154arm-sshminion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -536,6 +536,9 @@ module "debian12-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 // WORKAROUND: overdrive3 has been disconnected by mistake
@@ -920,6 +923,9 @@ module "debian12-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 // WORKAROUND: overdrive3 has been disconnected by mistake

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -735,6 +735,9 @@ module "debian12-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "opensuse154arm-minion" {
@@ -1180,6 +1183,9 @@ module "debian12-sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
 }
 
 module "opensuse154arm-sshminion" {


### PR DESCRIPTION
This PR tells to use the bundle for every Debian 12 instance.

As there's no real choice, I would have preferred to do it in sumaform, but I did not manage.

Tested to work on debian12 minion in 4.3 BV PRV.