### PR TITLE
Don't have a max. of days to keep Job executions

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-AWS
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber-provo') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '10', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-NUE
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-dev-acceptance-tests-PRV
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber-provo') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('0 2,6,10,14,18,22 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-NUE
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber-provo') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -17,7 +17,7 @@ node('sumaform-cucumber-provo') {
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -19,7 +19,7 @@ node('sumaform-cucumber') {
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -19,7 +19,7 @@ node('sumaform-cucumber-provo') {
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-offline-installation
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(

--- a/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
+++ b/jenkins_pipelines/environments/manager-4.3-qe-openqa-online-installation
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(

--- a/jenkins_pipelines/environments/manager-4.3-qe-sle-update
+++ b/jenkins_pipelines/environments/manager-4.3-qe-sle-update
@@ -3,7 +3,7 @@
 node('sumaform-cucumber-provo') {
     def minionList = 'sle15sp4_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/manager-4.3-vm-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-vm-dev-acceptance-tests-NUE
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -19,7 +19,7 @@ node('sumaform-cucumber') {
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -19,7 +19,7 @@ node('sumaform-cucumber-provo') {
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/manager-Head-dev-acceptance-tests-NUE
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-Head-infra-reference-NUE
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 3 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 20 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hub-acceptance-tests
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 03 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 22 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         // UTC Timezone
         pipelineTriggers([cron('30 18 * * *')]),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-centos7-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-centos7-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian10
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian10
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian10-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian10-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian11-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian11-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian12-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian12-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles12sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles12sp5-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp1
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp1
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp1-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp1-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-centos7-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-centos7-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian10
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian10
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian10-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian10-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian11-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian11-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian12-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian12-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles12sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles12sp5-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp1
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp1
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp1-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp1-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
@@ -2,7 +2,7 @@
 
 node('salt-shaker-tests') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([
             URLTrigger(

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber-provo') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-K3S
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-K3S
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '10', daysToKeepStr: '30', artifactNumToKeepStr: '10')),
+        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-NUE
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-PRV
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber-provo') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -1,6 +1,6 @@
 node('sumaform-cucumber-provo') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '1', daysToKeepStr: '30', artifactNumToKeepStr: '1')),
+        buildDiscarder(logRotator(numToKeepStr: '1', artifactNumToKeepStr: '1')),
         pipelineTriggers([cron('0 0 * * 7')]),
         disableConcurrentBuilds(),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-podman
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-podman
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '10', daysToKeepStr: '30', artifactNumToKeepStr: '10')),
+        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '5', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 5 * * *')]),
         parameters([

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -18,7 +18,7 @@ node('sumaform-cucumber') {
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -18,7 +18,7 @@ node('sumaform-cucumber-provo') {
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/uyuni-mu-cloud
+++ b/jenkins_pipelines/environments/uyuni-mu-cloud
@@ -2,7 +2,7 @@
 
 node('sumaform-cucumber') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4')),
+        buildDiscarder(logRotator(numToKeepStr: '20')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),

--- a/jenkins_pipelines/environments/uyuni-prs-ci-tests
+++ b/jenkins_pipelines/environments/uyuni-prs-ci-tests
@@ -2,7 +2,7 @@
 
 node('pull-request-test') {
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '15')),
+        buildDiscarder(logRotator(numToKeepStr: '30')),
         parameters([
             string(name: 'platform_localisation', defaultValue: 'PRV', description: 'Decide if it will be run in \'PRV\' or \'NUE\''),
             string(name: 'product_version', defaultValue: 'uyuni', description: 'Select if we are using \'uyuni\' or \'manager43\' project'),

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+    buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_javascript_lint
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -3,7 +3,7 @@
 // WARNING: This pipeline is working progress, the test is not finished. So please, don't add to the list of PR Checks
 
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+    buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_sql_standard_name
@@ -3,7 +3,7 @@
 // WARNING: This pipeline is working progress, the test is not finished. So please, don't add to the list of PR Checks
 
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
@@ -2,7 +2,7 @@
 
 // Configure the build properties
 properties([
-        buildDiscarder(logRotator(numToKeepStr: '500', daysToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '500'))
 ])
 
 pipeline {


### PR DESCRIPTION
With this PR we want to avoid the fact of not showing some job executions in the Jenkins UI, while in fact, in the workspace we keep storing them.
Additionally, we removed this parameter from the rest of Jobs, as we have enough by cleaning the history based on number of executed jobs.