### PR TITLE
Use latest container tag in Uyuni k3s

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -137,6 +137,7 @@ module "cucumber_testsuite" {
       }
       runtime = "k3s"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+      container_tag = "latest"
       helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server-helm"
       login_timeout = 28800
       main_disk_size = 250


### PR DESCRIPTION
Follow-up PR of https://github.com/SUSE/susemanager-ci/pull/1145