### PR TITLE
Keep database content inside the root partition on BV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -168,7 +168,6 @@ module "server" {
   name                       = "server"
   product_version            = "4.3-released"
   repository_disk_size       = 1500
-  database_disk_size         = 100
   server_registration_code   = var.SERVER_REGISTRATION_CODE
 
   java_debugging                 = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -179,7 +179,6 @@ module "server" {
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.suse.de"
   repository_disk_size           = 2048
-  database_disk_size             = 100
   java_debugging                 = false
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -325,7 +325,6 @@ module "server" {
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.prv.suse.net"
   repository_disk_size           = 2048
-  database_disk_size             = 100
   java_debugging                 = false
   auto_accept                    = false
   monitored                      = true


### PR DESCRIPTION
Keep database content inside the root partition on BV.
Otherwise we have too many free space in the root partition that it will never be used.


Note: We might have a similar consequence in our CI envs, but for now, we will keep it as it is there, as we are unsure about how to resize the root partition and the current size (200GB) is not enough for Database Backup/Restore test.