### PR TITLE
Add pipelines for OpenSUSE Leap testing in Salt Shaker

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap154
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap154
@@ -1,0 +1,37 @@
+#!/usr/bin/env groovy
+
+node('salt-shaker-tests') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([cron('H 0 * * *')]),
+        parameters([
+            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt or Salt Bundle'),
+            booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
+            booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
+            booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'skip_list_url', defaultValue: 'https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/main/skipped_tests.toml', description: 'URL to the skiplist.toml file to run Salt shaker'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap154.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terraform_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for terraform'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 3, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
+        pipeline.run(params)
+    }
+}

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap155
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap155
@@ -1,0 +1,48 @@
+#!/usr/bin/env groovy
+
+node('salt-shaker-tests') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([
+            URLTrigger(
+                cronTabSpec: '* * * * *',
+                triggerLabel: "salt-shaker-tests",
+                labelRestriction: true,
+                entries: [URLTriggerEntr
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack/15.5/repodata/repomd.xml',
+                    contentTypes: [MD5Sum()]
+                )]
+            ),
+            cron('H 0 * * *')],
+        ),
+        parameters([
+            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt'),
+            booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
+            booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
+            booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'skip_list_url', defaultValue: 'https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/main/skipped_tests.toml', description: 'URL to the skiplist.toml file to run Salt shaker'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap155.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terraform_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for terraform'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 3, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
+        pipeline.run(params)
+    }
+}

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap154.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap154.tf
@@ -1,0 +1,113 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-saltstack-leap154"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "echo EXECUTE SALT TESTS HERE"
+}
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Salt Shaker - saltstack - openSUSE Leap 15.4 $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Salt Shaker - saltstack - openSUSE Leap 15.4: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-03.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br0"
+  }
+
+  images = [ "opensuse154o" ]
+}
+
+module "salt-shaker-saltstack" {
+  source             = "./modules/salt_testenv"
+  base_configuration = module.base.configuration
+
+  name               = "salt-shaker-saltstack-leap154"
+  image              = "opensuse154o"
+  salt_obs_flavor    = "saltstack"
+}
+
+output "configuration" {
+  value = module.salt-shaker-saltstack.configuration
+}

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap155.tf
@@ -1,0 +1,113 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-saltstack-leap155"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "echo EXECUTE SALT TESTS HERE"
+}
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Salt Shaker - saltstack - openSUSE Leap 15.5 $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Salt Shaker - saltstack - openSUSE Leap 15.5: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-03.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br0"
+  }
+
+  images = [ "opensuse155o" ]
+}
+
+module "salt-shaker-saltstack" {
+  source             = "./modules/salt_testenv"
+  base_configuration = module.base.configuration
+
+  name               = "salt-shaker-saltstack-leap155"
+  image              = "opensuse155o"
+  salt_obs_flavor    = "saltstack"
+}
+
+output "configuration" {
+  value = module.salt-shaker-saltstack.configuration
+}


### PR DESCRIPTION
The goal is to be able to run the Salt Shaker tests after build finished in `systemsmanagement:saltstack` for OpenSUSE Leap 15.4 and OpenSUSE Leap 15.5.

Part of https://github.com/SUSE/spacewalk/issues/23286