### PR TITLE
Re-enabled the 24 ARM minions

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -96,11 +96,10 @@ provider "libvirt" {
   uri = "qemu+tcp://suma-07.mgr.suse.de/system"
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//provider "libvirt" {
-//  alias = "overdrive3"
-//  uri = "qemu+tcp://overdrive3.mgr.suse.de/system"
-//}
+provider "libvirt" {
+  alias = "suma-arm"
+  uri = "qemu+tcp:/suma-arm.mgr.suse.de/system"
+}
 
 provider "feilong" {
   connector   = "https://10.144.68.9"
@@ -130,31 +129,30 @@ module "base_core" {
   }
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "base_arm" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//
-//  source = "./modules/base"
-//
-//  cc_username = var.SCC_USER
-//  cc_password = var.SCC_PASSWORD
-//  name_prefix = "suma-bv-43-"
-//  use_avahi   = false
-//  domain      = "mgr.suse.de"
-//  images      = [ "opensuse154armo", "opensuse155armo" ]
-//
-//  mirror = "minima-mirror-ci-bv.mgr.suse.de"
-//  use_mirror_images = true
-//
-//  testsuite = true
-//
-//  provider_settings = {
-//    pool        = "ssd"
-//    bridge      = "br1"
-//  }
-//}
+module "base_arm" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "suma-bv-43-"
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+  images      = [ "opensuse154armo", "opensuse155armo" ]
+
+  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  use_mirror_images = true
+
+  testsuite = true
+
+  provider_settings = {
+    pool        = "ssd"
+    bridge      = "br0"
+  }
+}
 
 module "base_s390" {
   source = "./backend_modules/feilong/base"
@@ -704,53 +702,53 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse154arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "min-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:bf"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-43-pxy.mgr.suse.de"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "min-opensuse154arm-suma43-nue"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:bf"
+    overwrite_fqdn     = "suma-bv-43-min-opensuse154arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse155arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "min-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:c0"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-43-pxy.mgr.suse.de"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "min-opensuse155arm-suma43-nue"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:c0"
+    overwrite_fqdn     = "suma-bv-43-min-opensuse155arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
@@ -1156,45 +1154,45 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse154arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "minssh-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:df"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-opensuse154arm-suma43-nue"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:df"
+    overwrite_fqdn     = "suma-bv-43-minssh-opensuse154arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse155arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "minssh-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:e0"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-opensuse155arm-suma43-nue"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:e0"
+    overwrite_fqdn     = "suma-bv-43-minssh-opensuse155arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
@@ -1446,12 +1444,11 @@ module "controller" {
   debian12_minion_configuration    = module.debian12-minion.configuration
   debian12_sshminion_configuration = module.debian12-sshminion.configuration
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-//  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
-//
-//  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-//  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+
+  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -116,11 +116,10 @@ provider "libvirt" {
   uri = "qemu+tcp://mandalore.mgr.prv.suse.net/system"
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//provider "libvirt" {
-//  alias = "overdrive4"
-//  uri = "qemu+tcp://overdrive4.mgr.suse.de/system"
-//}
+provider "libvirt" {
+  alias = "suma-arm"
+  uri = "qemu+tcp://suma-arm.mgr.suse.de/system"
+}
 
 provider "feilong" {
   connector   = "https://10.144.68.9"
@@ -276,31 +275,30 @@ module "base_debian" {
   }
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "base_arm" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//
-//  source = "./modules/base"
-//
-//  cc_username = var.SCC_USER
-//  cc_password = var.SCC_PASSWORD
-//  name_prefix = "suma-bv-43-"
-//  use_avahi   = false
-//  domain      = "mgr.prv.suse.net"
-//  images      = [ "opensuse154armo", "opensuse155armo" ]
-//
-//  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-//  use_mirror_images = true
-//
-//  testsuite = true
-//
-//  provider_settings = {
-//    pool        = "ssd"
-//    bridge      = "br1"
-//  }
-//}
+module "base_arm" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "suma-bv-43-"
+  use_avahi   = false
+  domain      = "mgr.prv.suse.net"
+  images      = [ "opensuse154armo", "opensuse155armo" ]
+
+  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite = true
+
+  provider_settings = {
+    pool        = "ssd"
+    bridge      = "br0"
+  }
+}
 
 module "base_s390" {
   source = "./backend_modules/feilong/base"
@@ -925,53 +923,53 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse154arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "min-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:f0"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "min-opensuse154arm-suma43-prv"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f0"
+    overwrite_fqdn     = "suma-bv-43-min-opensuse154arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse155arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "min-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:f1"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "min-opensuse155arm-suma43-prv"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f1"
+    overwrite_fqdn     = "suma-bv-43-min-opensuse155arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
@@ -1443,45 +1441,45 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse154arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "minssh-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:f3"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-opensuse154arm-suma43-prv"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f2"
+    overwrite_fqdn     = "suma-bv-43-minssh-opensuse154arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse155arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "4.3-released"
-//  name               = "minssh-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:f4"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "4.3-released"
+  name               = "minssh-opensuse155arm-suma43-prv"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f3"
+    overwrite_fqdn     = "suma-bv-43-minssh-opensuse155arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
@@ -1763,12 +1761,11 @@ module "controller" {
   debian12_minion_configuration    = module.debian12-minion.configuration
   debian12_sshminion_configuration = module.debian12-sshminion.configuration
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-//  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
-//
-//  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-//  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+
+  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -96,11 +96,10 @@ provider "libvirt" {
   uri = "qemu+tcp://suma-06.mgr.suse.de/system"
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//provider "libvirt" {
-//  alias = "overdrive3"
-//  uri = "qemu+tcp://overdrive3.mgr.suse.de/system"
-//}
+provider "libvirt" {
+  alias = "suma-arm"
+  uri = "qemu+tcp://suma-arm.mgr.suse.de/system"
+}
 
 provider "feilong" {
   connector   = "https://10.144.68.9"
@@ -130,31 +129,30 @@ module "base_core" {
   }
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "base_arm" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//
-//  source = "./modules/base"
-//
-//  cc_username = var.SCC_USER
-//  cc_password = var.SCC_PASSWORD
-//  name_prefix = "suma-bv-50-"
-//  use_avahi   = false
-//  domain      = "mgr.suse.de"
-//  images      = [ "opensuse154armo", "opensuse155armo" ]
-//
-//  mirror = "minima-mirror-ci-bv.mgr.suse.de"
-//  use_mirror_images = true
-//
-//  testsuite = true
-//
-//  provider_settings = {
-//    pool        = "ssd"
-//    bridge      = "br1"
-//  }
-//}
+module "base_arm" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "suma-bv-50-"
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+  images      = [ "opensuse154armo", "opensuse155armo" ]
+
+  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  use_mirror_images = true
+
+  testsuite = true
+
+  provider_settings = {
+    pool        = "ssd"
+    bridge      = "br0"
+  }
+}
 
 module "base_s390" {
   source = "./backend_modules/feilong/base"
@@ -570,59 +568,59 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse154arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "min-o154arm-n"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:6f"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-50-srv.mgr.suse.de"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+module "opensuse154arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "min-opensuse154arm-suma50-nue"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:6f"
+    overwrite_fqdn     = "suma-bv-50-min-opensuse154arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse155arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "min-o155arm-n"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:70"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-50-srv.mgr.suse.de"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "opensuse155arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "min-opensuse155arm-suma50-nue"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:70"
+    overwrite_fqdn     = "suma-bv-50-min-opensuse155arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
 
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
@@ -1030,51 +1028,51 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse154arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "minssh-o154arm-n"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:8f"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+module "opensuse154arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "minssh-opensuse154arm-suma50-nue"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:8f"
+    overwrite_fqdn     = "suma-bv-50-minssh-opensuse154arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse155arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "minssh-o155arm-n"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:90"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "opensuse155arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "minssh-opensuse155arm-suma50-nue"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:90"
+    overwrite_fqdn     = "suma-bv-50-minssh-opensuse155arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
 
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
@@ -1344,12 +1342,11 @@ module "controller" {
   debian12_minion_configuration    = module.debian12-minion.configuration
   debian12_sshminion_configuration = module.debian12-sshminion.configuration
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-//  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
-//
-//  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-//  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+
+  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -116,11 +116,10 @@ provider "libvirt" {
   uri = "qemu+tcp://trantor.mgr.prv.suse.net/system"
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//provider "libvirt" {
-//  alias = "overdrive4"
-//  uri = "qemu+tcp://overdrive4.mgr.suse.de/system"
-//}
+provider "libvirt" {
+  alias = "suma-arm"
+  uri = "qemu+tcp://suma-arm.mgr.suse.de/system"
+}
 
 provider "feilong" {
   connector   = "https://10.144.68.9"
@@ -276,31 +275,30 @@ module "base_debian" {
   }
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "base_arm" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//
-//  source = "./modules/base"
-//
-//  cc_username = var.SCC_USER
-//  cc_password = var.SCC_PASSWORD
-//  name_prefix = "suma-bv-50"
-//  use_avahi   = false
-//  domain      = "mgr.prv.suse.net"
-//  images      = [ "opensuse154armo", "opensuse155armo" ]
-//
-//  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-//  use_mirror_images = true
-//
-//  testsuite = true
-//
-//  provider_settings = {
-//    pool        = "ssd"
-//    bridge      = "br1"
-//  }
-//}
+module "base_arm" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "suma-bv-50"
+  use_avahi   = false
+  domain      = "mgr.prv.suse.net"
+  images      = [ "opensuse154armo", "opensuse155armo" ]
+
+  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite = true
+
+  provider_settings = {
+    pool        = "ssd"
+    bridge      = "br0"
+  }
+}
 
 module "base_s390" {
   source = "./backend_modules/feilong/base"
@@ -766,61 +764,59 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-// TODO: Please adjust the values below!
-//module "opensuse154arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "min-o154arm-n"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:6f"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-50-srv.mgr.prv.suse.net"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+module "opensuse154arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "min-opensuse154arm-suma50-prv"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f4"
+    overwrite_fqdn     = "suma-bv-50-min-opensuse154arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-// TODO: Please adjust the values below!
-//module "opensuse155arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "min-o155arm-n"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:70"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "suma-bv-50-srv.mgr.prv.suse.net"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "opensuse155arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "min-opensuse155arm-suma50-prv"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f5"
+    overwrite_fqdn     = "suma-bv-50-min-opensuse155arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
 
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
@@ -1291,53 +1287,51 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-// TODO: Please adjust the values below!
-//module "opensuse154arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "minssh-o154arm-n"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:8f"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+module "opensuse154arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "minssh-opensuse154arm-suma50-prv"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f6"
+    overwrite_fqdn     = "suma-bv-50-minssh-opensuse154arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-// TODO: Please adjust the values below!
-//module "opensuse155arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "head"
-//  name               = "minssh-o155arm-n"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:92:42:00:90"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//}
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "opensuse155arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "head"
+  name               = "minssh-opensuse155arm-suma50-prv"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f7"
+    overwrite_fqdn     = "suma-bv-50-minssh-opensuse155arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
 
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
@@ -1637,12 +1631,11 @@ module "controller" {
   debian12_minion_configuration    = module.debian12-minion.configuration
   debian12_sshminion_configuration = module.debian12-sshminion.configuration
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-//  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
-//
-//  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-//  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+
+  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -96,11 +96,10 @@ provider "libvirt" {
   uri = "qemu+tcp://suma-06.mgr.suse.de/system"
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//provider "libvirt" {
-//  alias = "overdrive3"
-//  uri = "qemu+tcp://overdrive3.mgr.suse.de/system"
-//}
+provider "libvirt" {
+  alias = "suma-arm"
+  uri = "qemu+tcp://suma-arm.mgr.suse.de/system"
+}
 
 provider "feilong" {
   connector   = "https://10.144.68.9"
@@ -130,31 +129,30 @@ module "base_core" {
   }
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "base_arm" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//
-//  source = "./modules/base"
-//
-//  cc_username = var.SCC_USER
-//  cc_password = var.SCC_PASSWORD
-//  name_prefix = "uyuni-bv-master-"
-//  use_avahi   = false
-//  domain      = "mgr.suse.de"
-//  images      = [ "opensuse154armo", "opensuse155armo" ]
-//
-//  mirror = "minima-mirror-ci-bv.mgr.suse.de"
-//  use_mirror_images = true
-//
-//  testsuite = true
-//
-//  provider_settings = {
-//    pool        = "ssd"
-//    bridge      = "br1"
-//  }
-//}
+module "base_arm" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "uyuni-bv-master-"
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+  images      = [ "opensuse154armo", "opensuse155armo" ]
+
+  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  use_mirror_images = true
+
+  testsuite = true
+
+  provider_settings = {
+    pool        = "ssd"
+    bridge      = "br0"
+  }
+}
 
 module "base_s390" {
   source = "./backend_modules/feilong/base"
@@ -556,53 +554,53 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse154arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "min-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:bf"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "min-opensuse154arm-uyuni-nue"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:bf"
+    overwrite_fqdn     = "uyuni-bv-master-min-opensuse154arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse155arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "min-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:c0"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "min-opensuse155arm-uyuni-nue"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:c0"
+    overwrite_fqdn     = "uyuni-bv-master-min-opensuse155arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
@@ -989,45 +987,45 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse154arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "minssh-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:df"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "minssh-opensuse154arm-uyuni-nue"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:df"
+    overwrite_fqdn     = "uyuni-bv-master-minssh-opensuse154arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//module "opensuse155arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive3
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "minssh-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:e0"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "minssh-opensuse155arm-uyuni-nue"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:e0"
+    overwrite_fqdn     = "uyuni-bv-master-minssh-opensuse155arm.mgr.suse.de"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
@@ -1269,12 +1267,11 @@ module "controller" {
   debian12_minion_configuration    = module.debian12-minion.configuration
   debian12_sshminion_configuration = module.debian12-sshminion.configuration
 
-// WORKAROUND: overdrive3 will be replaced with a new ARM server
-//  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-//  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
-//
-//  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-//  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+
+  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -116,11 +116,10 @@ provider "libvirt" {
   uri = "qemu+tcp://caipirinha.mgr.prv.suse.net/system"
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//provider "libvirt" {
-//  alias = "overdrive4"
-//  uri = "qemu+tcp://overdrive4.mgr.suse.de/system"
-//}
+provider "libvirt" {
+  alias = "suma-arm"
+  uri = "qemu+tcp://suma-arm.mgr.suse.de/system"
+}
 
 provider "feilong" {
   connector   = "https://10.144.68.9"
@@ -276,31 +275,30 @@ module "base_debian" {
   }
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "base_arm" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//
-//  source = "./modules/base"
-//
-//  cc_username = var.SCC_USER
-//  cc_password = var.SCC_PASSWORD
-//  name_prefix = "uyuni-bv-master-"
-//  use_avahi   = false
-//  domain      = "mgr.prv.suse.net"
-//  images      = [ "opensuse154armo", "opensuse155armo" ]
-//
-//  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-//  use_mirror_images = true
-//
-//  testsuite = true
-//
-//  provider_settings = {
-//    pool        = "ssd"
-//    bridge      = "br1"
-//  }
-//}
+module "base_arm" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  name_prefix = "uyuni-bv-master-"
+  use_avahi   = false
+  domain      = "mgr.prv.suse.net"
+  images      = [ "opensuse154armo", "opensuse155armo" ]
+
+  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  use_mirror_images = true
+
+  testsuite = true
+
+  provider_settings = {
+    pool        = "ssd"
+    bridge      = "br0"
+  }
+}
 
 module "base_s390" {
   source = "./backend_modules/feilong/base"
@@ -755,53 +753,53 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse154arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "min-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:f8"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "min-opensuse154arm-uyuni-prv"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f8"
+    overwrite_fqdn     = "uyuni-bv-master-min-opensuse154arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse155arm-minion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/minion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "min-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:f9"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  server_configuration = {
-//    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
-//  }
-//  auto_connect_to_master  = false
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-minion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "min-opensuse155arm-uyuni-prv"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:f9"
+    overwrite_fqdn     = "uyuni-bv-master-min-opensuse155arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
@@ -1254,45 +1252,45 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse154arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "minssh-opensuse154arm"
-//  image              = "opensuse154armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:fb"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse154arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "minssh-opensuse154arm-uyuni-prv"
+  image              = "opensuse154armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:fa"
+    overwrite_fqdn     = "uyuni-bv-master-minssh-opensuse154arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//module "opensuse155arm-sshminion" {
-//  providers = {
-//    libvirt = libvirt.overdrive4
-//  }
-//  source             = "./modules/sshminion"
-//  base_configuration = module.base_arm.configuration
-//  product_version    = "uyuni-master"
-//  name               = "minssh-opensuse155arm"
-//  image              = "opensuse155armo"
-//  provider_settings = {
-//    mac                = "aa:b2:93:02:01:fc"
-//    memory             = 2048
-//    vcpu               = 2
-//    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-//  }
-//  use_os_released_updates = false
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//}
+module "opensuse155arm-sshminion" {
+  providers = {
+    libvirt = libvirt.suma-arm
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_arm.configuration
+  product_version    = "uyuni-master"
+  name               = "minssh-opensuse155arm-uyuni-prv"
+  image              = "opensuse155armo"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:fb"
+    overwrite_fqdn     = "uyuni-bv-master-minssh-opensuse155arm.mgr.prv.suse.net"
+    memory             = 2048
+    vcpu               = 2
+    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
 
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
@@ -1564,12 +1562,11 @@ module "controller" {
   debian12_minion_configuration    = module.debian12-minion.configuration
   debian12_sshminion_configuration = module.debian12-sshminion.configuration
 
-// WORKAROUND: overdrive4 will be replaced with a new ARM server
-//  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-//  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
-//
-//  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-//  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+
+  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration


### PR DESCRIPTION
Move all 24 minions from `overdrive3` and `overdrive4` to suma-arm

(We were missing IP and MAC addresses for 5.0 Provo -- added them)
