### PR TITLE
SL Micro 6.0: Deploy using install_salt_bundle = false, as we do for SLE Micro

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -980,6 +980,7 @@ module "slmicro60-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1228,6 +1228,7 @@ module "slmicro60-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -870,6 +870,7 @@ module "slmicro60-minion" {
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -1091,6 +1091,7 @@ module "slmicro60-minion" {
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -825,6 +825,7 @@ module "slmicro60-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1049,6 +1049,7 @@ module "slmicro60-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "sles12sp5-sshminion" {


### PR DESCRIPTION
Otherwise, the bootstrap will fail.