### PR TITLE
BV : Create bootstrap stage : synchronize s390 minion with there x86_64 equivalent

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -447,7 +447,7 @@ def clientTestingStages() {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start creating bootstrap repositories'
                         }
-                        // Make sure s390 minions are creating its bootstrap repository after the x86_64 equivalent to avoid flushing the repository folders.
+                        // Make sure s390 minions create their bootstrap repositories after the x86_64 equivalents to avoid flushing the repository folders.
                         if (node.contains('s390')){
                             def minion_name_without_s390 = node.replaceAll('s390', '')
                             waitUntil {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -447,6 +447,7 @@ def clientTestingStages() {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start creating bootstrap repositories'
                         }
+                        // Make sure s390 minions are creating its bootstrap repository after the x86_64 equivalent to avoid flushing the repository folders.
                         if (node.contains('s390')){
                             def minion_name_without_s390 = node.replaceAll('s390', '')
                             waitUntil {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -447,6 +447,12 @@ def clientTestingStages() {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start creating bootstrap repositories'
                         }
+                        if (node.contains('s390')){
+                            def minion_name_without_s390 = node.replaceAll('s390', '')
+                            waitUntil {
+                                bootstrap_repository_status[minion_name_without_s390] != 'NOT_CREATED'
+                            }
+                        }
                         // Employ a lock resource to prevent concurrent calls to create the bootstrap repository in the manager.
                         // Utilize a try-catch mechanism to release the resource for other nodes in the event of a failed bootstrap.
                         lock(resource: mgrCreateBootstrapRepo, timeout: 320) {
@@ -573,3 +579,5 @@ def randomWait() {
 }
 
 return this
+
+Reviewers

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -579,5 +579,3 @@ def randomWait() {
 }
 
 return this
-
-Reviewers


### PR DESCRIPTION
## What does this PR change?

### Context
During BV, sles15sp5s390 bootstrap is always failing because the bootstrap repository is missing for this architecture.
The issue is cause by the fact that sles15sp5 x86_64 arch and s390 arch are sharing the same bootstrap repository.
When the testsuite create the bootstrap repository, it will always flush the directory before generate the new bootstrap repository. @Bischoff  changed the create bootstrap step definition to be able to remove the flush option but this option is not used during create bootstrap stage in BV.
On uyuni side, we changed the create bootstrap feature so sles15sp5 x86_64 flush the directory and then sles15sp5s390 doesn't flush it.
We now need to make sure sles15sp5 x86_64 is creating his bootstrap repository before sles15sp5s390.
To do so, I'm using the node handler to get sles15sp5 x86_64 status and wait until sles15sp5 x86_64 bootstrap is created on sles15sp5s390 side. It will synchronize those two clients during the parallelization. 
### Changes
This PR makes sure that sles15sp5 x86_64 create its bootstrap repository before creating the sles15sp5s390 bootstrap repository. It uses the same synchronization method than the one use for ssh_minion.

### Dependencies
This change depends on https://github.com/uyuni-project/uyuni/pull/9079 to work