### PR TITLE
Increase disk space of Uyuni K3s to 250GB

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -139,6 +139,7 @@ module "cucumber_testsuite" {
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
       helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server-helm"
       login_timeout = 28800
+      main_disk_size = 250
     }
     proxy = {
       provider_settings = {


### PR DESCRIPTION
Increase disk space of Uyuni K3s to 250GB.

Otherwise, it becomes unstable when it finish, as it consumes too much disk space, the root cause it might be the DB backup test, but I don't have the time to debug it, I need to unblock this issue to be able to debug a more important issue configuring the Proxy. Therefore, I will increase the size of that disk in our terraform file.


```
Events:
  Type     Reason            Age                  From               Message
  ----     ------            ----                 ----               -------
  Warning  FailedScheduling  32m (x67 over 6h2m)  default-scheduler  0/1 nodes are available: 1 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
uyuni-master-k3s-srv:~ # df -h
Filesystem                                   Size  Used Avail Use% Mounted on
devtmpfs                                     4.0M  8.0K  4.0M   1% /dev
tmpfs                                        7.9G  4.0K  7.9G   1% /dev/shm
tmpfs                                        3.2G   66M  3.1G   3% /run
tmpfs                                        4.0M     0  4.0M   0% /sys/fs/cgroup
/dev/vda3                                    200G  188G   13G  94% /
/dev/vda2                                     33M  3.1M   30M  10% /boot/efi
minima-mirror-ci-bv.mgr.suse.de:/srv/mirror  5.9T  2.5T  3.4T  43% /srv/mirror
tmpfs                                        170M   12K  170M   1% /var/lib/kubelet/pods/d86c5681-f113-4b20-b5cf-1203a7326850/volumes/kubernetes.io~projected/kube-api-access-kcmn9
tmpfs                                         16G   12K   16G   1% /var/lib/kubelet/pods/2d21e06f-f5d5-4ef5-a4aa-5b49a656d147/volumes/kubernetes.io~projected/kube-api-access-hzv8n
tmpfs                                         16G   12K   16G   1% /var/lib/kubelet/pods/5e0c9dbe-496d-4913-961d-1a43084e0cca/volumes/kubernetes.io~projected/kube-api-access-hl28s
shm                                           64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/1c03fecd3c21b46fee4cb96f8561efe3ce5ab37379ef2d8ffa6f3265793f97c0/shm
shm                                           64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/958d6de5cf48a21b32b534117e92bbc2775073cce9ef5f63f9b37fde157d7f4b/shm
shm                                           64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/0e88c277ed66f98aef12ba121e991adb109aa2d51137d9bc03b8d55ce16d65aa/shm
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/1c03fecd3c21b46fee4cb96f8561efe3ce5ab37379ef2d8ffa6f3265793f97c0/rootfs
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/958d6de5cf48a21b32b534117e92bbc2775073cce9ef5f63f9b37fde157d7f4b/rootfs
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/0e88c277ed66f98aef12ba121e991adb109aa2d51137d9bc03b8d55ce16d65aa/rootfs
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/aa10216d95782618cb85b34a33bf300ba81accf71c20a70306102a443d67c355/rootfs
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/0092800feb4186a1d18303ae4bb941673d01d3ac119a2d28615fa3301e42583d/rootfs
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/519fcd314320ce12eb8de3a045bbd0cd09a81c0bbd7de686ee50f57a0a9a789d/rootfs
tmpfs                                         16G   12K   16G   1% /var/lib/kubelet/pods/e470318c-c984-40a6-8b1a-96820b7c93e2/volumes/kubernetes.io~projected/kube-api-access-msk9r
shm                                           64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/eebaf0587f859e47e2c5aa15effdaf33484b3208fd34e2fad210a779d2a0d7f0/shm
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/eebaf0587f859e47e2c5aa15effdaf33484b3208fd34e2fad210a779d2a0d7f0/rootfs
overlay                                      200G  188G   13G  94% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/0c4491343833d5aab1b40e95d84436d7a68e360f7d6530f3b74ea266d1629377/rootfs
tmpfs                                        1.6G     0  1.6G   0% /run/user/0
```
