### PR TITLE
Add liberty 9 to json generator and fix proxy repos

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -73,6 +73,7 @@ v43_client_tools: dict[str, set[str]] = {
     "rhel9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/"},
     "rocky9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/"},
     "alma9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/"},
+    "liberty9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/"},
     "oracle9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS_x86_64/"},
     "slemicro51_minion": {"/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SUSE-MicroOS_5.1_x86_64/"},
@@ -128,6 +129,7 @@ v50_client_tools_beta: dict[str, set[str]] = {
     "rocky9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS-BETA_x86_64/"},
     "alma9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS-BETA_x86_64/"},
     "oracle9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS-BETA_x86_64/"},
+    "liberty9_minion": {"/SUSE_Updates_EL_9-CLIENT-TOOLS-BETA_x86_64/"},
     "slemicro51_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_5_x86_64/",
                           "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/"},
     "slemicro52_minion": {"/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_5_x86_64/",
@@ -180,7 +182,12 @@ v50_nodes: dict[str, set[str]] = {
     "server": {"/SUSE_Products_SUSE-Manager-Server_5.0_x86_64/",
                "/SUSE_Updates_SUSE-Manager-Server_5.0_x86_64/"},
     "proxy": {"/SUSE_Products_SUSE-Manager-Proxy_5.0_x86_64/",
-              "/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"}
+              "/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"
+              "/SUSE_Updates_SLE-Manager-Tools-BETA-For-Micro_5_x86_64/",
+              "/SUSE_Updates_SLE-Manager-Tools_15-BETA_x86_64/",
+              "/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/",
+              "/SUSE_Updates_SUSE-MicroOS_5.5_x86_64/",
+              "/SUSE_Updates_SLE-Micro_5.5_x86_64/"},
 }
 v50_nodes.update(merged_client_tools)
 
@@ -227,7 +234,7 @@ def validate_and_store_results(expected_ids: set [str], custom_repositories: dic
     # there should be no set difference if all MI IDs are in the JSON
     missing_ids: set[str] = expected_ids.difference(found_ids)
     if missing_ids:
-        raise SystemExit(f"MI IDs #{missing_ids} do not exist in custom_repositories dictionary.")
+        print(f"MI IDs #{missing_ids} do not exist in custom_repositories dictionary.")
 
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(custom_repositories, f, indent=2)

--- a/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
@@ -111,7 +111,8 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
                     create_url(id, suffix)
             self.assertEqual(mock_http_call.call_count, num_entries, f"Iteration N°{i+1} of {iterations}")
 
-    def test_validate_and_store_results(self):
+    @patch('builtins.print')
+    def test_validate_and_store_results(self, mock_print):
         test_output_file: str = 'test_custom_repositories.json'
         test_mi_ids: set[str] = {"123", "456", "789"}
         # empty custom_repositories
@@ -123,7 +124,8 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
             'some minion': {'789': 'some repo'}
         }
         # missing MI ID 456
-        self.assertRaises(SystemExit, validate_and_store_results, test_mi_ids, test_custom_repos, test_output_file) 
+        validate_and_store_results(test_mi_ids, test_custom_repos, test_output_file)
+        mock_print.assert_called_with("MI IDs #{'456'} do not exist in custom_repositories dictionary.")
         
         test_custom_repos['some minion']['456'] = "some repo"
         validate_and_store_results(test_mi_ids, test_custom_repos, test_output_file)


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/24615

The things that this PR does:

- [x] Add Liberty 9 to json
- [x] Add sle micro 5.5 minion repos to the 5.0 proxy for after GA
- [x] Fixes the warning about missing IDs. This was the toughest to understand. Before we raised an exception and the script exited with 1. That caused it to NOT create the file. This can be a very usual case when we have both 4.3 and 5.0 IDs in the queue and it would exclude one version against the other depending on which one we specify we want. So there will always be IDs missing and the exit code would always/often be 1. We don't want that, we want a warning but I decided against introducing a new module (warnings module) and just print it.