### PR TITLE
Add default timeout to ci acceptance

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -1,6 +1,5 @@
 def run(params) {
     timestamps {
-
         //Capybara configuration
         def capybara_timeout = 60
         def default_timeout = 500

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -1,5 +1,6 @@
 def run(params) {
     timestamps {
+
         //Capybara configuration
         def capybara_timeout = 60
         def default_timeout = 500


### PR DESCRIPTION
Backport changes from BV to ci test to manage timeouts.
Those changes are needed because PR is failing with a 4 minutes timeout on onboarding event.
This come for a changes in how we set the default timeout. Before, it was hard written in code at 500. For more flexibility between infra, we use a parameter now.