### PR TITLE
Add possibility to use file to declare the sle update reference number

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -200,7 +200,6 @@ nodes_by_version: dict[str, dict[str, set[str]]] = {
 def setup_logging():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-
 def parse_cli_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="This script reads the open qam-manager requests and creates a json file that can be fed to the BV testsuite pipeline"


### PR DESCRIPTION
## What does this PR ? 

Add the option to specify mi IDs in a file instead of providing them directly on the command line.

### File example 
File name : mis_12082024
Content : 
```
35198
32007
35176
34880
35142
35177
35114
```
Command : `maintenance_json_generator.py -f mis_12082024`