### PR TITLE
Add DHCP and DNS server to private network

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -217,6 +217,10 @@ module "cucumber_testsuite" {
     pxeboot-minion = {
       image = "sles15sp4o"
     }
+    dhcp-dns = {
+      name = "dhcp-dns"
+      image = "opensuse155o"
+    }
     kvm-host = {
       image = "sles15sp4o"
       name = "min-kvm"

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -205,6 +205,10 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
+    dhcp-dns = {
+      name = "dhcp-dns"
+      image = "opensuse155o"
+    }
     kvm-host = {
       image = "opensuse155o"
       name = "min-kvm"


### PR DESCRIPTION
Fixes
```
    Scenario: Activate the branch network on the proxy
Then the "dhcp_dns" host should be present on private network
```