### PR TITLE
Fix wrong `tf_file` parameter for Salt Shaker test suite for TW

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-tumbleweed
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-tumbleweed
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'skip_list_url', defaultValue: 'https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/main/skipped_tests.toml', description: 'URL to the skiplist.toml file to run Salt shaker'),
-            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Tumbleweed.tf', description: 'Path to the tf file to be used'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Tumbleweed.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),


### PR DESCRIPTION
Fix a wrong `tf_file` parameter for Salt Shaker test suite for openSUSE Tumbleweed.