### PR TITLE
Remove nested VM entries

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -156,20 +156,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = var.IMAGE
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "suma-pr${var.ENVIRONMENT}-min-nested"
-            image = "http://${var.DOWNLOAD_ENDPOINT}/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://${var.DOWNLOAD_ENDPOINT}/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "suma-pr${var.ENVIRONMENT}-min-nested"
-            image = "http://${var.DOWNLOAD_ENDPOINT}/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://${var.DOWNLOAD_ENDPOINT}/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["kvm-host"]
       }
@@ -179,8 +166,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "suma-pr${var.ENVIRONMENT}-min-nested"
-  nested_vm_mac =  var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["nested-vm"]
+  
   provider_settings = {
     pool               = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].pool
     network_name       = null

--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
@@ -281,20 +281,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp4o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "suma-pr5-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "suma-pr5-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:92:04:00:4a"
       }
@@ -305,8 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "suma-pr5-min-nested"
-  nested_vm_mac =  "aa:b2:92:04:00:4b"
+
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
@@ -281,20 +281,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp4o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "suma-pr6-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "suma-pr6-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:92:04:00:5a"
       }
@@ -305,8 +292,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "suma-pr6-min-nested"
-  nested_vm_mac =  "aa:b2:92:04:00:5b"
+  
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -229,7 +229,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "min-nested"
+  
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -217,15 +217,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp4o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-        }
-      }
+    
       provider_settings = {
         mac = "aa:b2:92:03:00:8e"
         vcpu = 4
@@ -235,7 +227,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "min-nested"
+
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -208,20 +208,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp4o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "suma-head-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "suma-head-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:93:01:00:be"
         vcpu = 4
@@ -231,8 +218,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "suma-head-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:bf"
+  
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -217,20 +217,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse155o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "suma-testhexagon-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "suma-testhexagon-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:93:01:00:5e"
         vcpu = 4
@@ -240,8 +227,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "suma-testhexagon-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:5f"
+  
   provider_settings = {
     pool         = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -205,20 +205,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse154o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "uyuni-master-k3s-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "uyuni-master-k3s-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:93:01:00:3e"
       }
@@ -226,8 +213,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "uyuni-master-k3s-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:3f"
+  
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -211,20 +211,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse155o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "uyuni-master-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "uyuni-master-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:93:01:00:de"
         vcpu = 4
@@ -234,8 +221,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "uyuni-master-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:df"
+  
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -211,20 +211,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse155o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "uyuni-master-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "uyuni-master-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:92:03:00:de"
         vcpu = 4
@@ -234,8 +221,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "uyuni-master-min-nested"
-  nested_vm_mac =  "aa:b2:92:03:00:df"
+  
   provider_settings = {
     pool               = "images"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -205,20 +205,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse154o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "uyuni-master-podman-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "uyuni-master-podman-min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.suse.de/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:93:01:00:2e"
       }
@@ -226,8 +213,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "uyuni-master-podman-min-nested"
-  nested_vm_mac =  "aa:b2:93:01:00:2f"
+  
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -202,20 +202,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse155o"
       name = "min-kvm"
-      additional_grains = {
-        hvm_disk_image = {
-          leap = {
-            hostname = "min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256"
-          }
-          sles = {
-            hostname = "min-nested"
-            image = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
-            hash = "http://minima-mirror-ci-bv.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
-          }
-        }
-      }
+      
       provider_settings = {
         mac = "aa:b2:92:04:00:fa"
         memory = 8192
@@ -224,7 +211,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  nested_vm_host = "min-nested"
+  
   provider_settings = {
     pool               = "default"
     network_name       = null

--- a/terracumber_config/tf_files/tfvars/PR-testing-NUE-environments.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-NUE-environments.tfvars
@@ -17,7 +17,6 @@ ENVIRONMENT_CONFIGURATION = {
       debian-minion  = "aa:b2:93:01:03:57"
       build-host     = "aa:b2:93:01:03:59"
       kvm-host       = "aa:b2:93:01:03:5a"
-      nested-vm      = "aa:b2:93:01:03:5b"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.111.0/24"
@@ -35,7 +34,6 @@ ENVIRONMENT_CONFIGURATION = {
       debian-minion  = "aa:b2:93:01:03:64"
       build-host     = "aa:b2:93:01:03:65"
       kvm-host       = "aa:b2:93:01:03:66"
-      nested-vm      = "aa:b2:93:01:03:67"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.112.0/24"
@@ -53,7 +51,6 @@ ENVIRONMENT_CONFIGURATION = {
       debian-minion  = "aa:b2:93:01:03:70"
       build-host     = "aa:b2:93:01:03:71"
       kvm-host       = "aa:b2:93:01:03:72"
-      nested-vm      = "aa:b2:93:01:03:73"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.113.0/24"
@@ -71,7 +68,6 @@ ENVIRONMENT_CONFIGURATION = {
       debian-minion  = "aa:b2:93:01:03:7c"
       build-host     = "aa:b2:93:01:03:7d"
       kvm-host       = "aa:b2:93:01:03:7e"
-      nested-vm      = "aa:b2:93:01:03:7f"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.114.0/24"
@@ -89,7 +85,6 @@ ENVIRONMENT_CONFIGURATION = {
       debian-minion  = "aa:b2:93:01:03:88"
       build-host     = "aa:b2:93:01:03:89"
       kvm-host       = "aa:b2:93:01:03:8a"
-      nested-vm      = "aa:b2:93:01:03:8b"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.115.0/24"
@@ -107,7 +102,6 @@ ENVIRONMENT_CONFIGURATION = {
       debian-minion  = "aa:b2:93:01:03:94"
       build-host     = "aa:b2:93:01:03:95"
       kvm-host       = "aa:b2:93:01:03:96"
-      nested-vm      = "aa:b2:93:01:03:97"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.116.0/24"

--- a/terracumber_config/tf_files/tfvars/PR-testing-PRV-environments.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-PRV-environments.tfvars
@@ -17,7 +17,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:07"
       build-host     = "aa:b2:92:04:00:09"
       kvm-host       = "aa:b2:92:04:00:0a"
-      nested-vm      = "aa:b2:92:04:00:0b"
     }
     hypervisor = "romulus.mgr.prv.suse.net"
     additional_network = "192.168.101.0/24"
@@ -35,7 +34,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:17"
       build-host     = "aa:b2:92:04:00:19"
       kvm-host       = "aa:b2:92:04:00:1a"
-      nested-vm      = "aa:b2:92:04:00:1b"
     }
     hypervisor = "romulus.mgr.prv.suse.net"
     additional_network = "192.168.102.0/24"
@@ -53,7 +51,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:27"
       build-host     = "aa:b2:92:04:00:29"
       kvm-host       = "aa:b2:92:04:00:2a"
-      nested-vm      = "aa:b2:92:04:00:2b"
     }
     hypervisor = "vulcan.mgr.prv.suse.net"
     additional_network = "192.168.103.0/24"
@@ -71,7 +68,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:37"
       build-host     = "aa:b2:92:04:00:39"
       kvm-host       = "aa:b2:92:04:00:3a"
-      nested-vm      = "aa:b2:92:04:00:3b"
     }
     hypervisor = "vulcan.mgr.prv.suse.net"
     additional_network = "192.168.104.0/24"
@@ -89,7 +85,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:47"
       build-host     = "aa:b2:92:04:00:49"
       kvm-host       = "aa:b2:92:04:00:4a"
-      nested-vm      = "aa:b2:92:04:00:4b"
     }
     hypervisor = "hyperion.mgr.prv.suse.net"
     additional_network = "192.168.105.0/24"
@@ -107,7 +102,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:57"
       build-host     = "aa:b2:92:04:00:59"
       kvm-host       = "aa:b2:92:04:00:5a"
-      nested-vm      = "aa:b2:92:04:00:5b"
     }
     hypervisor = "hyperion.mgr.prv.suse.net"
     additional_network = "192.168.106.0/24"
@@ -125,7 +119,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:67"
       build-host     = "aa:b2:92:04:00:69"
       kvm-host       = "aa:b2:92:04:00:6a"
-      nested-vm      = "aa:b2:92:04:00:6b"
     }
     hypervisor = "daiquiri.mgr.prv.suse.net"
     additional_network = "192.168.107.0/24"
@@ -143,7 +136,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:77"
       build-host     = "aa:b2:92:04:00:79"
       kvm-host       = "aa:b2:92:04:00:7a"
-      nested-vm      = "aa:b2:92:04:00:7b"
     }
     hypervisor = "daiquiri.mgr.prv.suse.net"
     additional_network = "192.168.108.0/24"
@@ -161,7 +153,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:87"
       build-host     = "aa:b2:92:04:00:89"
       kvm-host       = "aa:b2:92:04:00:8a"
-      nested-vm      = "aa:b2:92:04:00:8b"
     }
     hypervisor = "mojito.mgr.prv.suse.net"
     additional_network = "192.168.109.0/24"
@@ -179,7 +170,6 @@ ENVIRONMENT_CONFIGURATION = {
       deblike-minion = "aa:b2:92:04:00:97"
       build-host     = "aa:b2:92:04:00:99"
       kvm-host       = "aa:b2:92:04:00:9a"
-      nested-vm      = "aa:b2:92:04:00:9b"
     }
     hypervisor = "mojito.mgr.prv.suse.net"
     additional_network = "192.168.110.0/24"


### PR DESCRIPTION
Related to https://github.com/SUSE/spacewalk/issues/22410

We'll test the migration from OS Salt to Salt bundle only on a dedicated BV host.
The entries for a minion running in a nested VM are thus no longer needed.