### PR TITLE
SLE Micro 5.5 now uses cloud-init

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -116,7 +116,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -863,25 +863,24 @@ module "slemicro54-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-// WORKAROUND qemu-guest-agent seems to have disappeared from SLE Micro 5.5
-//module "slemicro55-minion" {
-//  source             = "./modules/minion"
-//  base_configuration = module.base_core.configuration
-//  product_version    = "4.3-released"
-//  name               = "min-slemicro55"
-//  image              = "slemicro55-ign"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:ca"
-//    memory             = 2048
-//  }
-//
-//  server_configuration = {
-//    hostname = "suma-bv-43-pxy.mgr.suse.de"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "slemicro55-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro55"
+  image              = "slemicro55o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:ca"
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles12sp5-sshminion" {
   source             = "./modules/sshminion"
@@ -1269,20 +1268,19 @@ module "slemicro54-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-// WORKAROUND qemu-guest-agent seems to have disappeared from SLE Micro 5.5
-//module "slemicro55-sshminion" {
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_core.configuration
-//  product_version    = "4.3-released"
-//  name               = "minssh-slemicro55"
-//  image              = "slemicro55-ign"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:ea"
-//    memory             = 2048
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "slemicro55-sshminion" {
+  source             = "./modules/sshminion"
+  base_configuration = module.base_core.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-slemicro55"
+  image              = "slemicro55o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:ea"
+    memory             = 2048
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles12sp5-buildhost" {
   source             = "./modules/build_host"
@@ -1470,9 +1468,8 @@ module "controller" {
   slemicro54_minion_configuration    = module.slemicro54-minion.configuration
   slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
 
-// WORKAROUND qemu-guest-agent seems to have disappeared from SLE Micro 5.5
-//  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
-//  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -212,7 +212,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55-ign" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1104,7 +1104,7 @@ module "slemicro55-minion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "4.3-released"
   name               = "min-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:ca"
     memory             = 2048
@@ -1575,7 +1575,7 @@ module "slemicro55-sshminion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "4.3-released"
   name               = "minssh-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:ea"
     memory             = 2048

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -116,7 +116,7 @@ module "base_core" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -170,7 +170,7 @@ module "server_containerized" {
   base_configuration = module.base_core.configuration
   product_version    = "head"
   name               = "srv"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:51"
     memory             = 40960
@@ -693,7 +693,7 @@ module "slemicro55-minion" {
   base_configuration = module.base_core.configuration
   product_version    = "head"
   name               = "min-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:7a"
     memory             = 2048
@@ -1078,7 +1078,7 @@ module "slemicro55-sshminion" {
   base_configuration = module.base_core.configuration
   product_version    = "head"
   name               = "minssh-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:9a"
     memory             = 2048

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -212,7 +212,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-50"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -316,7 +316,7 @@ module "server_containerized" {
   base_configuration = module.base_core.configuration
   product_version    = "head"
   name               = "srv"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:01"
     memory             = 40960
@@ -906,7 +906,7 @@ module "slemicro55-minion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "head"
   name               = "min-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:2a"
     memory             = 2048
@@ -1356,7 +1356,7 @@ module "slemicro55-sshminion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "head"
   name               = "minssh-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:4a"
     memory             = 2048

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -116,7 +116,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -720,7 +720,7 @@ module "slemicro55-minion" {
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
   name               = "min-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:ca"
     memory             = 2048
@@ -1106,7 +1106,7 @@ module "slemicro55-sshminion" {
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
   name               = "minssh-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:ea"
     memory             = 2048

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -212,7 +212,7 @@ module "base_new_sle" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55-ign" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -935,7 +935,7 @@ module "slemicro55-minion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "uyuni-master"
   name               = "min-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:96"
     memory             = 2048
@@ -1386,7 +1386,7 @@ module "slemicro55-sshminion" {
   base_configuration = module.base_new_sle.configuration
   product_version    = "uyuni-master"
   name               = "minssh-slemicro55"
-  image              = "slemicro55-ign"
+  image              = "slemicro55o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:b6"
     memory             = 2048


### PR DESCRIPTION
* Re-enabled SLE Micro 5.5 in 4.3 (was temporarily disabled)
* Switched SLE Micro 5.5 to cloud-init in every branch