### PR TITLE
Do not install Salt Bundle when running the Salt Shaker test suite in Tumbleweed.

### DIFF
--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Tumbleweed.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Tumbleweed.tf
@@ -106,6 +106,7 @@ module "salt-shaker-saltstack-tumbleweed" {
   name               = "salt-shaker-saltstack-tumbleweed"
   image              = "tumbleweedo"
   salt_obs_flavor    = "saltstack"
+  install_salt_bundle = false
 }
 
 output "configuration" {


### PR DESCRIPTION
Avoid trying to install Salt Bundle for openSUSE Tumbleweed.