### PR TITLE
Update image version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ image for testing Pull Requests built with the open build service. This needs to
 
 | Version | Minion      | SSH minion  | Client      | RH-like  | Deb-like     | Virthosts   | Buildhost   | Terminal    | Controller | Server      | Proxy       |
 | ------- | ----------- | ----------- | ----------- | -------- | ------------ | ----------- | ----------- | ----------- | ---------- | ----------- | ----------- |
-|  PR test| Leap 15.4   | Leap 15.4   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.4   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | Leap 15.4   | Leap 15.4   |
-|  Uyuni  | Leap 15.4   | Leap 15.4   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.4   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | Leap 15.4   | Leap 15.4   |
-|  HEAD   | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | SLES 15 SP4 | SLES 15 SP4 |
-|  4.3    | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.4  | SLES 15 SP4 | SLES 15 SP4 |
+|  PR test| Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap 15.5   | Leap 15.5   |
+|  Uyuni  | Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap 15.5   | Leap 15.5   |
+|  HEAD   | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLES 15 SP4 | SLES 15 SP4 |
+|  4.3    | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLES 15 SP4 | SLES 15 SP4 |


### PR DESCRIPTION
We switched to openSUSE Leap 15.5 but forgot to update the image version matrix accordingly.