### PR TITLE
BV 5.0: Enable correct container registry for Beta 2

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -178,10 +178,9 @@ module "server_containerized" {
   }
   main_disk_size = 3000
   runtime = "podman"
-// WORKAROUND
-// We want to test the most recent code right now until the submissions for Beta 2 are ready
-//  container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
-  container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
+  container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
+  // Most recent code. Enable again once Beta 2 will be approved
+  // container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
 
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.suse.de"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -179,7 +179,7 @@ module "server_containerized" {
   main_disk_size = 3000
   runtime = "podman"
   container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
-  // Most recent code. Enable again once Beta 2 will be approved
+  // Most recent code. Enable again once Beta 2 will be approved:
   // container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
 
 

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -324,6 +324,8 @@ module "server_containerized" {
   main_disk_size = 3000
   runtime = "podman"
   container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
+  // Most recent code. Enable again once Beta 2 will be approved
+  // container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.prv.suse.net"
   java_debugging                 = false

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -324,7 +324,7 @@ module "server_containerized" {
   main_disk_size = 3000
   runtime = "podman"
   container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
-  // Most recent code. Enable again once Beta 2 will be approved
+  // Most recent code. Enable again once Beta 2 will be approved:
   // container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.prv.suse.net"


### PR DESCRIPTION
This sets the correct registry for the server container again to be ready for Beta 2.