### PR TITLE
Revert "Use SLES 15-SP4 for PR CI in Provo"

### DIFF
--- a/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
@@ -2,7 +2,7 @@
 
 IMAGE                  = "opensuse155-ci-pro"
 SERVER_IMAGE           = "leapmicro55o"
-PROXY_IMAGE            = "sles15sp4o"
+PROXY_IMAGE            = "opensuse155o"
 IMAGES                 = ["rocky9o", "opensuse155o", "opensuse155-ci-pro", "ubuntu2204o", "sles15sp4o", "leapmicro55o"]
 SUSE_MINION_IMAGE      = "opensuse155o"
 PRODUCT_VERSION        = "uyuni-pr"


### PR DESCRIPTION
This reverts commit c140ee6069786241c9dc235600b0f36d05993bcd.

This doesn't work as `uyuni-tools` are not available for this SLE version: reverting