### PR TITLE
Make sure URLTrigger finds nodes to run for Salt Shaker

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/testsuite/AlmaLinux_9/repodata/repomd.xml',
                     triggerLabel: "salt-shaker-tests",
+                    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next/15.5/repodata/repomd.xml',
                     triggerLabel: "salt-shaker-tests",
+                    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/testsuite/SLE_15/repodata/repomd.xml',
                     triggerLabel: "salt-shaker-tests",
+		    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/testsuite/Ubuntu_22.04/Packages',
                     triggerLabel: "salt-shaker-tests",
+                    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/testsuite/AlmaLinux_9/repodata/repomd.xml',
                     triggerLabel: "salt-shaker-tests",
+                    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/15.5/repodata/repomd.xml',
                     triggerLabel: "salt-shaker-tests",
+                    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/testsuite/SLE_15/repodata/repomd.xml',
                     triggerLabel: "salt-shaker-tests",
+                    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
@@ -10,6 +10,7 @@ node('salt-shaker-tests') {
                 entries: [URLTriggerEntry(
                     url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/testsuite/Ubuntu_22.04/Packages',
                     triggerLabel: "salt-shaker-tests",
+                    labelRestriction: true,
                     contentTypes: [MD5Sum()]
                     )]
             ),


### PR DESCRIPTION
I'm having issues to make "URLTrigger" plugin to find nodes where to run.

According to https://www.jenkins.io/doc/pipeline/steps/params/pipelinetriggers/ , now passing both `triggerLabel` and `labelRestriction` parameters I think this should work.
