### PR TITLE
Use `latest` container tag in Uyuni and HEAD

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -144,6 +144,7 @@ module "cucumber_testsuite" {
       login_timeout = 28800
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
+      container_tag = "latest"
     }
     proxy_containerized = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -138,6 +138,7 @@ module "cucumber_testsuite" {
       }
       runtime = "podman"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+      container_tag = "latest"
       helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server"
       login_timeout = 28800
     }


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/23908.

We have a variable for the container tag in sumaform
https://github.com/uyuni-project/sumaform/blob/b16b99d312db4093b06781e75b71d95794a8b60e/modules/server_containerized/main.tf#L43
but we are not using it. Therefore, we do not use the latest image in our Uyuni Podman and HEAD CI.