### PR TITLE
Update image version matrix for SUMA 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ image for testing Pull Requests built with the open build service. This needs to
 |  Uyuni        | Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap 15.5      | Leap 15.5      |
 |  Uyuni Podman | Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap Micro 5.5 | Leap Micro 5.5 |
 |  HEAD         | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLE Micro 5.5  | SLE Micro 5.5  |
-|  4.3          | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | CentOS 7 | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLES 15 SP4    | SLES 15 SP4    |
+|  4.3          | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLES 15 SP4    | SLES 15 SP4    |
 |  5.0          | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLE Micro 5.5  | SLE Micro 5.5  |


### PR DESCRIPTION
4.3 uses Rocky 8 now, too.