### PR TITLE
BV: Convert Uyuni BV to Uyuni containerized

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -163,7 +163,7 @@ module "base_s390" {
   testsuite   = true
 }
 
-module "server" {
+module "server_containerized" {
   source             = "./modules/server"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -200,15 +200,22 @@ module "server" {
   from_email                     = "root@suse.de"
   accept_all_ssl_protocols       = true
 
+  runtime = "podman"
+  container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+  container_tag = "latest"
+  helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server"
+  login_timeout = 28800
+
   //server_additional_repos
 
 }
 
-module "proxy" {
+module "proxy_containerized" {
   source             = "./modules/proxy"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
   name               = "pxy"
+  runtime = "podman"
   provider_settings = {
     mac                = "aa:b2:93:02:01:a2"
     memory             = 4096

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -309,7 +309,7 @@ module "base_s390" {
   testsuite   = true
 }
 
-module "server" {
+module "server_containerized" {
   source             = "./modules/server"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -346,11 +346,17 @@ module "server" {
   from_email                     = "root@suse.de"
   accept_all_ssl_protocols       = true
 
+  runtime = "podman"
+  container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+  container_tag = "latest"
+  helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server"
+  login_timeout = 28800
+
   //server_additional_repos
 
 }
 
-module "proxy" {
+module "proxy_containerized" {
   providers = {
     libvirt = libvirt.margarita
   }
@@ -358,6 +364,7 @@ module "proxy" {
   base_configuration = module.base_retail.configuration
   product_version    = "uyuni-master"
   name               = "pxy"
+  runtime = "podman"
   provider_settings = {
     mac                = "aa:b2:93:04:05:6e"
     memory             = 4096


### PR DESCRIPTION
It does not make sense to keep deploying Uyuni BV with non-containerized components.
So, this PR converts them to containerized components.