### PR TITLE
Remove monitoring stage from QE SLE testsuite since we do not deploy monitoring server

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-sle-update
+++ b/jenkins_pipelines/environments/manager-4.3-qe-sle-update
@@ -27,7 +27,6 @@ node('sumaform-cucumber-provo') {
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),
             booleanParam(name: 'must_sync', defaultValue: true, description: 'Sync. products and channels'),
             booleanParam(name: 'enable_proxy_stages', defaultValue: true, description: 'Run Proxy stages'),
-            booleanParam(name: 'enable_monitoring_stages', defaultValue: false, description: 'Run Monitoring stages'),
             booleanParam(name: 'enable_client_stages', defaultValue: true, description: 'Run Client stages'),
             booleanParam(name: 'must_add_MU_repositories', defaultValue: true, description: 'Add MU channels'),
             booleanParam(name: 'must_add_non_MU_repositories', defaultValue: true, description: 'Add non MU channels'),


### PR DESCRIPTION
The possibility to check the stage is still there, even if it's not used by default. Checking the stage and running it would cause an error:

```
 Don't know how to build task 'cucumber:build_validation_add_maintenance_update_repositories_monitoring_server' (See the list of available tasks with `rake --tasks`)
```

Removing it should prevent this from happening. 