### PR TITLE
Fix wrong path to Salt Shaker mail templates

### DIFF
--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux9-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux9-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-CENTOS7-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-CENTOS7-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian11-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian11-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian12-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian12-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES12SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES12SP5-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2204-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2204-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux9-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux9-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-CENTOS7-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-CENTOS7-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian11-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian11-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian12-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian12-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES12SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES12SP5-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2204-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2204-Bundle.tf
@@ -26,7 +26,7 @@ variable "MAIL_SUBJECT" {
 
 variable "MAIL_TEMPLATE" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker.txt"
+  default = "../../mail-templates/mail-template-salt-shaker.txt"
 }
 
 variable "MAIL_SUBJECT_ENV_FAIL" {
@@ -36,7 +36,7 @@ variable "MAIL_SUBJECT_ENV_FAIL" {
 
 variable "MAIL_TEMPLATE_ENV_FAIL" {
   type = string
-  default = "../mail_templates/mail-template-salt-shaker-env-fail.txt"
+  default = "../../mail-templates/mail-template-salt-shaker-env-fail.txt"
 }
 
 variable "MAIL_FROM" {


### PR DESCRIPTION
This PR fixes an small issue with the path to Salt Shaker mail templates after the TF files were moved inside `salt-shaker` subdirectory during https://github.com/SUSE/susemanager-ci/pull/1069