### PR TITLE
Synchronization of MU repositories is done when we add them.

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -253,10 +253,7 @@ def run(params) {
                     echo 'Add custom channels and MU repositories'
                     res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_proxy'")
                     echo "Custom channels and MU repositories status code: ${res_mu_repos}"
-
-                    res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'")
-                    echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
-                    sh "exit \$(( ${res_mu_repos}|${res_sync_mu_repos} ))"
+                    sh "exit \$(( ${res_mu_repos} ))"
                 }
             }
             stage('Add Activation Keys Proxy') {
@@ -303,10 +300,7 @@ def run(params) {
                             echo 'Add custom channels and MU repositories'
                             res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_monitoring_server'")
                             echo "Custom channels and MU repositories status code: ${res_mu_repos}"
-
-                            res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'")
-                            echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
-                            sh "exit \$(( ${res_mu_repos}|${res_sync_mu_repos} ))"
+                            sh "exit \$(( ${res_mu_repos} ))"
                         }
                     }
                     stage('Add Activation Keys Monitoring') {
@@ -510,12 +504,7 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                             error("Add custom channels and MU repositories failed with status code: ${res_mu_repos}")
                         }
                         echo "Custom channels and MU repositories status code: ${res_mu_repos}"
-                        res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export NODE=${node}; unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'", returnStatus: true)
-                        echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
-                        if (res_sync_mu_repos != 0) {
-                            mu_sync_status[node] = 'FAIL'
-                            error("Custom channels and MU repositories synchronization failed with status code: ${res_sync_mu_repos}")
-                        }
+
                         // Update minion repo sync status variable once the MU channel is synchronized
                         mu_sync_status[node] = 'SYNC'
                     }
@@ -534,11 +523,6 @@ def clientTestingStages(capybara_timeout, default_timeout) {
                         echo "Non MU Repositories status code: ${res_non_MU_repositories}"
                         if (res_non_MU_repositories != 0) {
                             error("Add common channels failed with status code: ${res_non_MU_repositories}")
-                        }
-                        res_sync_non_MU_repositories = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export NODE=${node}; unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'", returnStatus: true)
-                        echo "Non MU Repositories synchronization status code: ${res_sync_non_MU_repositories}"
-                        if (res_sync_non_MU_repositories != 0) {
-                            error("Non MU Repositories synchronization failed with status code: ${res_sync_non_MU_repositories}")
                         }
                     }
                 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -107,10 +107,7 @@ def run(params) {
                     echo 'Add custom channels and MU repositories'
                     res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_proxy'")
                     echo "Custom channels and MU repositories status code: ${res_mu_repos}"
-
-                    res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'")
-                    echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
-                    sh "exit \$(( ${res_mu_repos}|${res_sync_mu_repos} ))"
+                    sh "exit \$( ${res_mu_repos} )"
                 }
             }
             stage('Add Activation Keys Proxy') {
@@ -157,10 +154,7 @@ def run(params) {
                             echo 'Add custom channels and MU repositories'
                             res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_monitoring_server'")
                             echo "Custom channels and MU repositories status code: ${res_mu_repos}"
-
-                            res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'")
-                            echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
-                            sh "exit \$(( ${res_mu_repos}|${res_sync_mu_repos} ))"
+                            sh "exit \$( ${res_mu_repos} )"
                         }
                     }
                     stage('Add Activation Keys Monitoring') {
@@ -352,12 +346,6 @@ def clientTestingStages() {
                             error("Add custom channels and MU repositories failed with status code: ${res_mu_repos}")
                         }
                         echo "Custom channels and MU repositories status code: ${res_mu_repos}"
-                        res_sync_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export NODE=${node}; unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'", returnStatus: true)
-                        echo "Custom channels and MU repositories synchronization status code: ${res_sync_mu_repos}"
-                        if (res_sync_mu_repos != 0) {
-                            required_custom_channel_status[node] = 'FAIL'
-                            error("Custom channels and MU repositories synchronization failed with status code: ${res_sync_mu_repos}")
-                        }
                     }
                 }
                 // Don't update required_custom_channel_status for minion who needs non MU repositories
@@ -380,12 +368,6 @@ def clientTestingStages() {
                             if (res_non_MU_repositories != 0) {
                                 required_custom_channel_status[node] = 'FAIL'
                                 error("Add common channels failed with status code: ${res_non_MU_repositories}")
-                            }
-                            res_sync_non_MU_repositories = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export NODE=${node}; unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_custom_reposync'", returnStatus: true)
-                            echo "Non MU Repositories synchronization status code: ${res_sync_non_MU_repositories}"
-                            if (res_sync_non_MU_repositories != 0) {
-                                required_custom_channel_status[node] = 'FAIL'
-                                error("Non MU Repositories synchronization failed with status code: ${res_sync_non_MU_repositories}")
                             }
                         }
                     }


### PR DESCRIPTION
As we are waiting to synchronize the different channels at the same time we trigger the synchronization of them, we don't need any more this separate rake task.