### PR TITLE
Make the timeouts unique to each environment

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -1,9 +1,5 @@
 def run(params) {
     timestamps {
-        //Capybara configuration
-        def capybara_timeout = 20
-        def default_timeout = 300
-
         // Init path env variables
         env.resultdir = "${WORKSPACE}/results"
         env.resultdirbuild = "${resultdir}/${BUILD_NUMBER}"

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-AWS
@@ -36,6 +36,9 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
+    //Capybara configuration
+    capybara_timeout = 10
+    default_timeout = 250
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-aws.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
@@ -30,6 +30,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 18, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
@@ -30,6 +30,9 @@ node('sumaform-cucumber-provo') {
         checkout scm
     }
     timeout(activity: false, time: 18, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 20
+        default_timeout = 400
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
@@ -30,6 +30,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
@@ -32,6 +32,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
@@ -30,6 +30,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
@@ -30,6 +30,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
@@ -31,6 +31,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -32,6 +32,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -32,7 +32,8 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 14, unit: 'HOURS') {        //Capybara configuration
+    timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
         capybara_timeout = 10
         default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -32,7 +32,9 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 14, unit: 'HOURS') {
+    timeout(activity: false, time: 14, unit: 'HOURS') {        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-K3S
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-K3S
@@ -30,6 +30,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 14, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
@@ -30,6 +30,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 18, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-PRV
@@ -30,6 +30,9 @@ node('sumaform-cucumber-provo') {
         checkout scm
     }
     timeout(activity: false, time: 18, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 20
+        default_timeout = 400
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-podman
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-podman
@@ -30,6 +30,9 @@ node('sumaform-cucumber') {
         checkout scm
     }
     timeout(activity: false, time: 15, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
         def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
## What does this PR ?

We currently have the capybara timeout and the default max timeout set for all the environments at the pipeline description level.
When the timeout is too short, PRV envs will timeout on some onboardings and if the timeout is too long, the execution time for the pipelines will drastically increase.

To fix this issue, I would like to have the timeout set at the environment description level. So we can easily have different timeout depending on where we run the tests.

## Notes
### Context 
Adapting those timeouts are now required because of the BV stabilization backport.
 
### Note 1
I had a in between timeout before to try to make it work on both envs.
In this PR I reduce the timeouts for NUE ( I had no issue so far with those timeouts ) and increase back the timeout for PRV when the CI was running correctly.
It should speed up NUE pipelines and stabilize PRV pipelines.