### PR TITLE
Fix typo in comparison

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -56,7 +56,7 @@ def run(params) {
                             checkout scm
                             res_python_script_ = sh(script: "python3 jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py --mi_ids ${params.mi_ids}", returnStatus: true)
                             echo "Build Validation JSON script return code:\n ${json_content}"
-                            if res_python_script != 0 {
+                            if (res_python_script != 0) {
                                 error("MI IDs (${params.mi_ids}) passed by parameter are wrong (or already released)")
                             }
                         }


### PR DESCRIPTION
Fix typo in comparison

fixes error:

```
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 7269fbd1-3333-49c4-8199-23e46f59c37a
org.jenkinsci.plugins.workflow.cps.CpsCompilationErrorsException: startup failed:
Script1.groovy: 59: expecting '(', found 'res_python_script' @ line 59, column 32.
                               if res_python_script != 0 {
                                  ^

1 error
```
example happening: https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-qe-sle-update/113/console