### PR TITLE
BV: Disable Salt Bundle for SLE Micros in 5.0

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -682,8 +682,9 @@ module "slemicro51-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro52-minion" {
@@ -704,8 +705,9 @@ module "slemicro52-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro53-minion" {
@@ -726,8 +728,9 @@ module "slemicro53-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true 
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro54-minion" {
@@ -748,8 +751,9 @@ module "slemicro54-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro55-minion" {
@@ -770,8 +774,9 @@ module "slemicro55-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "sles12sp5-sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -884,8 +884,9 @@ module "slemicro51-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro52-minion" {
@@ -909,8 +910,9 @@ module "slemicro52-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro53-minion" {
@@ -934,8 +936,9 @@ module "slemicro53-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro54-minion" {
@@ -959,8 +962,9 @@ module "slemicro54-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "slemicro55-minion" {
@@ -984,8 +988,9 @@ module "slemicro55-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
 }
 
 module "sles12sp5-sshminion" {


### PR DESCRIPTION
This does not work in sumaform properly, yet, because the Salt state for handling additional packages does not take transactional systems into account. 
https://github.com/uyuni-project/sumaform/pull/1509 fixes this state, but there is still the problem with a necessary reboot.