### PR TITLE
Add RuboCop version output

### DIFF
--- a/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
 echo "running rubocop on step files"
+rubocop.ruby2.5 -v
 cd testsuite
 rubocop.ruby2.5 features/*

--- a/jenkins_pipelines/uyuni_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/uyuni_prs/tests_files/rubocop.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
 echo "running rubocop on step files"
+rubocop.ruby2.5 -v
 cd testsuite
 rubocop.ruby2.5 features/*


### PR DESCRIPTION
This adds the RuboCop version as output for our RuboCop CI checks, which helps debugging issues in the future.

```bash
sumadocker5:/var/lib/jenkins/workspace/manager-prs-ruby_rubocop-pipeline # rubocop.ruby2.5 -v
0.84.0
```