### PR TITLE
Ion replace trad client with slem

### DIFF
--- a/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
@@ -6,8 +6,8 @@ node('sumaform-cucumber') {
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([
-            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/agraul/uyuni.git', description: 'Testsuite Git Repository'),
-            string(name: 'cucumber_ref', defaultValue: 'serverside-trad-cleanup', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-ion-"
@@ -137,14 +137,14 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    suse-client = {
-      image = "sles15sp4o"
-      name = "cli-sles15"
+    suse-transactional-minion = {
+      image = "slemicro55o"
+      name = "min-slem55"
       provider_settings = {
         mac = "aa:b2:93:01:00:44"
       }
       additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
+      install_salt_bundle = false
     }
     suse-minion = {
       image = "sles15sp4o"


### PR DESCRIPTION
We don't need the traditional client at this time, but it would be good to have a widely available SLE Micro 5.5 instance.