### PR TITLE
Use SLES 15-SP4 for PR CI in Provo

### DIFF
--- a/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
@@ -2,7 +2,7 @@
 
 IMAGE                  = "opensuse155-ci-pro"
 SERVER_IMAGE           = "leapmicro55o"
-PROXY_IMAGE            = "opensuse155o"
+PROXY_IMAGE            = "sles15sp4o"
 IMAGES                 = ["rocky9o", "opensuse155o", "opensuse155-ci-pro", "ubuntu2204o", "sles15sp4o", "leapmicro55o"]
 SUSE_MINION_IMAGE      = "opensuse155o"
 PRODUCT_VERSION        = "uyuni-pr"


### PR DESCRIPTION
Using Leap 15.5 seems to break the CI as the proxy host couldn't be bootstrapped due to broken repo. Trying SLE 15 SP4 instead to unblock PR test.