### PR TITLE
BV-AWS: Add and use mi_ids parameters to generate custom repositories

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -60,7 +60,8 @@ node('sumaform-cucumber-provo') {
             string(name: 'key_file', defaultValue: '/home/jenkins/.ssh/testing-suma.pem', description: 'Path to SSH private key to access instance in AWS'),
             string(name: 'key_name', defaultValue: 'testing-suma', description: 'SSH key name in AWS'),
             text(name: 'allowed_IPS', defaultValue: '65.132.116.252', description: 'Add the public IPs to add to AWS ingress security group ( keep default Jenkins address ) separated by new line' ),
-            text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools MU Repositories for each client, in json format'),
+            text(name: 'mi_ids', defaultValue: '', description: 'MI Identifiers separated by comma and whitespaces (Option A)'),
+            text(name: 'custom_repositories', defaultValue: '{}', description: 'Salt & Client Tools MU Repositories for each client, in json format (Option B)'),
             booleanParam(name: 'use_latest_ami_image', defaultValue: false, description: 'Use latest ami image')
             ])
     ])


### PR DESCRIPTION
Follow-up of https://github.com/SUSE/susemanager-ci/pull/1138


Related to https://github.com/SUSE/spacewalk/issues/21702

Adds the mi_ids parameter to the current 4.3 AWS pipeline and uses it to generate the **custom_repositories.json** file calling `maintenance_json_generator.py`.
The `--no_embargo` instruct the script to discard MIs containing fixes which are still under embargo.