### PR TITLE
HEAD CI proxy: Do not use `venv-salt-minion`

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -153,8 +153,9 @@ module "cucumber_testsuite" {
         memory = 2048
       }
       main_disk_size = 200
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+      // WORKAROUND: The Salt bundle causes onboarding issues.
+      // See https://github.com/SUSE/spacewalk/issues/24074
+      install_salt_bundle = false
       runtime = "podman"
     }
     suse-minion = {


### PR DESCRIPTION
This will do not install the Salt bundle to our proxy VM on the HEAD CI, in order to be able to onboard the proxy as normal Minion again.

See https://github.com/SUSE/spacewalk/issues/24074