### PR TITLE
5.0 BV: add Salt migration minion

### DIFF
--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -8,6 +8,7 @@ node('sumaform-cucumber') {
             'sle15sp4_minion, sle15sp4_ssh_minion, ' +
             'sle15sp5_minion, sle15sp5_ssh_minion, ' +
             'sle15sp6_minion, sle15sp6_ssh_minion, ' +
+            'salt_migration_minion, ' +
             'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
             'centos7_minion, centos7_ssh_minion, ' +
             'liberty9_minion, liberty9_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -8,6 +8,7 @@ node('sumaform-cucumber-provo') {
             'sle15sp4_minion, sle15sp4_ssh_minion, ' +
             'sle15sp5_minion, sle15sp5_ssh_minion, ' +
             'sle15sp6_minion, sle15sp6_ssh_minion, ' +
+            'salt_migration_minion, ' +
             'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
             'centos7_minion, centos7_ssh_minion, ' +
             'liberty9_minion, liberty9_ssh_minion, ' +

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -422,6 +422,8 @@ module "sles15sp4-minion" {
   }
 }
 
+// This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
+// dedicated to testing migration from OS Salt to Salt bundle
 module "salt-migration-minion" {
   source             = "./modules/minion"
   base_configuration = module.base.configuration
@@ -680,6 +682,8 @@ module "controller" {
   sle15sp5_client_configuration    = module.sles15sp5-client.configuration
   sle15sp5_minion_configuration    = module.sles15sp5-minion.configuration
   sle15sp5_sshminion_configuration = module.sles15sp5-sshminion.configuration
+
+  salt_migration_minion_configuration = module.salt-migration-minion.configuration
 
   sle15sp6_client_configuration    = module.sles15sp6-client.configuration
   sle15sp6_minion_configuration    = module.sles15sp6-minion.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -827,6 +827,8 @@ module "sles15sp5s390-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+// This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
+// dedicated to testing migration from OS Salt to Salt bundle
 module "salt-migration-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1054,7 +1054,12 @@ module "sles15sp5s390-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+// This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
+// dedicated to testing migration from OS Salt to Salt bundle
 module "salt-migration-minion" {
+  providers = {
+    libvirt = libvirt.moscowmule
+  }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
   name               = "min-salt-migration"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -714,7 +714,8 @@ module "sles15sp5s390-minion" {
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
 }
-
+// This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
+// dedicated to testing migration from OS Salt to Salt bundle
 module "salt-migration-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -715,6 +715,25 @@ module "sles15sp5s390-minion" {
   install_salt_bundle = true
 }
 
+module "salt-migration-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  name               = "min-salt-migration"
+  product_version    = "head"
+  image              = "sles15sp5o"
+  provider_settings  = {
+    mac                = "aa:b2:92:42:00:7f"
+    memory             = 4096
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.suse.de"
+  }
+  auto_connect_to_master  = true
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "slemicro51-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -1539,6 +1539,8 @@ module "controller" {
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration
 
+  salt_migration_minion_configuration = module.salt-migration-minion.configuration
+
   slemicro51_minion_configuration    = module.slemicro51-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro51_sshminion_configuration = module.slemicro51-sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -916,6 +916,8 @@ module "sles15sp5s390-minion" {
   install_salt_bundle = true
 }
 
+// This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
+// dedicated to testing migration from OS Salt to Salt bundle
 module "salt-migration-minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -1840,6 +1840,8 @@ module "controller" {
   sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
   sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration
 
+  salt_migration_minion_configuration = module.salt-migration-minion.configuration
+
   slemicro51_minion_configuration    = module.slemicro51-minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 //  slemicro51_sshminion_configuration = module.slemicro51-sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -916,6 +916,25 @@ module "sles15sp5s390-minion" {
   install_salt_bundle = true
 }
 
+module "salt-migration-minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  name               = "min-salt-migration"
+  product_version    = "head"
+  image              = "sles15sp5o"
+  provider_settings  = {
+    mac                = "aa:b2:92:05:00:2f"
+    memory             = 4096
+  }
+
+  server_configuration = {
+    hostname = "suma-bv-50-srv.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = true
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "slemicro51-minion" {
   providers = {
     libvirt = libvirt.florina


### PR DESCRIPTION
As the title implies, adds entries in 5.0 BV for a dedicated SLES 15 SP5 minion on which to test migration from OS Salt to Salt bundle