### PR TITLE
Use Leap for proxy

### DIFF
--- a/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
@@ -2,7 +2,7 @@
 
 IMAGE                  = "opensuse155-ci-pro"
 SERVER_IMAGE           = "leapmicro55o"
-PROXY_IMAGE            = "leapmicro55o"
+PROXY_IMAGE            = "opensuse155o"
 IMAGES                 = ["rocky9o", "opensuse155o", "opensuse155-ci-pro", "ubuntu2204o", "sles15sp4o", "leapmicro55o"]
 SUSE_MINION_IMAGE      = "opensuse155o"
 PRODUCT_VERSION        = "uyuni-pr"


### PR DESCRIPTION
We are having issue with the Leap Micro. Until we can fix it, let's get back to Leap to unblock the team.