### PR TITLE
Bump controller image version from opensuse154o to opensuse155o

### DIFF
--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky9o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky9o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"

--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
@@ -161,7 +161,7 @@ module "cucumber_testsuite" {
   mirror      = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  images = ["rocky9o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky9o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-pr${var.ENVIRONMENT}-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -143,7 +143,7 @@ module "base" {
   mirror                   = var.MIRROR
   testsuite                = true
 
-  images = ["rocky8", "opensuse154o", "sles15sp4o", "ubuntu2204"]
+  images = ["rocky8", "opensuse155o", "sles15sp4o", "ubuntu2204"]
   provider_settings = {
     availability_zone = var.AVAILABILITY_ZONE
     region            = var.REGION

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-43-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -104,7 +104,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-43-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLE-update.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLE-update.tf
@@ -96,7 +96,7 @@ module "base" {
   name_prefix = "suma-su-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse154o" ]
+  images      = [ "sles15sp4o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -116,7 +116,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o" ]
+  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -136,7 +136,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse154o" ]
+  images      = [ "sles15sp4o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-ref43-"

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-head-"

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-refhead-"

--- a/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
@@ -93,7 +93,7 @@ module "base_core" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse154o", "sles15sp3o", "sles15sp4o"]
+  images = ["centos7o", "opensuse155o", "sles15sp3o", "sles15sp4o"]
   use_avahi    = false
   name_prefix  = "suma-testhub-"
   domain       = "mgr.suse.de"

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-ion-"

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-testnaica-"

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -104,7 +104,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "rocky8o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-testorion-"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -116,7 +116,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o" ]
+  images      = [ "sles12sp4o", "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse154o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -136,7 +136,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse154o" ]
+  images      = [ "sles15sp4o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true

--- a/terracumber_config/tf_files/tfvars/PR-testing-manager43.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-manager43.tfvars
@@ -1,7 +1,7 @@
 ############ Spacewalk unique variables ############
 
 IMAGE                  = "sles15sp4o"
-IMAGES                 = ["rocky9o", "opensuse154o", "sles15sp4o", "ubuntu2204o"]
+IMAGES                 = ["rocky9o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 SUSE_MINION_IMAGE      = "sles15sp4o"
 PRODUCT_VERSION        = "4.3-nightly"
 MAIL_TEMPLATE_ENV_FAIL = "../mail_templates/mail-template-jenkins-suma43-pull-request-env-fail.txt"


### PR DESCRIPTION
On sumaform side, controller is now using opensuse155o. 
opensuse155o was not declared in most of ci descriptions. 
This PR adds opensuse155o when needed or bump opensuse154o to opensuse155o when opensuse154o was only used for controller.