### PR TITLE
Fix URLTrigger schedule for some Salt Shaker tests

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/AlmaLinux9/AlmaLinux_9/repodata/repomd.xml')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/testsuite/AlmaLinux_9/repodata/repomd.xml',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next/15.5/repodata/repomd.xml')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next/15.5/repodata/repomd.xml',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/SLE15/SLE_15/repodata/repomd.xml')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/testsuite/SLE_15/repodata/repomd.xml',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/Ubuntu2204/Ubuntu_22.04/Packages')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/testsuite/Ubuntu_22.04/Packages',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/AlmaLinux9/AlmaLinux_9/repodata/repomd.xml')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/testsuite/AlmaLinux_9/repodata/repomd.xml',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/15.5/repodata/repomd.xml')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/15.5/repodata/repomd.xml',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/SLE15/SLE_15/repodata/repomd.xml')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/testsuite/SLE_15/repodata/repomd.xml',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
@@ -7,7 +7,11 @@ node('salt-shaker-tests') {
         pipelineTriggers([
             URLTrigger(
                 cronTabSpec: '* * * * *',
-                entries: [URLTriggerEntry(url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/Ubuntu2204/Ubuntu_22.04/Packages')]
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/testsuite/Ubuntu_22.04/Packages',
+                    triggerLabel: "salt-shaker-tests",
+                    contentTypes: [MD5Sum()]
+                    )]
             ),
             cron('H 0 * * *')],
         ),


### PR DESCRIPTION
This PR simply fixes the configuration for the `URLTrigger` scheduler set in some Salt Shaker jobs:

- Add node to run the URLTrigger execution.
- Replace the URL to monitor for Salt Bundle to testsuite repository.
- Monitor a change on the MD5Sum of the content of the URL.

The "URLTrigger" is only configured for:

- `products:testing` -> SLE15SP5 (classic & bundle), AlmaLinux9 (bundle) and Ubuntu2204 (bundle)
- `products:next` -> SLE15SP5 (classic & bundle), AlmaLinux9 (bundle) and Ubuntu2204 (bundle) 