### PR TITLE
Update Test Ion gitrepo and infra

### DIFF
--- a/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
@@ -6,8 +6,8 @@ node('sumaform-cucumber') {
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([
-            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SchoolGuy/uyuni.git', description: 'Testsuite Git Repository'),
-            string(name: 'cucumber_ref', defaultValue: 'fix/xml-rpc-createSystemRecord', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-4.3', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -132,6 +132,7 @@ module "cucumber_testsuite" {
       }
       additional_repos = {
         server_stack = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Ion/images/repo/SLE-Module-SUSE-Manager-Server-4.3-POOL-x86_64-Media1/"
+        test_python_remote_bump = "http://download.suse.de/ibs/SUSE:/Maintenance:/31259/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/"
       }
     }
     proxy = {


### PR DESCRIPTION
Update `manager-TEST-Ion-2obs` job to point to `spacewalk/Manager-4.3` and add a repo to the instance to test the `python-requests` version bump.