### PR TITLE
Fix SLE Micro 5.5 image names

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o", "slemicro55-ign"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-head-"
@@ -132,7 +132,7 @@ module "cucumber_testsuite" {
       }
     }
     server_containerized = {
-      image = "slemicro55-ign"
+      image = "slemicro55o"
       provider_settings = {
         mac = "aa:b2:93:01:00:b1"
         vcpu = 8

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o", "slemicro55-ign"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o", "slemicro55o"]
 
   container_server = true
 
@@ -134,7 +134,7 @@ module "cucumber_testsuite" {
       }
     }
     server_containerized = {
-      image = "slemicro55-ign"
+      image = "slemicro55o"
       provider_settings = {
         mac = "aa:b2:93:01:00:c1"
         vcpu = 4
@@ -145,7 +145,7 @@ module "cucumber_testsuite" {
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containers/suse/manager/5.0"
     }
     #proxy = {
-    #  image = "slemicro55-ign"
+    #  image = "slemicro55o"
     #  provider_settings = {
     #    mac = "aa:b2:93:01:00:c2"
     #    vcpu = 2


### PR DESCRIPTION
This PR fixes the image names of SLE Micro 5.5 according to the recent changes in sumaform.

See https://github.com/uyuni-project/sumaform/pull/1483