### PR TITLE
BV: salt migration minion setup

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -389,7 +389,6 @@ def run(params) {
                     stage('Clients stages') {
                         clientTestingStages(capybara_timeout, default_timeout)
                     }
-
                 } catch (Exception ex) {
                     println("ERROR: one or more clients have failed\\nException: ${ex}")
                     client_stage_result_fail = true
@@ -398,15 +397,15 @@ def run(params) {
             /** Clients stages end **/
 
             /** Products and Salt migration stages begin **/
-            try {
-                stage('Products and Salt migration stages') {
-                    if(params.must_run_products_and_salt_migration_tests) {
+            if(params.must_run_products_and_salt_migration_tests) {
+                try {
+                    stage('Products and Salt migration stages') {
                         clientMigrationStages()
                     }
+                } catch (Exception ex) {
+                    println("ERROR: one or more migrations have failed\\nException: ${ex}")
+                    products_and_salt_migration_stage_result_fail = true
                 }
-            } catch (Exception ex) {
-                println('ERROR: one or more migrations have failed')
-                products_and_salt_migration_stage_result_fail = true
             }
             /** Products and Salt migration stages end **/      
 

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -209,15 +209,15 @@ def run(params) {
             /** Clients stages end **/
 
             /** Products and Salt migration stages begin **/
-            try {
-                stage('Products and Salt migration stages') {
-                    if(params.must_run_products_and_salt_migration_tests){
+            if(params.must_run_products_and_salt_migration_tests) {
+                try {
+                    stage('Products and Salt migration stages') {
                         clientMigrationStages()
-                    }                   
-                } 
-            } catch (Exception ex) {
-                println('ERROR: one or more migrations have failed')
-                products_and_salt_migration_stage_result_fail = true
+                    }
+                } catch (Exception ex) {
+                    println('ERROR: one or more migrations have failed')
+                    products_and_salt_migration_stage_result_fail = true
+                }
             }
             /** Products and Salt migration stages stages end **/
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -420,6 +420,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "sles15sp5-minion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -807,6 +807,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1028,6 +1028,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -689,6 +689,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -891,6 +891,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 


### PR DESCRIPTION
Takes care of not installing the salt bundle on the salt migration minion during deployment.

The minion should use only OS salt and auto-connect to the master.
During migration tests, we will install the salt bundle on it and switch it to use venv-salt, purging OS salt.