### PR TITLE
Fix init proxy rake command in BV

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -131,7 +131,7 @@ def run(params) {
                     if (params.confirm_before_continue) {
                         input 'Press any key to start bootstraping the Proxy'
                     }
-                    res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${params.proxy_type}'", returnStatus: true)
+                    res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_${params.proxy_type}'", returnStatus: true)
                     echo "Init Proxy status code: ${res_init_proxy}"
                     sh "exit ${res_init_proxy}"
                 }


### PR DESCRIPTION
Fixes: 

```
09:43:15  Don't know how to build task 'cucumber:build_validation_init_client_proxy' (See the list of available tasks with `rake --tasks`)
09:43:15  Did you mean?  cucumber:build_validation_init_proxy
```