### PR TITLE
Remove wait_for_product_reposync since it does not correspond to rake task

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -236,9 +236,8 @@ def run(params) {
                     def nodesHandler = getNodesHandler()
                     res_products = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_reposync'", returnStatus: true)
                     echo "Custom channels and MU repositories status code: ${res_products}"
-                    res_sync_products = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_product_reposync'", returnStatus: true)
                     echo "Custom channels and MU repositories synchronization status code: ${res_sync_products}"
-                    sh "exit \$(( ${res_products}|${res_sync_products} ))"
+                    sh "exit \$(( ${res_products} ))"
                 }
             }
 

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -91,9 +91,7 @@ def run(params) {
                     def nodesHandler = getNodesHandler()
                     res_products = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_reposync'", returnStatus: true)
                     echo "Custom channels and MU repositories status code: ${res_products}"
-                    res_sync_products = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_product_reposync'", returnStatus: true)
-                    echo "Custom channels and MU repositories synchronization status code: ${res_sync_products}"
-                    sh "exit \$(( ${res_products}|${res_sync_products} ))"
+                    sh "exit \$(( ${res_products} ))"
                 }
             }
 


### PR DESCRIPTION
Remove wait_for_product_reposync since it does not correspond to rake task:

It should fix this:

```
10:29:15  + ./terracumber-cli --outputdir /home/jenkins/workspace/manager-4.3-qe-sle-update/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-4.3-SLE-update.tf --gitfolder /home/jenkins/workspace/manager-4.3-qe-sle-update/results/sumaform --logfile /home/jenkins/workspace/manager-4.3-qe-sle-update/results/84/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_NUMBER=84; export BUILD_VALIDATION=true; export CAPYBARA_TIMEOUT=60; export DEFAULT_TIMEOUT=500;  cd /root/spacewalk/testsuite; rake cucumber:build_validation_wait_for_product_reposync'
10:29:16  Running command...
10:29:16  rake aborted!
10:29:16  Don't know how to build task 'cucumber:build_validation_wait_for_product_reposync' (See the list of available tasks with `rake --tasks`)
10:29:16  Did you mean?  cucumber:build_validation_reposync
10:29:16  
10:29:16  (See full trace by running task with --trace)
```

I am not sure when the rake was removed, or changed name or what but it seems this is no longer valid.