### PR TITLE
QE: Remove proxy from HEAD

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -143,15 +143,16 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
     }
-    proxy = {
-      provider_settings = {
-        mac = "aa:b2:93:01:00:b2"
-        vcpu = 2
-        memory = 2048
-      }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-    }
+    # commenting out the proxy as per https://github.com/SUSE/susemanager-ci/pull/1089
+    # proxy = {
+    #  provider_settings = {
+    #    mac = "aa:b2:93:01:00:b2"
+    #    vcpu = 2
+    #    memory = 2048
+    #  }
+    #  additional_packages = [ "venv-salt-minion" ]
+    #  install_salt_bundle = true
+    # }
     suse-minion = {
       image = "sles15sp4o"
       name = "min-sles15"


### PR DESCRIPTION
Removing proxy from HEAD again, so we can reach secondary tests, which is a priority - repeating what was done in https://github.com/SUSE/susemanager-ci/pull/1089 and discussed in https://suse.slack.com/archives/C02D134507M/p1707474456766809