### PR TITLE
Replace CentOS 7 (EOL) with Rocky8 in 4.3 CI

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-43-"
@@ -180,10 +180,10 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     redhat-minion = {
-      image = "centos7o"
-      name = "min-centos7"
+      image = "rocky8o"
+      name = "min-rocky8"
       provider_settings = {
-        mac = "aa:b2:93:01:00:99"
+        mac = "aa:b2:93:01:00:9a"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
         // Also, openscap cannot run with less than 1.25 GB of RAM
         vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -104,7 +104,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-43-"
@@ -179,10 +179,10 @@ module "cucumber_testsuite" {
       install_salt_bundle = true
     }
     redhat-minion = {
-      image = "centos7o"
-      name = "min-centos7"
+      image = "rocky8o"
+      name = "min-rocky8o"
       provider_settings = {
-        mac = "aa:b2:92:03:00:89"
+        mac = "aa:b2:92:03:00:8a"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
         // Also, openscap cannot run with less than 1.25 GB of RAM
         vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -180,7 +180,7 @@ module "cucumber_testsuite" {
     }
     redhat-minion = {
       image = "rocky8o"
-      name = "min-rocky8o"
+      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:92:03:00:8a"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM


### PR DESCRIPTION
CentOS 7 reached EOL on the 30th June 2024.

This prevents 4.3 CI pipelines from deploying.
As a temporary measure, we'll use a Rocky8 minion before attempting to move all CIs pipelines to Rocky9.