### PR TITLE
In server containerized use only main_disk

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -59,9 +59,7 @@ module "cucumber_testsuite" {
         vcpu = 8
         memory = 32768
       }
-      main_disk_size       = 20
-      repository_disk_size = 300
-      database_disk_size   = 50
+      main_disk_size       = 400
       login_timeout        = 28800
       additional_repos_only = var.ADDITIONAL_REPOS_ONLY
       additional_repos = local.additional_repos["server"]

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -140,7 +140,7 @@ module "cucumber_testsuite" {
       container_tag = "latest"
       helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server-helm"
       login_timeout = 28800
-      main_disk_size = 250
+      main_disk_size = 300
     }
     proxy = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -132,9 +132,7 @@ module "cucumber_testsuite" {
         memory = 65536
         vcpu = 6
       }
-      main_disk_size       = 20
-      repository_disk_size = 300
-      database_disk_size   = 50
+      main_disk_size       = 400
       login_timeout        = 28800
     }
     proxy = {


### PR DESCRIPTION
We are experiencing this issue:
![image](https://github.com/SUSE/susemanager-ci/assets/2827771/43bea3d2-5241-429f-bee5-0dadffc88003)

And we though it could be related with the implementation we made of additional disks.

Cedric Bosdonnat:

> For some reason postgresql is already started and the /var/lib/pqsql/.bash_profile is gone
> /var/lib/pgsql and /var/spacewalk are mounted volumes in the Jenkins PR CI... is that expected? It seems this mount hides the .bash_profile