### PR TITLE
Salt Shaker: Do not use avahi but static ip/hostname

### DIFF
--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux9-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux9-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-CENTOS7-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-CENTOS7-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian11-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian11-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian12-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian12-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES12SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES12SP5-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2204-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2204-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Products-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Products-SLES15SP5.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap154.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap154.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap155.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Tumbleweed.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Tumbleweed.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux9-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux9-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-CENTOS7-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-CENTOS7-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian11-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian11-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian12-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian12-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES12SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES12SP5-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2204-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2204-Bundle.tf
@@ -89,6 +89,8 @@ module "base" {
 
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
 
   provider_settings = {
     pool               = "ssd"


### PR DESCRIPTION
We have enabled static ip addresses and hostname with:

https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/911
https://github.com/SUSE/susemanager-ci/pull/1267

But we were still missing to remove avahi from the TF files, as it is not needed now that we have static addresses / hostnames. Therefore this PR.