### PR TITLE
Salt Shaker: Reduce timeout value for SLMicro60 jobs

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 6, unit: 'HOURS') {
+    timeout(activity: false, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60-bundle
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 6, unit: 'HOURS') {
+    timeout(activity: false, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 6, unit: 'HOURS') {
+    timeout(activity: false, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60-bundle
@@ -43,7 +43,7 @@ node('salt-shaker-tests') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    timeout(activity: false, time: 6, unit: 'HOURS') {
+    timeout(activity: false, time: 3, unit: 'HOURS') {
         def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
         pipeline.run(params)
     }


### PR DESCRIPTION
After fixing the root cause of the performance drop for SLMicro60 tests, included in https://github.com/openSUSE/salt/pull/654, this PR just sets back the timeout for Salt Shaker SLMicro60 jobs to 3 hours