### PR TITLE
Salt Shaker: Define static MAC address for SLMicro60 instances

### DIFF
--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60-Bundle.tf
@@ -106,6 +106,9 @@ module "salt-shaker-products-next" {
   name               = "salt-shaker-products-next-slmicro60-bundle"
   image              = "slmicro60o"
   salt_obs_flavor    = "saltstack:products:next"
+  provider_settings = {
+    mac = "aa:b2:93:01:01:b3"
+  }
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60.tf
@@ -106,6 +106,9 @@ module "salt-shaker-products-next" {
   name               = "salt-shaker-products-next-slmicro60"
   image              = "slmicro60o"
   salt_obs_flavor    = "saltstack:products:next"
+  provider_settings = {
+    mac = "aa:b2:93:01:01:b2"
+  }
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60-Bundle.tf
@@ -106,6 +106,9 @@ module "salt-shaker-products-testing" {
   name               = "salt-shaker-products-testing-slmicro60-bundle"
   image              = "slmicro60o"
   salt_obs_flavor    = "saltstack:products:testing"
+  provider_settings = {
+    mac = "aa:b2:93:01:01:b1"
+  }
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60.tf
@@ -106,6 +106,9 @@ module "salt-shaker-products-testing" {
   name               = "salt-shaker-products-testing-slmicro60"
   image              = "slmicro60o"
   salt_obs_flavor    = "saltstack:products:testing"
+  provider_settings = {
+    mac = "aa:b2:93:01:01:b0"
+  }
 }
 
 output "configuration" {


### PR DESCRIPTION
The SLMicro60 instances for Salt Shaker need to be rebooted after the deployment, so we need the IP address to be preserved after the reboot so terracumber is able to connect to the deployed instance and trigger the Salt Shaker execution.

The necessary configuration for dhcp and bind was made here: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/895