### PR TITLE
Remove sles15sp5 ssh minion from NUE 43 BV deployment

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -1478,7 +1478,8 @@ module "controller" {
   opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration
+// Disable until  sle15sp5s390_sshminion correctly clean from feilong
+//  sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration
 
   salt_migration_minion_configuration = module.salt-migration-minion.configuration
 


### PR DESCRIPTION
Currently, deploying sle15sp5s390_sshminion is failing with this error : 

```
13:51:06  [31m│[0m [0mGot error: HTTP status: 409, body: {"overallRC": 8, "modID": 1, "rc": 400,
13:51:06  [31m│[0m [0m"rs": 8, "errmsg": "Failed to create userid 'S43SSNUE'. SMT error: SMT
13:51:06  [31m│[0m [0mrequest failed. RequestData: 'makevm S43SSNUE directory LBYONLY 2G G --cpus
13:51:06  [31m│[0m [0m1 --profile osdflt --maxCPU 32 --maxMemSize 64G --setIniStandbyRem
13:51:06  [31m│[0m [0m--logonby guest --ipl 0100 --commandSetShare \"RELATIVE 100\"', Results:
13:51:06  [31m│[0m [0m'{'overallRC': 8, 'rc': 400, 'rs': 8, 'errno': 0, 'strError': 'ULGSMC5400E
13:51:06  [31m│[0m [0mImage or profile name already defined', 'response': ['(Error) ULTVMU0300E
13:51:06  [31m│[0m [0mSMAPI API failed: Image_Create_DM, overall rc: 8, rc: 400, rs: 8, errno: 0,
13:51:06  [31m│[0m [0mcmd: sudo /opt/zthin/bin/smcli Image_Create_DM --addRCheader -T S43SSNUE -f
13:51:06  [31m│[0m [0m/tmp/tmpgn3k8rtg, out:   API issued : Image_Create_DM', 'Defining S43SSNUE
13:51:06  [31m│[0m [0min the directory... ', 'Failed', '  Return Code: 400', '  Reason Code: 8',
13:51:06  [31m│[0m [0m'  Description: ULGSMC5400E Image or profile name already defined', '  API
13:51:06  [31m│[0m [0missued : Image_Create_DM']}'.", "output": ""}
```