### PR TITLE
Disable mirror usage in Head and Uyuni podman

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -117,10 +117,10 @@ module "cucumber_testsuite" {
 
   container_server = true
 
-  mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
-  use_mirror_images        = true
+  # mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
+  # use_mirror_images        = true
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
+  # custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
   host_settings = {
@@ -214,7 +214,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "sles15sp4o"
       name = "min-kvm"
-      
+
       provider_settings = {
         mac = "aa:b2:93:01:00:be"
         vcpu = 4
@@ -224,7 +224,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  
+
   provider_settings = {
     pool = "ssd"
     network_name = null

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -114,14 +114,14 @@ module "cucumber_testsuite" {
   auth_registry_username = "cucutest"
   auth_registry_password = "cucusecret"
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
-  
+
   container_server = true
 
-  mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
-  use_mirror_images        = true
+  # mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
+  # use_mirror_images        = true
 
   server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
+  # custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
   host_settings = {
@@ -205,7 +205,7 @@ module "cucumber_testsuite" {
     kvm-host = {
       image = "opensuse155o"
       name = "min-kvm"
-      
+
       provider_settings = {
         mac = "aa:b2:93:01:00:2e"
       }
@@ -213,7 +213,7 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
   }
-  
+
   provider_settings = {
     pool               = "ssd"
     network_name       = null


### PR DESCRIPTION
Disable mirror usage in Head and Uyuni podman. 

Issue: Fixes https://github.com/SUSE/spacewalk/issues/23570

Also some empty lines removal.