### PR TITLE
Uyuni BV: Add entries for private network

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -1188,7 +1188,10 @@ module "sles12sp5-terminal" {
     manufacturer       = "Supermicro"
     product            = "X9DR3-F"
   }
+  private_ip         = 5
+  private_name       = "sle12sp5terminal"
 }
+
 
 module "sles15sp4-buildhost" {
   source             = "./modules/build_host"
@@ -1219,6 +1222,24 @@ module "sles15sp4-terminal" {
     vcpu               = 2
     manufacturer       = "HP"
     product            = "ProLiant DL360 Gen9"
+  }
+  private_ip         = 6
+  private_name       = "sle15sp4terminal"
+}
+
+module "dhcp-dns" {
+  source             = "./modules/dhcp_dns"
+  base_configuration = module.base_core.configuration
+  name               = "dhcp-dns"
+  image              = "opensuse155o"
+  private_hosts = [
+    module.sles12sp5-terminal.configuration,
+    module.sles15sp4-terminal.configuration
+  ]
+  hypervisor = {
+    host        = "suma-06.mgr.suse.de"
+    user        = "root"
+    private_key = file("~/.ssh/id_rsa")
   }
 }
 

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -1227,22 +1227,6 @@ module "sles15sp4-terminal" {
   private_name       = "sle15sp4terminal"
 }
 
-module "dhcp-dns" {
-  source             = "./modules/dhcp_dns"
-  base_configuration = module.base_core.configuration
-  name               = "dhcp-dns"
-  image              = "opensuse155o"
-  private_hosts = [
-    module.sles12sp5-terminal.configuration,
-    module.sles15sp4-terminal.configuration
-  ]
-  hypervisor = {
-    host        = "suma-06.mgr.suse.de"
-    user        = "root"
-    private_key = file("~/.ssh/id_rsa")
-  }
-}
-
 module "monitoring-server" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1480,6 +1480,8 @@ module "sles12sp5-terminal" {
     manufacturer       = "Supermicro"
     product            = "X9DR3-F"
   }
+  private_ip         = 5
+  private_name       = "sle12sp5terminal"
 }
 
 module "sles15sp4-buildhost" {
@@ -1517,6 +1519,24 @@ module "sles15sp4-terminal" {
     vcpu               = 2
     manufacturer       = "HP"
     product            = "ProLiant DL360 Gen9"
+  }
+  private_ip         = 6
+  private_name       = "sle15sp4terminal"
+}
+
+module "dhcp-dns" {
+  source             = "./modules/dhcp_dns"
+  base_configuration = module.base_retail.configuration
+  name               = "dhcp-dns"
+  image              = "opensuse155o"
+  private_hosts = [
+    module.sles12sp5-terminal.configuration,
+    module.sles15sp4-terminal.configuration
+  ]
+  hypervisor = {
+    host        = "terminus.mgr.prv.suse.net"
+    user        = "root"
+    private_key = file("~/.ssh/id_rsa")
   }
 }
 

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1534,7 +1534,7 @@ module "dhcp-dns" {
     module.sles15sp4-terminal.configuration
   ]
   hypervisor = {
-    host        = "terminus.mgr.prv.suse.net"
+    host        = "margarita.mgr.prv.suse.net"
     user        = "root"
     private_key = file("~/.ssh/id_rsa")
   }

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1524,22 +1524,6 @@ module "sles15sp4-terminal" {
   private_name       = "sle15sp4terminal"
 }
 
-module "dhcp-dns" {
-  source             = "./modules/dhcp_dns"
-  base_configuration = module.base_retail.configuration
-  name               = "dhcp-dns"
-  image              = "opensuse155o"
-  private_hosts = [
-    module.sles12sp5-terminal.configuration,
-    module.sles15sp4-terminal.configuration
-  ]
-  hypervisor = {
-    host        = "margarita.mgr.prv.suse.net"
-    user        = "root"
-    private_key = file("~/.ssh/id_rsa")
-  }
-}
-
 module "monitoring-server" {
   providers = {
     libvirt = libvirt.margarita


### PR DESCRIPTION
This PR adds missing entries to the Uyuni BV files for the new DHCP/DNS module.

See https://ci.suse.de/blue/organizations/jenkins/uyuni-master-qe-build-validation-NUE/detail/uyuni-master-qe-build-validation-NUE/131/pipeline/30/

```bash
[2024-04-04T08:48:31.020Z] Terraform has been successfully initialized!
[2024-04-04T08:48:31.020Z] 
[2024-04-04T08:48:31.020Z] You may now begin working with Terraform. Try running "terraform plan" to see
[2024-04-04T08:48:31.020Z] any changes that are required for your infrastructure. All Terraform commands
[2024-04-04T08:48:31.020Z] should now work.
[2024-04-04T08:48:31.020Z] 
[2024-04-04T08:48:31.020Z] If you ever set or change modules or backend configuration for Terraform,
[2024-04-04T08:48:31.020Z] rerun this command to reinitialize your working directory. If you forget, other
[2024-04-04T08:48:31.020Z] commands will detect it and remind you to do so if necessary.
[2024-04-04T08:48:31.020Z] ╷
[2024-04-04T08:48:31.020Z] │ Error: Missing required argument
[2024-04-04T08:48:31.020Z] │ 
[2024-04-04T08:48:31.020Z] │   on main.tf line 1180, in module "sles12sp5-terminal":
[2024-04-04T08:48:31.020Z] │ 1180: module "sles12sp5-terminal" {
[2024-04-04T08:48:31.020Z] │ 
[2024-04-04T08:48:31.020Z] │ The argument "private_ip" is required, but no definition was found.
[2024-04-04T08:48:31.020Z] ╵
[2024-04-04T08:48:31.020Z] ╷
[2024-04-04T08:48:31.020Z] │ Error: Missing required argument
[2024-04-04T08:48:31.020Z] │ 
[2024-04-04T08:48:31.020Z] │   on main.tf line 1180, in module "sles12sp5-terminal":
[2024-04-04T08:48:31.020Z] │ 1180: module "sles12sp5-terminal" {
[2024-04-04T08:48:31.020Z] │ 
[2024-04-04T08:48:31.020Z] │ The argument "private_name" is required, but no definition was found.
[2024-04-04T08:48:31.020Z] ╵
script returned exit code 1
```