### PR TITLE
Various fixes for reference environments

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -89,7 +89,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-03.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-02.mgr.suse.de/system"
 }
 
 module "cucumber_testsuite" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
@@ -89,7 +89,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://selektah.mgr.prv.suse.net/system"
+  uri = "qemu+tcp://suma-02.mgr.suse.de/system"
 }
 
 module "cucumber_testsuite" {
@@ -144,7 +144,7 @@ module "cucumber_testsuite" {
       main_disk_size = 500
       login_timeout = 28800
       runtime = "podman"
-      container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
+      container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile/suse/manager/5.0/x86_64"
       container_tag = "latest"
     }
     proxy_containerized = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
@@ -144,7 +144,7 @@ module "cucumber_testsuite" {
       main_disk_size = 500
       login_timeout = 28800
       runtime = "podman"
-      container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
+      container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile/suse/manager/5.0/x86_64"
       container_tag = "latest"
     }
     proxy_containerized = {


### PR DESCRIPTION
* fix hypervisor for 5.0 NUE refenv
   (was in Provo, my bad)
* move hypervisor of 4.3 NUE refenv from suma-03 to suma-02
   rationale: align with other refenvs, we already have many things on suma-03
* align containers registry of 5.0 NUE refenv with 5.0 NUE acceptance
   (was identical to 5.0 BV)