### PR TITLE
BV 5.0: Enable correct container registry for proxy

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -219,6 +219,9 @@ module "proxy_containerized" {
     password = "admin"
   }
   runtime = "podman"
+  container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
+  // Most recent code. Enable again once Beta 2 will be approved:
+  // container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"
 }

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -366,6 +366,9 @@ module "proxy_containerized" {
     password = "admin"
   }
   runtime = "podman"
+  container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
+  // Most recent code. Enable again once Beta 2 will be approved:
+  // container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"
 }


### PR DESCRIPTION
This will also add the correct registry to the containerized proxy in the 5.0 BV environment.  Thank you, @srbarrios, for catching this!
Otherwise, sumaform would set it as

```jinja
{% if grains.get('container_repository') %}
  {% set container_repository = grains.get('container_repository') %}
{% else %}
  {% if 'uyuni' in grains.get('product_version') %}
    {% set container_repository = 'registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni' %}
  {% elif '5.0' in grains.get('product_version') %}
    {% set container_repository = 'registry.suse.de/devel/galaxy/manager/5.0/containers/suse/manager/5.0' %}
  {% else %} # Head
    {% set container_repository = 'registry.suse.de/devel/galaxy/manager/head/containers/suse/manager/5.0' %}
  {% endif %}
{% endif %}
```
