### PR TITLE
Add missing `product_version` to s390 Minions

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -774,6 +774,7 @@ module "opensuse156arm-minion" {
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "4.3-released"
 
   name               = "min-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"
@@ -1278,6 +1279,7 @@ module "opensuse156arm-sshminion" {
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "4.3-released"
 
   name               = "minssh-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -994,6 +994,7 @@ module "opensuse156arm-minion" {
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "4.3-released"
 
   name               = "min-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"
@@ -1569,6 +1570,7 @@ module "opensuse156arm-sshminion" {
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "4.3-released"
 
   name               = "minssh-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -671,6 +671,7 @@ module "opensuse156arm-minion" {
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "5.0-released"
 
   name               = "min-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"
@@ -1214,6 +1215,7 @@ module "opensuse156arm-sshminion" {
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "5.0-released"
 
   name               = "minssh-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -871,6 +871,7 @@ module "opensuse156arm-minion" {
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "5.0-released"
 
   name               = "min-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"
@@ -1483,6 +1484,7 @@ module "opensuse156arm-sshminion" {
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "5.0-released"
 
   name               = "minssh-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o"  ]
+  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -606,7 +606,7 @@ module "opensuse156arm-minion" {
   base_configuration = module.base_arm.configuration
   product_version    = "uyuni-master"
   name               = "nue-min-opensuse156arm"
-  image              = "opensuse1556rmo"
+  image              = "opensuse156armo"
   provider_settings = {
     mac                = "aa:b2:93:02:01:ce"
     overwrite_fqdn     = "uyuni-bv-master-min-opensuse156arm.mgr.suse.de"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -625,6 +625,7 @@ module "opensuse156arm-minion" {
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "uyuni-master"
 
   name               = "min-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"
@@ -1089,6 +1090,7 @@ module "opensuse156arm-sshminion" {
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "uyuni-master"
 
   name               = "minssh-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -135,7 +135,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse155o", "opensuse156o" ]
+  images      = [ "sles15sp4o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -236,7 +236,7 @@ module "base_retail" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "opensuse155o" ]
+  images      = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "opensuse155o", "leapmicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -821,6 +821,7 @@ module "opensuse156arm-minion" {
 module "sles15sp5s390-minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "uyuni-master"
 
   name               = "min-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"
@@ -1352,6 +1353,7 @@ module "opensuse156arm-sshminion" {
 module "sles15sp5s390-sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
+  product_version    = "uyuni-master"
 
   name               = "minssh-sles15sp5s390"
   image              = "s15s5-minimal-2part-xfs"


### PR DESCRIPTION
Fixes

- renderning error:
```bash
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): local:
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):     Data failed to compile:
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): ----------
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):     Rendering SLS 'base:repos' failed: Jinja error: argument of type 'NoneType' is not iterable
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): Traceback (most recent call last):
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   File "/usr/lib/python3.6/site-packages/salt/utils/templates.py", line 476, in render_jinja_tmpl
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):     output = template.render(**decoded_context)
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   File "/usr/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):     return original_render(self, *args, **kwargs)
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   File "/usr/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):     return self.environment.handle_exception(exc_info, True)
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   File "/usr/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):     reraise(exc_type, exc_value, tb)
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   File "/usr/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):     raise value.with_traceback(tb)
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   File "<template>", line 18, in top-level template code
[2024-08-14T10:15:53.058Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): TypeError: argument of type 'NoneType' is not iterable
[2024-08-14T10:15:53.987Z]
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): ; line 18
[2024-08-14T10:15:53.987Z]
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): ---
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): [...]
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   - repos.testsuite
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   - repos.tools
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   - repos.jenkins
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   - repos.server_containerized
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   - repos.proxy_containerized
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   {% if '4.3' not in grains.get('product_version') %}    <======================
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   - repos.ruby
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   {% endif %}
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   {% endif %}
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec):   - repos.additional
[2024-08-14T10:15:53.987Z]
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): [...]
[2024-08-14T10:15:53.987Z] module.sles15sp5s390-minion.null_resource.provisioning (remote-exec): ---
```
- Leap 15.6 ARM image name
- Missing Leap Micro in base config

currently this is not an issue, but it will be, once I merge https://github.com/uyuni-project/sumaform/pull/1248. Since we always add a `product_version` to all Minions, this will align the s390 ones.