### PR TITLE
Tune disk sizes for CI

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -135,6 +135,7 @@ module "cucumber_testsuite" {
         vcpu = 8
         memory = 32768
       }
+      main_disk_size       = 20
       repository_disk_size = 150
       database_disk_size   = 50
     }

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -137,6 +137,7 @@ module "cucumber_testsuite" {
         vcpu = 8
         memory = 32768
       }
+      main_disk_size       = 20
       repository_disk_size = 150
       database_disk_size   = 50
     }

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -167,7 +167,9 @@ module "server" {
   })
   name                       = "server"
   product_version            = "4.3-released"
+  main_disk_size             = 20
   repository_disk_size       = 1500
+  database_disk_size         = 100
   server_registration_code   = var.SERVER_REGISTRATION_CODE
 
   java_debugging                 = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -178,7 +178,9 @@ module "server" {
   }
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.suse.de"
+  main_disk_size                 = 20
   repository_disk_size           = 2048
+  database_disk_size             = 150
   java_debugging                 = false
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -324,7 +324,9 @@ module "server" {
   }
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  main_disk_size                 = 20
   repository_disk_size           = 2048
+  database_disk_size             = 150
   java_debugging                 = false
   auto_accept                    = false
   monitored                      = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-paygo-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-paygo-AWS.tf
@@ -169,7 +169,9 @@ module "server" {
   name                       = "server"
   product_version            = "paygo"
   image                      = "suma-server-43-ltd-paygo"
+  main_disk_size             = 20
   repository_disk_size       = 1500
+  database_disk_size         = 100
 
   auto_accept                    = false
   monitored                      = false

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -135,9 +135,10 @@ module "cucumber_testsuite" {
         vcpu = 4
         memory = 16384
       }
-      repository_disk_size = 200
+      main_disk_size       = 20
+      repository_disk_size = 300
       database_disk_size   = 50
-      login_timeout = 28800
+      login_timeout        = 28800
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -135,9 +135,10 @@ module "cucumber_testsuite" {
         vcpu = 4
         memory = 16384
       }
-      repository_disk_size = 200
+      main_disk_size       = 20
+      repository_disk_size = 300
       database_disk_size   = 50
-      login_timeout = 28800
+      login_timeout        = 28800
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -178,7 +178,9 @@ module "server" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
-  repository_disk_size = 2048
+  main_disk_size        = 20
+  repository_disk_size  = 2048
+  database_disk_size    = 150
 
   java_debugging                 = false
   auto_accept                    = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -324,7 +324,9 @@ module "server" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-  repository_disk_size = 2048
+  main_disk_size        = 20
+  repository_disk_size  = 2048
+  database_disk_size    = 150
 
   java_debugging                 = false
   auto_accept                    = false


### PR DESCRIPTION
On uyuni branch:
```
/dev/vda3                                         200G  5.7G  195G   3% /
/dev/vdb1                                         196G  175G   12G  95% /var/spacewalk
/dev/vdc1                                          49G   17G   31G  35% /var/lib/pgsql
```

This PR shrinks `/` and enlarges `/var/spacewalk`.