### PR TITLE
QE: Do not use Salt bundle by default in 5.0 BV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -686,7 +686,7 @@ module "slemicro51-minion" {
 
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro52-minion" {
@@ -709,7 +709,7 @@ module "slemicro52-minion" {
 
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro53-minion" {
@@ -732,7 +732,7 @@ module "slemicro53-minion" {
 
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro54-minion" {
@@ -755,7 +755,7 @@ module "slemicro54-minion" {
 
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro55-minion" {
@@ -778,7 +778,7 @@ module "slemicro55-minion" {
 
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {


### PR DESCRIPTION
Hopefully fixes the following for the 5.0 BV in NUE:

```bash
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):       Result: False
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Comment: Parent directory not present
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Started: 14:12:27.292446
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):     Duration: 2.781 ms
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Changes:
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec): ----------
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):           ID: minion_service
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):     Function: service.running
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):         Name: venv-salt-minion
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):       Result: False
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Comment: The named service venv-salt-minion is not available
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Started: 14:12:27.295549
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):     Duration: 11.835 ms
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Changes:
[2024-04-17T12:12:28.044Z] module.slemicro53-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec): Failed:     2
[2024-04-17T12:12:46.248Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec): local:
[2024-04-17T12:12:46.507Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec): ----------
[2024-04-17T12:12:46.507Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):           ID: minion_id
[2024-04-17T12:12:46.507Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):     Function: file.managed
[2024-04-17T12:12:47.069Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):         Name: /etc/venv-salt-minion/minion_id
[2024-04-17T12:12:47.069Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):       Result: False
[2024-04-17T12:12:47.069Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Comment: Parent directory not present
[2024-04-17T12:12:47.069Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Started: 14:12:46.130128
[2024-04-17T12:12:47.069Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):     Duration: 2.777 ms
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Changes:
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec): ----------
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):           ID: minion_service
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):     Function: service.running
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):         Name: venv-salt-minion
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):       Result: False
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Comment: The named service venv-salt-minion is not available
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Started: 14:12:46.133208
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):     Duration: 10.754 ms
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):      Changes:
[2024-04-17T12:12:47.070Z] module.slemicro52-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec): Failed:     2
```