### PR TITLE
Disable deblike minions in 4.3 PR testing

### DIFF
--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env5.tf
@@ -245,18 +245,18 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    debian-minion = {
-      image = "ubuntu2204o"
-      name = "min-deblike"
-      provider_settings = {
-        mac = "aa:b2:92:04:00:47"
-      }
-      additional_repos = {
-        client_repo = var.DEBLIKE_CLIENT_REPO,
-      }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-    }
+//    debian-minion = {
+//      image = "ubuntu2204o"
+//      name = "min-deblike"
+//      provider_settings = {
+//        mac = "aa:b2:92:04:00:47"
+//      }
+//      additional_repos = {
+//        client_repo = var.DEBLIKE_CLIENT_REPO,
+//      }
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
+//    }
     build-host = {
       image = "sles15sp4o"
       name = "min-build"

--- a/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
+++ b/terracumber_config/tf_files/SUSE-Manager-4.3-PR-tests-env6.tf
@@ -245,18 +245,18 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    debian-minion = {
-      image = "ubuntu2204o"
-      name = "min-deblike"
-      provider_settings = {
-        mac = "aa:b2:92:04:00:57"
-      }
-      additional_repos = {
-        client_repo = var.DEBLIKE_CLIENT_REPO,
-      }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-    }
+//    debian-minion = {
+//      image = "ubuntu2204o"
+//      name = "min-deblike"
+//      provider_settings = {
+//        mac = "aa:b2:92:04:00:47"
+//      }
+//      additional_repos = {
+//        client_repo = var.DEBLIKE_CLIENT_REPO,
+//      }
+//      additional_packages = [ "venv-salt-minion" ]
+//      install_salt_bundle = true
+//    }
     build-host = {
       image = "sles15sp4o"
       name = "min-build"


### PR DESCRIPTION
Tests on deblike minions are failing. Disabling them so this is usable.