### PR TITLE
5.0 BV: Do not install the Salt bundle

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -222,6 +222,10 @@ module "proxy_containerized" {
   runtime = "podman"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"
+
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "sles12sp5-minion" {
@@ -682,9 +686,9 @@ module "slemicro51-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro52-minion" {
@@ -705,9 +709,9 @@ module "slemicro52-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro53-minion" {
@@ -728,9 +732,9 @@ module "slemicro53-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro54-minion" {
@@ -751,9 +755,9 @@ module "slemicro54-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro55-minion" {
@@ -774,9 +778,9 @@ module "slemicro55-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -366,6 +366,10 @@ module "proxy_containerized" {
   runtime = "podman"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"
+
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "sles12sp5-minion" {
@@ -880,9 +884,9 @@ module "slemicro51-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro52-minion" {
@@ -906,9 +910,9 @@ module "slemicro52-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro53-minion" {
@@ -932,9 +936,9 @@ module "slemicro53-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro54-minion" {
@@ -958,9 +962,9 @@ module "slemicro54-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "slemicro55-minion" {
@@ -984,9 +988,9 @@ module "slemicro55-minion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+// WORKAROUND: The Salt bundle causes onboarding issues.
+// See https://github.com/SUSE/spacewalk/issues/24074
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {


### PR DESCRIPTION
This will disable installing the Salt bundle to all our SLE Micro Minions in the 5.0 BV.

See https://github.com/SUSE/spacewalk/issues/24074