### PR TITLE
Fix SLE 5.0 testsuite url

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
@@ -124,7 +124,7 @@ module "server_containerized" {
 
   main_disk_size        = 1500
   runtime               = "podman"
-  container_repository  = "registry.suse.com/suse/manager/5.0/x86_64/server"
+  container_repository  = "registry.suse.com/suse/manager/5.0/x86_64"
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
 
   auto_accept                    = false
@@ -163,7 +163,7 @@ module "proxy_containerized" {
   }
 
   runtime              = "podman"
-  container_repository = "registry.suse.com/suse/manager/5.0/x86_64/proxy"
+  container_repository = "registry.suse.com/suse/manager/5.0/x86_64"
 
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"


### PR DESCRIPTION
Fix SLE 5.0 testsuite url because we add /server at the end from sumaform and this was it was double and it was invalid. 