### PR TITLE
Change option in sle update pipeline

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-sle-update
+++ b/jenkins_pipelines/environments/manager-4.3-qe-sle-update
@@ -22,7 +22,8 @@ node('sumaform-cucumber-provo') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            choice(name: 'proxy_type', choices: ['proxy_traditional', 'proxy_container'], description: 'The proxy type'),
+            // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
+            choice(name: 'proxy_type', choices: ['proxy', 'proxy_container'], description: 'The proxy type'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),


### PR DESCRIPTION
Change option in sle update pipeline. Using proxy_traditional breaks the Rakefile, which needs adjusting. The Rakefile creates the feature files and run_sets from templates. We need to change pretty much every proxy feature file to proxy_traditional to make it work and until that refactor happens we need the pipeline to work.