### PR TITLE
The bundle is now available on Ubuntu too

### DIFF
--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
@@ -255,9 +255,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
@@ -255,9 +255,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -185,10 +185,7 @@ module "cucumber_testsuite" {
         mac = "aa:b2:93:01:00:3b"
       }
       additional_packages = [ "venv-salt-minion" ]
-
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -190,10 +190,7 @@ module "cucumber_testsuite" {
         memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
-
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -190,10 +190,7 @@ module "cucumber_testsuite" {
         memory = 2048
       }
       additional_packages = [ "venv-salt-minion" ]
-
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -185,10 +185,7 @@ module "cucumber_testsuite" {
         mac = "aa:b2:93:01:00:2b"
       }
       additional_packages = [ "venv-salt-minion" ]
-
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -182,7 +182,7 @@ module "cucumber_testsuite" {
         memory = 4096
       }
       additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env1.tf
@@ -278,9 +278,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env10.tf
@@ -278,9 +278,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env2.tf
@@ -278,9 +278,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env3.tf
@@ -278,9 +278,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env4.tf
@@ -278,9 +278,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env7.tf
@@ -278,9 +278,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env8.tf
@@ -278,9 +278,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"

--- a/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
+++ b/terracumber_config/tf_files/Uyuni-PR-tests-env9.tf
@@ -279,9 +279,7 @@ module "cucumber_testsuite" {
         client_repo = var.DEBLIKE_CLIENT_REPO,
       }
       additional_packages = [ "venv-salt-minion" ]
-      // FIXME: cloudl-init fails if venv-salt-minion is not avaiable
-      // We can set "install_salt_bundle = true" as soon as venv-salt-minion is available Uyuni:Stable
-      install_salt_bundle = false
+      install_salt_bundle = true
     }
     build-host = {
       image = "sles15sp4o"


### PR DESCRIPTION
Remove an old FIXME

This will hopefully remove that error:
```
[2023-12-14T14:32:22.663Z] ^[[0m^[[1mmodule.cucumber_testsuite.module.debian-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):^[[0m ^[[0mpkg_resources.DistributionNotFound: The 'contextvars' distribution was not found and is required by salt
```