### PR TITLE
Remove Salt Bundle from SLE Micro SSH Minions

### DIFF
--- a/.github/workflows/sumaform-validation.yml
+++ b/.github/workflows/sumaform-validation.yml
@@ -32,8 +32,8 @@ jobs:
         uses: robinraju/release-downloader@v1.9
         with:
           repository: Bischoff/terraform-provider-feilong
-          tag: v0.0.4
-          fileName: terraform-provider-feilong_0.0.4_linux_amd64.tar.gz
+          tag: v0.0.6
+          fileName: terraform-provider-feilong_0.0.6_linux_amd64.tar.gz
           extract: true
       - name: Validate files
         if: steps.tf_files.outputs.added_modified

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -1146,8 +1146,9 @@ module "slemicro51-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro52-sshminion" {
@@ -1163,8 +1164,9 @@ module "slemicro52-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro53-sshminion" {
@@ -1180,8 +1182,9 @@ module "slemicro53-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro54-sshminion" {
@@ -1197,8 +1200,9 @@ module "slemicro54-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro55-sshminion" {
@@ -1214,8 +1218,9 @@ module "slemicro55-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "sles12sp5-buildhost" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -1414,8 +1414,9 @@ module "slemicro51-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro52-sshminion" {
@@ -1434,8 +1435,9 @@ module "slemicro52-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro53-sshminion" {
@@ -1454,8 +1456,9 @@ module "slemicro53-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro54-sshminion" {
@@ -1474,8 +1477,9 @@ module "slemicro54-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro55-sshminion" {
@@ -1494,8 +1498,9 @@ module "slemicro55-sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed  
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "sles12sp5-buildhost" {


### PR DESCRIPTION
This PR

- fixes the CI with respect to the Feilong version bump (0.0.4 -> 0.0.6)
- removes the Salt bundle for SLE Micro SSH Minions (This is not supported, yet. See https://bugzilla.suse.com/show_bug.cgi?id=1208045)


