### PR TITLE
5.0 BV: Add missing sumaform parameters

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -1262,6 +1262,8 @@ module "sles12sp5-terminal" {
     manufacturer       = "Supermicro"
     product            = "X9DR3-F"
   }
+  private_ip = "1"
+  private_name = " "
 }
 
 module "sles15sp4-buildhost" {
@@ -1297,6 +1299,8 @@ module "sles15sp4-terminal" {
     manufacturer       = "HP"
     product            = "ProLiant DL360 Gen9"
   }
+  private_ip = "1"
+  private_name = " "
 }
 
 module "monitoring-server" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -1543,6 +1543,8 @@ module "sles12sp5-terminal" {
     manufacturer       = "Supermicro"
     product            = "X9DR3-F"
   }
+  private_ip = "1"
+  private_name = " "
 }
 
 module "sles15sp4-buildhost" {
@@ -1584,6 +1586,8 @@ module "sles15sp4-terminal" {
     manufacturer       = "HP"
     product            = "ProLiant DL360 Gen9"
   }
+  private_ip = "1"
+  private_name = " "
 }
 
 module "monitoring-server" {


### PR DESCRIPTION
This will add missing sumaform dummy parameters to the 5.0 BV configuration file in order to get the deployment working. Those values will be needed for the retail tests, but they are not yet migrated to the containerized setup. So these dummy values will be enough for now.

```bash
[2024-03-22T12:27:10.718Z] Terraform has been successfully initialized!
[2024-03-22T12:27:10.718Z] 
[2024-03-22T12:27:10.718Z] You may now begin working with Terraform. Try running "terraform plan" to see
[2024-03-22T12:27:10.718Z] any changes that are required for your infrastructure. All Terraform commands
[2024-03-22T12:27:10.718Z] should now work.
[2024-03-22T12:27:10.718Z] 
[2024-03-22T12:27:10.718Z] If you ever set or change modules or backend configuration for Terraform,
[2024-03-22T12:27:10.718Z] rerun this command to reinitialize your working directory. If you forget, other
[2024-03-22T12:27:10.718Z] commands will detect it and remind you to do so if necessary.
[2024-03-22T12:27:10.718Z] ╷
[2024-03-22T12:27:10.718Z] │ Error: Missing required argument
[2024-03-22T12:27:10.718Z] │ 
[2024-03-22T12:27:10.718Z] │   on main.tf line 1289, in module "sles15sp4-terminal":
[2024-03-22T12:27:10.718Z] │ 1289: module "sles15sp4-terminal" {
[2024-03-22T12:27:10.718Z] │ 
[2024-03-22T12:27:10.718Z] │ The argument "private_ip" is required, but no definition was found.
[2024-03-22T12:27:10.718Z] ╵
[2024-03-22T12:27:10.718Z] ╷
[2024-03-22T12:27:10.718Z] │ Error: Missing required argument
[2024-03-22T12:27:10.718Z] │ 
[2024-03-22T12:27:10.718Z] │   on main.tf line 1289, in module "sles15sp4-terminal":
[2024-03-22T12:27:10.718Z] │ 1289: module "sles15sp4-terminal" {
[2024-03-22T12:27:10.718Z] │ 
[2024-03-22T12:27:10.718Z] │ The argument "private_name" is required, but no definition was found.
[2024-03-22T12:27:10.718Z] ╵
script returned exit code 1
```