### PR TITLE
BV: check sh return code in all proxy and monitoring stages

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -262,6 +262,7 @@ def run(params) {
                     }
                     res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_proxy'", returnStatus: true)
                     echo "Add Proxy Activation Key status code: ${res_add_keys}"
+                    sh "exit ${res_add_keys}"
                 }
             }
             stage('Create bootstrap repository Proxy') {
@@ -272,6 +273,7 @@ def run(params) {
                     }
                     res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_proxy'", returnStatus: true)
                     echo "Create Proxy bootstrap repository status code: ${res_create_bootstrap_repos}"
+                    sh "exit ${res_create_bootstrap_repos}"
                 }
             }
             stage('Bootstrap Proxy') {
@@ -281,6 +283,7 @@ def run(params) {
                     }
                     res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_proxy'", returnStatus: true)
                     echo "Init Proxy status code: ${res_init_proxy}"
+                    sh "exit ${res_init_proxy}"
                 }
             }
 
@@ -332,6 +335,7 @@ def run(params) {
                             }
                             res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_monitoring_server'", returnStatus: true)
                             echo "Add Server Monitoring Activation Key status code: ${res_add_keys}"
+                            sh "exit ${res_add_keys}"
                         }
                     }
                     stage('Create bootstrap repository Monitoring') {
@@ -342,6 +346,7 @@ def run(params) {
                             }
                             res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_monitoring_server'", returnStatus: true)
                             echo "Create Server Monitoring bootstrap repository status code: ${res_create_bootstrap_repos}"
+                            sh "exit ${res_create_bootstrap_repos}"
                         }
                     }
                     stage('Bootstrap Monitoring Server') {
@@ -352,6 +357,7 @@ def run(params) {
                             echo 'Register monitoring server as minion with gui'
                             res_init_monitoring = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_monitoring'", returnStatus: true)
                             echo "Init Monitoring Server status code: ${res_init_monitoring}"
+                            sh "exit ${res_init_monitoring}"
                         }
                     }
                 } catch (Exception ex) {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -116,6 +116,7 @@ def run(params) {
                     }
                     res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_proxy'", returnStatus: true)
                     echo "Add Proxy Activation Key status code: ${res_add_keys}"
+                    sh "exit ${res_add_keys}"
                 }
             }
             stage('Create bootstrap repository Proxy') {
@@ -126,6 +127,7 @@ def run(params) {
                     }
                     res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_proxy'", returnStatus: true)
                     echo "Create Proxy bootstrap repository status code: ${res_create_bootstrap_repos}"
+                    sh "exit ${res_create_bootstrap_repos}"
                 }
             }
             stage('Bootstrap Proxy') {
@@ -135,6 +137,7 @@ def run(params) {
                     }
                     res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_proxy'", returnStatus: true)
                     echo "Init Proxy status code: ${res_init_proxy}"
+                    sh "exit ${res_init_proxy}"
                 }
             }
             /** Proxy stages end **/
@@ -162,6 +165,7 @@ def run(params) {
                             }
                             res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_monitoring_server'", returnStatus: true)
                             echo "Add Server Monitoring Activation Key status code: ${res_add_keys}"
+                            sh "exit ${res_add_keys}"
                         }
                     }
                     stage('Create bootstrap repository Monitoring') {
@@ -172,6 +176,7 @@ def run(params) {
                             }
                             res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_monitoring_server'", returnStatus: true)
                             echo "Create Server Monitoring bootstrap repository status code: ${res_create_bootstrap_repos}"
+                            sh "exit ${res_create_bootstrap_repos}"
                         }
                     }
                     stage('Bootstrap Monitoring Server') {
@@ -182,6 +187,7 @@ def run(params) {
                             echo 'Register monitoring server as minion with gui'
                             res_init_monitoring = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_monitoring'", returnStatus: true)
                             echo "Init Monitoring Server status code: ${res_init_monitoring}"
+                            sh "exit ${res_init_monitoring}"
                         }
                     }
                 } catch (Exception ex) {


### PR DESCRIPTION
Closes https://github.com/SUSE/susemanager-ci/issues/1108

Docs for the sh global function state this about using returnStatus

>Normally, a script which exits with a nonzero status code will cause the step to fail with an exception. If this option is checked, the return value of the step will instead be the status code. You may then compare it to zero, for example

Currently most of the steps for the proxy save the returnStatus to a variable but don't use it to determine whether a failure occurred or not. The same holds true for the monitoring server.
Only the MUs stages will properly fail if a script execution does not return with 0.