### PR TITLE
Salt Shaker: Temporary increase timeout for SLMicro 6.0 to allow testsuite to finish

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 6, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60-bundle
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 6, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 6, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60-bundle
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 3, unit: 'HOURS') {
+    timeout(activity: false, time: 6, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
Apparently, testsuite execution on SLMicro 6.0, particurly the integration tests, are taking much longer to complete than in SLE, and the default 3 hours timeout is reached by our Jenkins jobs.

The tests are not stuck, but they are progressing quite slowly. We still need to debug this further but this PR increases the timeout from 3 to 6 hours trying to get at least one complete execution of the tests.