### PR TITLE
Add SLE Micro 6.0 minions to BV envs

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -19,7 +19,7 @@ node('sumaform-cucumber-provo') {
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -19,7 +19,7 @@ node('sumaform-cucumber-provo') {
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -20,7 +20,7 @@ node('sumaform-cucumber') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -20,7 +20,7 @@ node('sumaform-cucumber') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -20,7 +20,7 @@ node('sumaform-cucumber-provo') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -20,7 +20,7 @@ node('sumaform-cucumber-provo') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -19,7 +19,7 @@ node('sumaform-cucumber') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -19,7 +19,7 @@ node('sumaform-cucumber') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -19,7 +19,7 @@ node('sumaform-cucumber-provo') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -19,7 +19,7 @@ node('sumaform-cucumber-provo') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -18,7 +18,7 @@ node('sumaform-cucumber') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -18,7 +18,7 @@ node('sumaform-cucumber') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
-            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slemicro60_minion'
+            'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -87,7 +87,6 @@ v43_client_tools: dict[str, set[str]] = {
     "slemicro55_minion": {"/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SUSE-MicroOS_5.5_x86_64/",
                           "/SUSE_Updates_SLE-Micro_5.5_x86_64/"},
-# TODO Verify that these are accurate
     "slmicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-For-Micro_6_x86_64/",
                           "/SUSE_Updates_SUSE-MicroOS_6.0_x86_64/",
                           "/SUSE_Updates_SLE-Micro_6.0_x86_64/"},
@@ -139,7 +138,6 @@ v50_client_tools_beta: dict[str, set[str]] = {
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
     "slemicro55_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
-# TODO Verify these are accurate
     "slmicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_6_x86_64/",
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
     "salt_migration_minion": {"/SUSE_Updates_SLE-Manager-Tools_15_x86_64-BETA/"}

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -87,6 +87,10 @@ v43_client_tools: dict[str, set[str]] = {
     "slemicro55_minion": {"/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SUSE-MicroOS_5.5_x86_64/",
                           "/SUSE_Updates_SLE-Micro_5.5_x86_64/"},
+# TODO Verify that these are accurate
+    "slemicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-For-Micro_6_x86_64/",
+                          "/SUSE_Updates_SUSE-MicroOS_6.0_x86_64/",
+                          "/SUSE_Updates_SLE-Micro_6.0_x86_64/"},
     "salt_migration_minion": {"/SUSE_Updates_SLE-Manager-Tools_15_x86_64/",
                               "/SUSE_Updates_SLE-Module-Basesystem_15-SP5_x86_64/",
                               "/SUSE_Updates_SLE-Module-Server-Applications_15-SP5_x86_64/"},
@@ -134,6 +138,9 @@ v50_client_tools_beta: dict[str, set[str]] = {
     "slemicro54_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
     "slemicro55_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_5_x86_64/",
+                          "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
+# TODO Verify these are accurate
+    "slemicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_6_x86_64/",
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
     "salt_migration_minion": {"/SUSE_Updates_SLE-Manager-Tools_15_x86_64-BETA/"}
 }
@@ -190,7 +197,7 @@ def parse_cli_args() -> argparse.Namespace:
     )
     parser.add_argument("-v", "--version", dest="version",
         help="Version of SUMA you want to run this script for, the options are 43 for 4.3 and 50 for 5.0. The default is 43 for now",
-        choices=["43", "50"], default="43", action='store', 
+        choices=["43", "50"], default="43", action='store',
     )
     parser.add_argument("-i", "--mi_ids", required=False, dest="mi_ids", help="Space separated list of MI IDs", nargs='*', action='store')
     parser.add_argument("-e", "--no_embargo", dest="embargo_check", help="Reject MIs under embargo",  action='store_true')
@@ -217,7 +224,7 @@ def create_url(mi_id:str, suffix: str) -> str:
 def validate_and_store_results(expected_ids: set [str], custom_repositories: dict[str, dict[str, str]], output_file: str = JSON_OUTPUT_FILE_NAME):
     if not custom_repositories:
         raise SystemExit("Empty custom_repositories dictionary, something went wrong")
-    
+
     found_ids: set[str] = { id for custom_repo in custom_repositories.values() for id in custom_repo.keys() }
     # there should be no set difference if all MI IDs are in the JSON
     missing_ids: set[str] = expected_ids.difference(found_ids)
@@ -253,7 +260,7 @@ def find_valid_repos(mi_ids: set[str], version: str):
                         final_id: str = mi_id
                         if final_id in custom_repositories[node]:
                             for i in range(1, 100):
-                                new_id: str = f"{mi_id}-{i}" 
+                                new_id: str = f"{mi_id}-{i}"
                                 if new_id not in custom_repositories[node]:
                                     final_id = new_id
                                     break
@@ -261,7 +268,7 @@ def find_valid_repos(mi_ids: set[str], version: str):
                         custom_repositories[node][final_id] = repo_url
                     else:
                         custom_repositories[node] = {mi_id: repo_url}
-    
+
     validate_and_store_results(mi_ids, custom_repositories)
 
 def main():

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -88,7 +88,7 @@ v43_client_tools: dict[str, set[str]] = {
                           "/SUSE_Updates_SUSE-MicroOS_5.5_x86_64/",
                           "/SUSE_Updates_SLE-Micro_5.5_x86_64/"},
 # TODO Verify that these are accurate
-    "slemicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-For-Micro_6_x86_64/",
+    "slmicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-For-Micro_6_x86_64/",
                           "/SUSE_Updates_SUSE-MicroOS_6.0_x86_64/",
                           "/SUSE_Updates_SLE-Micro_6.0_x86_64/"},
     "salt_migration_minion": {"/SUSE_Updates_SLE-Manager-Tools_15_x86_64/",
@@ -140,7 +140,7 @@ v50_client_tools_beta: dict[str, set[str]] = {
     "slemicro55_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
 # TODO Verify these are accurate
-    "slemicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_6_x86_64/",
+    "slmicro60_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_6_x86_64/",
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
     "salt_migration_minion": {"/SUSE_Updates_SLE-Manager-Tools_15_x86_64-BETA/"}
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -961,6 +961,25 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
+module "slemicro60-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro60"
+  image              = "slemicro60o"
+  provider_settings = {
+    mac                = ""
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp5-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
@@ -1400,6 +1419,21 @@ module "opensuse156arm-sshminion" {
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
 // }
 
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+// module "slemicro60-sshminion" {
+//   source             = "./modules/sshminion"
+//   base_configuration = module.base_core.configuration
+//   product_version    = "4.3-released"
+//   name               = "minssh-slemicro60"
+//   image              = "slemicro60o"
+//   provider_settings = {
+//     mac                = ""
+//     memory             = 2048
+//   }
+//   use_os_released_updates = false
+//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+// }
+
 module "sles12sp5-buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
@@ -1604,6 +1638,10 @@ module "controller" {
   slemicro55_minion_configuration    = module.slemicro55-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+
+  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -961,12 +961,12 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro60-minion" {
+module "slmicro60-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
-  name               = "min-slemicro60"
-  image              = "slemicro60o"
+  name               = "min-slmicro60"
+  image              = "slmicro60o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:cb"
     memory             = 2048
@@ -1420,12 +1420,12 @@ module "opensuse156arm-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro60-sshminion" {
+// module "slmicro60-sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "4.3-released"
-//   name               = "minssh-slemicro60"
-//   image              = "slemicro60o"
+//   name               = "minssh-slmicro60"
+//   image              = "slmicro60o"
 //   provider_settings = {
 //     mac                = "aa:b2:92:42:00:eb"
 //     memory             = 2048
@@ -1639,9 +1639,9 @@ module "controller" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
-  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -968,7 +968,7 @@ module "slemicro60-minion" {
   name               = "min-slemicro60"
   image              = "slemicro60o"
   provider_settings = {
-    mac                = ""
+    mac                = "aa:b2:92:42:00:cb"
     memory             = 2048
   }
 
@@ -1427,7 +1427,7 @@ module "opensuse156arm-sshminion" {
 //   name               = "minssh-slemicro60"
 //   image              = "slemicro60o"
 //   provider_settings = {
-//     mac                = ""
+//     mac                = "aa:b2:92:42:00:eb"
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1213,7 +1213,7 @@ module "slemicro60-minion" {
   name               = "min-slemicro60"
   image              = "slemicro60o"
   provider_settings = {
-    mac                = ""
+    mac                = "aa:b2:92:42:00:cb"
     memory             = 2048
   }
 
@@ -1743,7 +1743,7 @@ module "sles15sp5s390-sshminion" {
 //   name               = "minssh-slemicro60"
 //   image              = "slemicro60o"
 //   provider_settings = {
-//     mac                = ""
+//     mac                = "aa:b2:92:42:00:eb"
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -211,7 +211,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55o" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55o", "slemicro60o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1203,6 +1203,28 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
+module "slemicro60-minion" {
+  providers = {
+    libvirt = libvirt.moscowmule
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "4.3-released"
+  name               = "min-slemicro60"
+  image              = "slemicro60o"
+  provider_settings = {
+    mac                = ""
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp5-sshminion" {
   providers = {
     libvirt = libvirt.endor
@@ -1710,6 +1732,24 @@ module "sles15sp5s390-sshminion" {
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
 // }
 
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+// module "slemicro60-sshminion" {
+//  providers = {
+//     libvirt = libvirt.moscowmule
+//   }
+//   source             = "./modules/sshminion"
+//   base_configuration = module.base_new_sle.configuration
+//   product_version    = "4.3-released"
+//   name               = "minssh-slemicro60"
+//   image              = "slemicro60o"
+//   provider_settings = {
+//     mac                = ""
+//     memory             = 2048
+//   }
+//   use_os_released_updates = false
+//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+// }
+
 module "sles12sp5-buildhost" {
   providers = {
     libvirt = libvirt.coruscant
@@ -1928,6 +1968,10 @@ module "controller" {
   slemicro55_minion_configuration    = module.slemicro55-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+
+  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -211,7 +211,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55o", "slemicro60o" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55o", "slmicro60o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1203,15 +1203,15 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro60-minion" {
+module "slmicro60-minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
   product_version    = "4.3-released"
-  name               = "min-slemicro60"
-  image              = "slemicro60o"
+  name               = "min-slmicro60"
+  image              = "slmicro60o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:cb"
     memory             = 2048
@@ -1733,15 +1733,15 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro60-sshminion" {
+// module "slmicro60-sshminion" {
 //  providers = {
 //     libvirt = libvirt.moscowmule
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
 //   product_version    = "4.3-released"
-//   name               = "minssh-slemicro60"
-//   image              = "slemicro60o"
+//   name               = "minssh-slmicro60"
+//   image              = "slmicro60o"
 //   provider_settings = {
 //     mac                = "aa:b2:92:42:00:eb"
 //     memory             = 2048
@@ -1969,9 +1969,9 @@ module "controller" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
-  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -836,7 +836,7 @@ module "slemicro60-minion" {
   name               = "min-slemicro60"
   image              = "slemicro60o"
   provider_settings = {
-    mac                = ""
+    mac                = "aa:b2:92:42:00:7b"
     memory             = 2048
   }
 
@@ -1349,7 +1349,7 @@ module "sles15sp5s390-sshminion" {
 //   name               = "minssh-slemicro60"
 //   image              = "slemicro60o"
 //   provider_settings = {
-//     mac                = ""
+//     mac                = "aa:b2:92:42:00:9b"
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -115,8 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
-
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o","slemicro60o",  "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -830,6 +829,29 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
+module "slemicro60-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "head"
+  name               = "min-slemicro60"
+  image              = "slemicro60o"
+  provider_settings = {
+    mac                = ""
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+}
+
 module "sles12sp5-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
@@ -1319,6 +1341,23 @@ module "sles15sp5s390-sshminion" {
 //  install_salt_bundle = true
 //}
 
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+// module "slemicro60-sshminion" {
+//   source             = "./modules/sshminion"
+//   base_configuration = module.base_core.configuration
+//   product_version    = "head"
+//   name               = "minssh-slemicro60"
+//   image              = "slemicro60o"
+//   provider_settings = {
+//     mac                = ""
+//     memory             = 2048
+//   }
+//   use_os_released_updates = false
+//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+//}
+
 module "sles12sp5-buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
@@ -1538,6 +1577,10 @@ module "controller" {
   slemicro55_minion_configuration    = module.slemicro55-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+
+  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o","slemicro60o",  "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -829,12 +829,12 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro60-minion" {
+module "slmicro60-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "head"
-  name               = "min-slemicro60"
-  image              = "slemicro60o"
+  name               = "min-slmicro60"
+  image              = "slmicro60o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:7b"
     memory             = 2048
@@ -1342,12 +1342,12 @@ module "sles15sp5s390-sshminion" {
 //}
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro60-sshminion" {
+// module "slmicro60-sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "head"
-//   name               = "minssh-slemicro60"
-//   image              = "slemicro60o"
+//   name               = "minssh-slmicro60"
+//   image              = "slmicro60o"
 //   provider_settings = {
 //     mac                = "aa:b2:92:42:00:9b"
 //     memory             = 2048
@@ -1578,9 +1578,9 @@ module "controller" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
-  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -211,7 +211,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o"  ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1046,6 +1046,32 @@ module "slemicro55-minion" {
 //  install_salt_bundle = true
 }
 
+module "slemicro60-minion" {
+  providers = {
+    libvirt = libvirt.florina
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "head"
+  name               = "min-slemicro60"
+  image              = "slemicro60o"
+  provider_settings = {
+    mac                = ""
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+// WORKAROUND: Does not work in sumaform, yet
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+}
+
 module "sles12sp5-sshminion" {
   providers = {
     libvirt = libvirt.tatooine
@@ -1604,6 +1630,27 @@ module "sles15sp5s390-sshminion" {
 //  install_salt_bundle = true
 // }
 
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+// module "slemicro60-sshminion" {
+//   providers = {
+//     libvirt = libvirt.florina
+//   }
+//   source             = "./modules/sshminion"
+//   base_configuration = module.base_new_sle.configuration
+//   product_version    = "head"
+//   name               = "minssh-slemicro60"
+//   image              = "slemicro60o"
+//   provider_settings = {
+//     mac                = ""
+//     memory             = 2048
+//   }
+//   use_os_released_updates = false
+//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+// }
+
 module "sles12sp5-buildhost" {
   providers = {
     libvirt = libvirt.terminus
@@ -1838,6 +1885,10 @@ module "controller" {
   slemicro55_minion_configuration    = module.slemicro55-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+
+  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -211,7 +211,7 @@ module "base_new_sle" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o"  ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o"  ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1046,15 +1046,15 @@ module "slemicro55-minion" {
 //  install_salt_bundle = true
 }
 
-module "slemicro60-minion" {
+module "slmicro60-minion" {
   providers = {
     libvirt = libvirt.florina
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
   product_version    = "head"
-  name               = "min-slemicro60"
-  image              = "slemicro60o"
+  name               = "min-slmicro60"
+  image              = "slmicro60o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:2b"
     memory             = 2048
@@ -1631,15 +1631,15 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro60-sshminion" {
+// module "slmicro60-sshminion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
 //   product_version    = "head"
-//   name               = "minssh-slemicro60"
-//   image              = "slemicro60o"
+//   name               = "minssh-slmicro60"
+//   image              = "slmicro60o"
 //   provider_settings = {
 //     mac                = "aa:b2:92:42:00:4b"
 //     memory             = 2048
@@ -1886,9 +1886,9 @@ module "controller" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
-  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -1056,7 +1056,7 @@ module "slemicro60-minion" {
   name               = "min-slemicro60"
   image              = "slemicro60o"
   provider_settings = {
-    mac                = ""
+    mac                = "aa:b2:92:42:00:2b"
     memory             = 2048
   }
 
@@ -1641,7 +1641,7 @@ module "sles15sp5s390-sshminion" {
 //   name               = "minssh-slemicro60"
 //   image              = "slemicro60o"
 //   provider_settings = {
-//     mac                = ""
+//     mac                = "aa:b2:92:42:00:4b"
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -812,7 +812,7 @@ module "slemicro60-minion" {
   name               = "min-slemicro60"
   image              = "slemicro60o"
   provider_settings = {
-    mac                = ""
+    mac                = "aa:b2:93:02:01:cb"
     memory             = 2048
   }
 
@@ -1269,7 +1269,7 @@ module "sles15sp5s390-sshminion" {
 //   name               = "minssh-slemicro60"
 //   image              = "slemicro60o"
 //   provider_settings = {
-//     mac                = ""
+//     mac                = "aa:b2:93:02:01:eb"
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o", "opensuse156o"  ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o", "opensuse156o"  ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -805,12 +805,12 @@ module "slemicro55-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "slemicro60-minion" {
+module "slmicro60-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
-  name               = "min-slemicro60"
-  image              = "slemicro60o"
+  name               = "min-slmicro60"
+  image              = "slmicro60o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:cb"
     memory             = 2048
@@ -1262,12 +1262,12 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro60-sshminion" {
+// module "slmicro60-sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "uyuni-master"
-//   name               = "minssh-slemicro60"
-//   image              = "slemicro60o"
+//   name               = "minssh-slmicro60"
+//   image              = "slmicro60o"
 //   provider_settings = {
 //     mac                = "aa:b2:93:02:01:eb"
 //     memory             = 2048
@@ -1473,9 +1473,9 @@ module "controller" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
-  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o", "opensuse156o"  ]
+  images      = [ "sles12sp5o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian10o", "debian11o", "debian12o", "opensuse155o", "opensuse156o"  ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -805,6 +805,25 @@ module "slemicro55-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro60-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "uyuni-master"
+  name               = "min-slemicro60"
+  image              = "slemicro60o"
+  provider_settings = {
+    mac                = ""
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp5-sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
@@ -1242,6 +1261,21 @@ module "sles15sp5s390-sshminion" {
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
 // }
 
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+// module "slemicro60-sshminion" {
+//   source             = "./modules/sshminion"
+//   base_configuration = module.base_core.configuration
+//   product_version    = "uyuni-master"
+//   name               = "minssh-slemicro60"
+//   image              = "slemicro60o"
+//   provider_settings = {
+//     mac                = ""
+//     memory             = 2048
+//   }
+//   use_os_released_updates = false
+//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+// }
+
 module "sles12sp5-buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
@@ -1438,6 +1472,10 @@ module "controller" {
   slemicro55_minion_configuration    = module.slemicro55-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+
+  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1036,7 +1036,7 @@ module "slemicro60-minion" {
   name               = "min-slemicro60"
   image              = "slemicro60o"
   provider_settings = {
-    mac                = ""
+    mac                = "aa:b2:93:02:01:97"
     memory             = 2048
   }
 
@@ -1567,7 +1567,7 @@ module "sles15sp5s390-sshminion" {
 //   name               = "minssh-slemicro60"
 //   image              = "slemicro60o"
 //   provider_settings = {
-//     mac                = ""
+//     mac                = "aa:b2:93:02:01:b7"
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -211,7 +211,7 @@ module "base_new_sle" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1026,6 +1026,28 @@ module "slemicro55-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "slemicro60-minion" {
+  providers = {
+    libvirt = libvirt.ginfizz
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_new_sle.configuration
+  product_version    = "uyuni-master"
+  name               = "min-slemicro60"
+  image              = "slemicro60o"
+  provider_settings = {
+    mac                = ""
+    memory             = 2048
+  }
+
+  server_configuration = {
+    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "sles12sp5-sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
@@ -1534,6 +1556,24 @@ module "sles15sp5s390-sshminion" {
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
 // }
 
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+// module "slemicro60-sshminion" {
+//   providers = {
+//     libvirt = libvirt.ginfizz
+//   }
+//   source             = "./modules/sshminion"
+//   base_configuration = module.base_new_sle.configuration
+//   product_version    = "uyuni-master"
+//   name               = "minssh-slemicro60"
+//   image              = "slemicro60o"
+//   provider_settings = {
+//     mac                = ""
+//     memory             = 2048
+//   }
+//   use_os_released_updates = false
+//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+// }
+
 module "sles12sp5-buildhost" {
   providers = {
     libvirt = libvirt.margarita
@@ -1744,6 +1784,10 @@ module "controller" {
   slemicro55_minion_configuration    = module.slemicro55-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+
+  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+//  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
+//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -211,7 +211,7 @@ module "base_new_sle" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slemicro60o" ]
+  images      = [ "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -1026,15 +1026,15 @@ module "slemicro55-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "slemicro60-minion" {
+module "slmicro60-minion" {
   providers = {
     libvirt = libvirt.ginfizz
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
   product_version    = "uyuni-master"
-  name               = "min-slemicro60"
-  image              = "slemicro60o"
+  name               = "min-slmicro60"
+  image              = "slmicro60o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:97"
     memory             = 2048
@@ -1557,15 +1557,15 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro60-sshminion" {
+// module "slmicro60-sshminion" {
 //   providers = {
 //     libvirt = libvirt.ginfizz
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
 //   product_version    = "uyuni-master"
-//   name               = "minssh-slemicro60"
-//   image              = "slemicro60o"
+//   name               = "minssh-slmicro60"
+//   image              = "slmicro60o"
 //   provider_settings = {
 //     mac                = "aa:b2:93:02:01:b7"
 //     memory             = 2048
@@ -1785,9 +1785,9 @@ module "controller" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
 
-  slemicro60_minion_configuration    = module.slemicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro60_sshminion_configuration = module.slemicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration


### PR DESCRIPTION
Add SLE Micro 6.0 minions to BV envs.

~Missing MAC addresses in tf files.~ added
TODO: Verify that the suffixes in the json script are correct.

~The test is failing because [this PR](https://github.com/uyuni-project/sumaform/pull/1583) is not yet merged and the slemicro60 module is still unknown~
The test is failing because the sumaform states are not implemented properly for these variables: helm_chart_url, runtime, container_repository, container_tag