### PR TITLE
Don't use the default venv-salt-minion for salt migration minon

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -847,6 +847,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1076,6 +1076,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -729,6 +729,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -933,6 +933,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -711,6 +711,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 module "slemicro51-minion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -916,6 +916,7 @@ module "salt-migration-minion" {
   auto_connect_to_master  = true
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = false
 }
 
 


### PR DESCRIPTION
## What does this PR do ?

In 4.3 BV, salt-migration is always failing to bootstrap. I was able to fix the issue by rebooting venv-salt-minion service but I was surprise we were using venv-salt-minion and not OS salt.
From my understanding, we want to bootstrap this minion using salt and then do the migration ? 

I need some feedback from @NamelessOne91.
If we want to bootstrap using salt, those changes will fix the deployment.
If we don't specify the `install_salt_bundle`, it will be set to `true` by default.
With `auto_connect_to_master` set to true and `install_salt_bundle` set to true, we will bootstrap the minion using venv-salt-minion  :
https://github.com/uyuni-project/sumaform/blob/676c3aaacd724ef454f6da2bcad9f3129e76591d/salt/minion/init.sls#L50-L81
