### PR TITLE
BV: increase default timeout during client boostrap and disable the catch timeout method

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -1,9 +1,9 @@
 def run(params) {
     timestamps {
         //Capybara configuration
-        def capybara_timeout= 60
+        def capybara_timeout = 60
         def default_timeout = 500
-        env.bootstrap_timeout        = 800
+        env.bootstrap_timeout = 800
 
         deployed = false
         env.resultdir = "${WORKSPACE}/results"

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -484,7 +484,7 @@ def clientTestingStages() {
                     if (params.confirm_before_continue) {
                         input 'Press any key to start running the smoke tests'
                     }
-                    randomWait()
+//                    randomWait()
                     echo 'Run Smoke tests'
                     res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_smoke_tests_${node}'", returnStatus: true)
                     echo "Smoke tests status code: ${res_smoke_tests}"

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -2,7 +2,7 @@ def run(params) {
     timestamps {
         //Capybara configuration
         def capybara_timeout = 60
-        def default_timeout = 500
+        def default_timeout = 800
 
         deployed = false
         env.resultdir = "${WORKSPACE}/results"
@@ -484,7 +484,7 @@ def clientTestingStages() {
                     if (params.confirm_before_continue) {
                         input 'Press any key to start running the smoke tests'
                     }
-//                    randomWait()
+                    randomWait()
                     echo 'Run Smoke tests'
                     res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_smoke_tests_${node}'", returnStatus: true)
                     echo "Smoke tests status code: ${res_smoke_tests}"

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -1,8 +1,9 @@
 def run(params) {
     timestamps {
         //Capybara configuration
-        def capybara_timeout = 60
-        env.default_timeout = 500
+        def capybara_timeout= 60
+        def default_timeout = 500
+        env.bootstrap_timeout        = 800
 
         deployed = false
         env.resultdir = "${WORKSPACE}/results"
@@ -472,9 +473,7 @@ def clientTestingStages() {
                     }
                     randomWait()
                     echo 'Bootstrap clients'
-                    // Increase by 1.6 the default timeout (800 seconds) to manage the events taking up to 750 seconds during bootstrap
-                    def temporary_timeout = env.default_timeout * 1.6
-                    res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} export DEFAULT_TIMEOUT=${temporary_timeout}; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
+                    res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} export DEFAULT_TIMEOUT=${env.bootstrap_timeout}; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
                     echo "Init clients status code: ${res_init_clients}"
                     if (res_init_clients != 0) {
                         error("Bootstrap clients failed with status code: ${res_init_clients}")

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -2,7 +2,7 @@ def run(params) {
     timestamps {
         //Capybara configuration
         def capybara_timeout = 60
-        def default_timeout = 800
+        env.default_timeout = 500
 
         deployed = false
         env.resultdir = "${WORKSPACE}/results"
@@ -472,7 +472,9 @@ def clientTestingStages() {
                     }
                     randomWait()
                     echo 'Bootstrap clients'
-                    res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
+                    // Increase by 1.6 the default timeout (800 seconds) to manage the events taking up to 750 seconds during bootstrap
+                    def temporary_timeout = env.default_timeout*1.6
+                    res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} export DEFAULT_TIMEOUT=${temporary_timeout}; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
                     echo "Init clients status code: ${res_init_clients}"
                     if (res_init_clients != 0) {
                         error("Bootstrap clients failed with status code: ${res_init_clients}")

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -473,7 +473,7 @@ def clientTestingStages() {
                     randomWait()
                     echo 'Bootstrap clients'
                     // Increase by 1.6 the default timeout (800 seconds) to manage the events taking up to 750 seconds during bootstrap
-                    def temporary_timeout = env.default_timeout*1.6
+                    def temporary_timeout = env.default_timeout * 1.6
                     res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} export DEFAULT_TIMEOUT=${temporary_timeout}; cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
                     echo "Init clients status code: ${res_init_clients}"
                     if (res_init_clients != 0) {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -1535,7 +1535,7 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  catch_timeout_message = true
+  catch_timeout_message = false
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1868,7 +1868,7 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  catch_timeout_message = true
+  catch_timeout_message = false
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -1378,7 +1378,7 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  catch_timeout_message = true
+  catch_timeout_message = false
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -1690,7 +1690,7 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  catch_timeout_message = true
+  catch_timeout_message = false
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER


### PR DESCRIPTION
## What does this PR do ?

### Increase the default timeout during client bootstrap
During my BV testing for 4.3 NUE, I had all my clients failing during bootstrap. This fail was related to the events taking up to 700 seconds. Currently the default timeout is set to 500 seconds for BV. I think this timeout is correct for everything except the client bootstrap ( the server can be slow at that time ).
That's why I added a temporary default timeout of about 800 for the client bootstrap stage ( I prefer to keep a ratio from default timeout if we need to change it later ).

### Disable catch timeout message mechanism
Also, the catch timeout method should not be needed anymore with the last server configuration. And I think this solution is bringing more problems than it solves. ( screenshot not available sometime when timing out ).
That's why I'm disabling this method for all the pipelines. Let's see if we see those timeout messages again. On a long term, we will need to remove completely this method from the testsuite.