### PR TITLE
QE: Add BV entries for SLE Micro 5.5 minions

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -15,7 +15,8 @@ node('sumaform-cucumber-provo') {
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian10_minion, debian10_ssh_minion, debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
-            'slemicro51_minion, slemicro51_ssh_minion, slemicro52_minion, slemicro52_ssh_minion, slemicro53_minion, slemicro53_ssh_minion, slemicro54_minion, slemicro54_ssh_minion'
+            'slemicro51_minion, slemicro51_ssh_minion, slemicro52_minion, slemicro52_ssh_minion, slemicro53_minion, slemicro53_ssh_minion, slemicro54_minion, slemicro54_ssh_minion, ' +
+            'slemicro55_minion, slemicro55_ssh_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -20,7 +20,8 @@ node('sumaform-cucumber') {
             'slemicro51_minion, slemicro51_ssh_minion, ' +
             'slemicro52_minion, slemicro52_ssh_minion, ' +
             'slemicro53_minion, slemicro53_ssh_minion, ' +
-            'slemicro54_minion, slemicro54_ssh_minion'
+            'slemicro54_minion, slemicro54_ssh_minion, ' +
+            'slemicro55_minion, slemicro55_ssh_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -20,7 +20,8 @@ node('sumaform-cucumber-provo') {
             'slemicro51_minion, slemicro51_ssh_minion, ' +
             'slemicro52_minion, slemicro52_ssh_minion, ' +
             'slemicro53_minion, slemicro53_ssh_minion, ' +
-            'slemicro54_minion, slemicro54_ssh_minion'
+            'slemicro54_minion, slemicro54_ssh_minion, ' +
+            'slemicro55_minion, slemicro55_ssh_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -19,7 +19,8 @@ node('sumaform-cucumber') {
             'slemicro51_minion, slemicro51_ssh_minion, ' +
             'slemicro52_minion, slemicro52_ssh_minion, ' +
             'slemicro53_minion, slemicro53_ssh_minion, ' +
-            'slemicro54_minion, slemicro54_ssh_minion'
+            'slemicro54_minion, slemicro54_ssh_minion, ' +
+            'slemicro55_minion, slemicro55_ssh_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -19,7 +19,8 @@ node('sumaform-cucumber-provo') {
             'slemicro51_minion, slemicro51_ssh_minion, ' +
             'slemicro52_minion, slemicro52_ssh_minion, ' +
             'slemicro53_minion, slemicro53_ssh_minion, ' +
-            'slemicro54_minion, slemicro54_ssh_minion'
+            'slemicro54_minion, slemicro54_ssh_minion, ' +
+            'slemicro55_minion, slemicro55_ssh_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/scripts/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/maintenance_json_generator.py
@@ -71,6 +71,9 @@ defaultdict = {
     "slemicro54_minion": ["/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SUSE-MicroOS_5.4_x86_64/",
                           "/SUSE_Updates_SLE-Micro_5.4_x86_64/"],
+    "slemicro55_minion": ["/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/",
+                          "/SUSE_Updates_SUSE-MicroOS_5.5_x86_64/",
+                          "/SUSE_Updates_SLE-Micro_5.5_x86_64/"],
 }
 
 # Dictionary for SUMA 4.3 Server and Proxy, which is then added together with the common dictionary for client tools

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -112,7 +112,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o" ]
+  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -877,6 +877,25 @@ module "slemicro54-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro55-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:ca"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp4-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
@@ -1279,6 +1298,20 @@ module "slemicro54-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro55-sshminion" {
+  source             = "./modules/sshminion"
+  base_configuration = module.base_core.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:ea"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp5-buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
@@ -1466,6 +1499,9 @@ module "controller" {
 
   slemicro54_minion_configuration    = module.slemicro54-minion.configuration
   slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
+
+  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -208,7 +208,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55-ign" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1116,6 +1116,29 @@ module "slemicro54-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro55-minion" {
+  providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:ca"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+
 module "sles12sp4-sshminion" {
   providers = {
     libvirt = libvirt.endor
@@ -1584,6 +1607,23 @@ module "slemicro54-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro55-sshminion" {
+ providers = {
+    libvirt = libvirt.giediprime
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:ea"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp5-buildhost" {
   providers = {
     libvirt = libvirt.coruscant
@@ -1786,6 +1826,9 @@ module "controller" {
 
   slemicro54_minion_configuration    = module.slemicro54-minion.configuration
   slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
+
+  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -112,7 +112,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o" ]
+  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -710,6 +710,25 @@ module "slemicro54-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro55-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "uyuni-master"
+  name               = "min-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:ca"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp4-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
@@ -1093,6 +1112,20 @@ module "slemicro54-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro55-sshminion" {
+  source             = "./modules/sshminion"
+  base_configuration = module.base_core.configuration
+  product_version    = "uyuni-master"
+  name               = "minssh-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:ea"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp5-buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
@@ -1269,6 +1302,9 @@ module "controller" {
 
   slemicro54_minion_configuration    = module.slemicro54-minion.configuration
   slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
+
+  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -208,7 +208,7 @@ module "base_new_sle" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -924,6 +924,29 @@ module "slemicro54-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro55-minion" {
+  providers = {
+    libvirt = libvirt.ginfizz
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "uyuni-master"
+  name               = "min-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:96"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+
 module "sles12sp4-sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
@@ -1305,7 +1328,7 @@ module "debian12-sshminion" {
 //}
 
 module "slemicro51-sshminion" {
- providers = {
+  providers = {
     libvirt = libvirt.ginfizz
   }
   source             = "./modules/sshminion"
@@ -1322,7 +1345,7 @@ module "slemicro51-sshminion" {
 }
 
 module "slemicro52-sshminion" {
- providers = {
+  providers = {
     libvirt = libvirt.ginfizz
   }
   source             = "./modules/sshminion"
@@ -1339,7 +1362,7 @@ module "slemicro52-sshminion" {
 }
 
 module "slemicro53-sshminion" {
- providers = {
+  providers = {
     libvirt = libvirt.ginfizz
   }
   source             = "./modules/sshminion"
@@ -1356,7 +1379,7 @@ module "slemicro53-sshminion" {
 }
 
 module "slemicro54-sshminion" {
- providers = {
+  providers = {
     libvirt = libvirt.ginfizz
   }
   source             = "./modules/sshminion"
@@ -1366,6 +1389,23 @@ module "slemicro54-sshminion" {
   image              = "slemicro54-ign"
   provider_settings = {
     mac                = "aa:b2:93:02:01:b5"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "slemicro55-sshminion" {
+  providers = {
+    libvirt = libvirt.ginfizz
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "uyuni-master"
+  name               = "minssh-slemicro55"
+  image              = "slemicro55-ign"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:b6"
     memory             = 2048
   }
   use_os_released_updates = false
@@ -1563,6 +1603,9 @@ module "controller" {
 
   slemicro54_minion_configuration    = module.slemicro54-minion.configuration
   slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
+
+  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration


### PR DESCRIPTION
As the title implies, I've added some entries to support SLE Micro 5.5 in our BV pipelines.

This is related to https://github.com/SUSE/spacewalk/issues/22824

Edited files include:

- BV terraform configuration files 
-  BV Jenkins pipelines
- [maintenance_json_generator.py](https://github.com/SUSE/susemanager-ci/blob/master/jenkins_pipelines/scripts/maintenance_json_generator.py)