### PR TITLE
Revert "increase default timeout to wait for build minion"

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request-envs.groovy
@@ -22,7 +22,6 @@ short_product_name = "suma"
 update_repo = "http://minima-mirror-ci-bv.mgr.prv.suse.net/jordi/some-updates/"
 additional_repo = "http://minima-mirror-ci-bv.mgr.prv.suse.net/jordi/dummy/"
 build_packages = true
-default_timeout = 500
 
 if (env.JOB_NAME == "uyuni-prs-ci-tests-jordi") {
     first_env = 10;


### PR DESCRIPTION
This reverts commit 666123051d080bf965a5c4f92bef94e60897a889.

That commit was changing the default timeout for all the testsuite, and we only want to change the one for the build host bootstrap step.