### PR TITLE
Disable liberty 9 again, it still does not deploy

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -441,26 +441,26 @@ module "centos7-minion" {
   install_salt_bundle = true
 }
 
-module "liberty9-minion" {
-  source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "head"
-  name               = "min-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:75"
-    memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-srv.mgr.suse.de"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
+//module "liberty9-minion" {
+//  source             = "./modules/minion"
+//  base_configuration = module.base_core.configuration
+//  product_version    = "head"
+//  name               = "min-liberty9"
+//  image              = "libertylinux9o"
+//  provider_settings = {
+//    mac                = "aa:b2:92:42:00:75"
+//    memory             = 4096
+//  }
+//  server_configuration = {
+//    hostname = "suma-bv-50-srv.mgr.suse.de"
+//  }
+//  auto_connect_to_master  = false
+//  use_os_released_updates = false
+//  ssh_key_path            = "./salt/controller/id_rsa.pub"
+//
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+//}
 
 module "oracle9-minion" {
   source             = "./modules/minion"
@@ -1046,22 +1046,22 @@ module "centos7-sshminion" {
 }
 
 
-module "liberty9-sshminion" {
-  source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "head"
-  name               = "minssh-liberty9"
-  image              = "libertylinux9o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:95"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
+//module "liberty9-sshminion" {
+//  source             = "./modules/sshminion"
+//  base_configuration = module.base_core.configuration
+//  product_version    = "head"
+//  name               = "minssh-liberty9"
+//  image              = "libertylinux9o"
+//  provider_settings = {
+//    mac                = "aa:b2:92:42:00:95"
+//    memory             = 4096
+//  }
+//  use_os_released_updates = false
+//  ssh_key_path            = "./salt/controller/id_rsa.pub"
+//
+//  additional_packages = [ "venv-salt-minion" ]
+//  install_salt_bundle = true
+//}
 
 module "oracle9-sshminion" {
   source             = "./modules/sshminion"
@@ -1543,8 +1543,8 @@ module "controller" {
   centos7_minion_configuration    = module.centos7-minion.configuration
   centos7_sshminion_configuration = module.centos7-sshminion.configuration
 
-  liberty9_minion_configuration    = module.liberty9-minion.configuration
-  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
+//  liberty9_minion_configuration    = module.liberty9-minion.configuration
+//  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9-minion.configuration
   oracle9_sshminion_configuration = module.oracle9-sshminion.configuration


### PR DESCRIPTION
Disable liberty 9 again, it still does not deploy

```
[2024-06-20T14:24:35.559Z] module.liberty9-sshminion.module.sshminion.module.host.
null_resource.provisioning[0] (remote-exec): Error: Cannot find venv-salt-call or salt-call on the system
```