### PR TITLE
CI: remove proxy from head test pipelines

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -142,15 +142,15 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containers/suse/manager/5.0"
     }
-    proxy = {
-      provider_settings = {
-        mac = "aa:b2:93:01:00:b2"
-        vcpu = 2
-        memory = 2048
-      }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-    }
+    #proxy = {
+    #  provider_settings = {
+    #    mac = "aa:b2:93:01:00:b2"
+    #    vcpu = 2
+    #    memory = 2048
+    #  }
+    #  additional_packages = [ "venv-salt-minion" ]
+    #  install_salt_bundle = true
+    #}
     suse-minion = {
       image = "sles15sp4o"
       name = "min-sles15"

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -144,16 +144,16 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containers/suse/manager/5.0"
     }
-    proxy = {
-      image = "slemicro55-ign"
-      provider_settings = {
-        mac = "aa:b2:93:01:00:c2"
-        vcpu = 2
-        memory = 2048
-      }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-    }
+    #proxy = {
+    #  image = "slemicro55-ign"
+    #  provider_settings = {
+    #    mac = "aa:b2:93:01:00:c2"
+    #    vcpu = 2
+    #    memory = 2048
+    #  }
+    #  additional_packages = [ "venv-salt-minion" ]
+    #  install_salt_bundle = true
+    #}
     suse-minion = {
       image = "sles15sp4o"
       name = "min-sles15"


### PR DESCRIPTION
As we don't have yet support to deploy a containerized proxy for Head. Let's keep for now Proxy VM out of Head test environments, until we do.