### PR TITLE
Set external disks for repository and database

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -135,6 +135,8 @@ module "cucumber_testsuite" {
         vcpu = 8
         memory = 32768
       }
+      repository_disk_size = 150
+      database_disk_size   = 50
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -137,6 +137,8 @@ module "cucumber_testsuite" {
         vcpu = 8
         memory = 32768
       }
+      repository_disk_size = 150
+      database_disk_size   = 50
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -168,6 +168,7 @@ module "server" {
   name                       = "server"
   product_version            = "4.3-released"
   repository_disk_size       = 1500
+  database_disk_size         = 100
   server_registration_code   = var.SERVER_REGISTRATION_CODE
 
   java_debugging                 = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -177,9 +177,9 @@ module "server" {
     data_pool          = "ssd"
   }
 
-  server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
-  repository_disk_size = 2048
-
+  server_mounted_mirror          = "minima-mirror-ci-bv.mgr.suse.de"
+  repository_disk_size           = 2048
+  database_disk_size             = 100
   java_debugging                 = false
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -323,9 +323,9 @@ module "server" {
     data_pool          = "ssd"
   }
 
-  server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-  repository_disk_size = 2048
-
+  server_mounted_mirror          = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  repository_disk_size           = 2048
+  database_disk_size             = 100
   java_debugging                 = false
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -135,6 +135,8 @@ module "cucumber_testsuite" {
         vcpu = 8
         memory = 32768
       }
+      repository_disk_size = 150
+      database_disk_size   = 50
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -135,6 +135,8 @@ module "cucumber_testsuite" {
         vcpu = 4
         memory = 16384
       }
+      repository_disk_size = 150
+      database_disk_size   = 50
       login_timeout = 28800
     }
     proxy = {

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -135,6 +135,8 @@ module "cucumber_testsuite" {
         vcpu = 4
         memory = 16384
       }
+      repository_disk_size = 150
+      database_disk_size   = 50
       login_timeout = 28800
     }
     proxy = {


### PR DESCRIPTION
Depends on https://github.com/uyuni-project/sumaform/pull/1454

This PR aims to setup a bigger disk size for pgsql partition, as otherwise we had problems on CI tests, when we run the backup/restore test.

**Will those disk sizes make sense to you?**

I set up the official minimal size, but maybe we can work with less in CI?
<img width="821" alt="image" src="https://github.com/SUSE/susemanager-ci/assets/2827771/aa18ccd5-a098-47dd-ac61-06673ef86cb5">

```
suma-43-srv:/var/spacewalk # du -h -d0
54G	.
suma-43-srv:/var/lib/pgsql # du -h -d0
6,5G	.
```

Note: In Uyuni, I expect more, as we synchronize Leap (even if we kill it later) + SLES15SP4. But I don't have a working CI testsuite to check it.