### PR TITLE
Rename module to match testsuite minion tags.

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1887,7 +1887,7 @@ module "controller" {
   sle15sp5s390_minion_configuration    = module.sle15sp5s390_minion.configuration
   sle15sp5s390_sshminion_configuration = module.sle15sp5s390_ssh_minion.configuration
 
-  salt_migration_minion_configuration = module.salt-migration_minion.configuration
+  salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
   slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -377,7 +377,7 @@ module "proxy" {
   ssh_key_path              = "./salt/controller/id_rsa.pub"
 }
 
-module "sles12sp5-client" {
+module "sle12sp5_client" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -398,7 +398,7 @@ module "sles12sp5-client" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp2-client" {
+module "sle15sp2_client" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -419,7 +419,7 @@ module "sles15sp2-client" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp3-client" {
+module "sle15sp3_client" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -440,7 +440,7 @@ module "sles15sp3-client" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp4-client" {
+module "sle15sp4_client" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -461,7 +461,7 @@ module "sles15sp4-client" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5-client" {
+module "sle15sp5_client" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -482,7 +482,7 @@ module "sles15sp5-client" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp6-client" {
+module "sle15sp6_client" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -503,7 +503,7 @@ module "sles15sp6-client" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "centos7-client" {
+module "centos7_client" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -527,7 +527,7 @@ module "centos7-client" {
   install_salt_bundle = true
 }
 
-module "sles12sp5-minion" {
+module "sle12sp5_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -548,7 +548,7 @@ module "sles12sp5-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp2-minion" {
+module "sle15sp2_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -570,7 +570,7 @@ module "sles15sp2-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp3-minion" {
+module "sle15sp3_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -592,7 +592,7 @@ module "sles15sp3-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp4-minion" {
+module "sle15sp4_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -614,7 +614,7 @@ module "sles15sp4-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5-minion" {
+module "sle15sp5_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -636,7 +636,7 @@ module "sles15sp5-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp6-minion" {
+module "sle15sp6_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -658,7 +658,7 @@ module "sles15sp6-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "alma8-minion" {
+module "alma8_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -682,7 +682,7 @@ module "alma8-minion" {
   install_salt_bundle = true
 }
 
-module "alma9-minion" {
+module "alma9_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -706,7 +706,7 @@ module "alma9-minion" {
   install_salt_bundle = true
 }
 
-module "centos7-minion" {
+module "centos7_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -730,7 +730,7 @@ module "centos7-minion" {
   install_salt_bundle = true
 }
 
-module "liberty9-minion" {
+module "liberty9_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -754,7 +754,7 @@ module "liberty9-minion" {
   install_salt_bundle = true
 }
 
-module "oracle9-minion" {
+module "oracle9_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -778,7 +778,7 @@ module "oracle9-minion" {
   install_salt_bundle = true
 }
 
-module "rocky8-minion" {
+module "rocky8_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -802,7 +802,7 @@ module "rocky8-minion" {
   install_salt_bundle = true
 }
 
-module "rocky9-minion" {
+module "rocky9_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -826,7 +826,7 @@ module "rocky9-minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004-minion" {
+module "ubuntu2004_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -851,7 +851,7 @@ module "ubuntu2004-minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204-minion" {
+module "ubuntu2204_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -872,7 +872,7 @@ module "ubuntu2204-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian11-minion" {
+module "debian11_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -894,7 +894,7 @@ module "debian11-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian12-minion" {
+module "debian12_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -919,7 +919,7 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm-minion" {
+module "opensuse154arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -943,7 +943,7 @@ module "opensuse154arm-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse155arm-minion" {
+module "opensuse155arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -967,7 +967,7 @@ module "opensuse155arm-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse156arm-minion" {
+module "opensuse156arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -991,7 +991,7 @@ module "opensuse156arm-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5s390-minion" {
+module "sle15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "4.3-released"
@@ -1010,9 +1010,9 @@ module "sles15sp5s390-minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-// This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
+// This is an x86_64 SLES 15 SP5 minion (like sle15sp5_minion),
 // dedicated to testing migration from OS Salt to Salt bundle
-module "salt-migration-minion" {
+module "salt_migration_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1035,7 +1035,7 @@ module "salt-migration-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro51-minion" {
+module "slemicro51_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1061,7 +1061,7 @@ module "slemicro51-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro52-minion" {
+module "slemicro52_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1087,7 +1087,7 @@ module "slemicro52-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro53-minion" {
+module "slemicro53_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1113,7 +1113,7 @@ module "slemicro53-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro54-minion" {
+module "slemicro54_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1139,7 +1139,7 @@ module "slemicro54-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro55-minion" {
+module "slemicro55_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1165,7 +1165,7 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
-module "slmicro60-minion" {
+module "slmicro60_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1188,7 +1188,7 @@ module "slmicro60-minion" {
   install_salt_bundle = false
 }
 
-module "sles12sp5-sshminion" {
+module "sle12sp5_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1207,7 +1207,7 @@ module "sles12sp5-sshminion" {
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
-module "sles15sp2-sshminion" {
+module "sle15sp2_ssh_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1224,7 +1224,7 @@ module "sles15sp2-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp3-sshminion" {
+module "sle15sp3_ssh_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1241,7 +1241,7 @@ module "sles15sp3-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp4-sshminion" {
+module "sle15sp4_ssh_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1258,7 +1258,7 @@ module "sles15sp4-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5-sshminion" {
+module "sle15sp5_ssh_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1275,7 +1275,7 @@ module "sles15sp5-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp6-sshminion" {
+module "sle15sp6_ssh_minion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1292,7 +1292,7 @@ module "sles15sp6-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "alma8-sshminion" {
+module "alma8_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1312,7 +1312,7 @@ module "alma8-sshminion" {
   install_salt_bundle = true
 }
 
-module "alma9-sshminion" {
+module "alma9_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1332,7 +1332,7 @@ module "alma9-sshminion" {
   install_salt_bundle = true
 }
 
-module "centos7-sshminion" {
+module "centos7_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1352,7 +1352,7 @@ module "centos7-sshminion" {
   install_salt_bundle = true
 }
 
-module "liberty9-sshminion" {
+module "liberty9_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1372,7 +1372,7 @@ module "liberty9-sshminion" {
   install_salt_bundle = true
 }
 
-module "oracle9-sshminion" {
+module "oracle9_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1392,7 +1392,7 @@ module "oracle9-sshminion" {
   install_salt_bundle = true
 }
 
-module "rocky8-sshminion" {
+module "rocky8_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1412,7 +1412,7 @@ module "rocky8-sshminion" {
   install_salt_bundle = true
 }
 
-module "rocky9-sshminion" {
+module "rocky9_ssh_minion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1432,7 +1432,7 @@ module "rocky9-sshminion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004-sshminion" {
+module "ubuntu2004_ssh_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1453,7 +1453,7 @@ module "ubuntu2004-sshminion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204-sshminion" {
+module "ubuntu2204_ssh_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1470,7 +1470,7 @@ module "ubuntu2204-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian11-sshminion" {
+module "debian11_ssh_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1487,7 +1487,7 @@ module "debian11-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian12-sshminion" {
+module "debian12_ssh_minion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1507,7 +1507,7 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm-sshminion" {
+module "opensuse154arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1527,7 +1527,7 @@ module "opensuse154arm-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse155arm-sshminion" {
+module "opensuse155arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1547,7 +1547,7 @@ module "opensuse155arm-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse156arm-sshminion" {
+module "opensuse156arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1567,7 +1567,7 @@ module "opensuse156arm-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5s390-sshminion" {
+module "sle15sp5s390_ssh_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "4.3-released"
@@ -1587,7 +1587,7 @@ module "sles15sp5s390-sshminion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51-sshminion" {
+// module "slemicro51_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1605,7 +1605,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52-sshminion" {
+// module "slemicro52_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1623,7 +1623,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53-sshminion" {
+// module "slemicro53_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1641,7 +1641,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54-sshminion" {
+// module "slemicro54_ssh_minion" {
 //  providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1659,7 +1659,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55-sshminion" {
+// module "slemicro55_ssh_minion" {
 //  providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1677,7 +1677,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60-sshminion" {
+// module "slmicro60_ssh_minion" {
 //  providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1694,7 +1694,7 @@ module "sles15sp5s390-sshminion" {
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
 // }
 
-module "sles12sp5-buildhost" {
+module "sle12sp5_buildhost" {
   providers = {
     libvirt = libvirt.coruscant
   }
@@ -1716,7 +1716,7 @@ module "sles12sp5-buildhost" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles12sp5-terminal" {
+module "sle12sp5_terminal" {
   providers = {
     libvirt = libvirt.coruscant
   }
@@ -1734,7 +1734,7 @@ module "sles12sp5-terminal" {
   private_name       = "sle12sp5terminal"
 }
 
-module "sles15sp4-buildhost" {
+module "sle15sp4_buildhost" {
   providers = {
     libvirt = libvirt.coruscant
   }
@@ -1756,7 +1756,7 @@ module "sles15sp4-buildhost" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp4-terminal" {
+module "sle15sp4_terminal" {
   providers = {
     libvirt = libvirt.coruscant
   }
@@ -1817,107 +1817,107 @@ module "controller" {
   server_configuration = module.server.configuration
   proxy_configuration  = module.proxy.configuration
 
-  sle12sp5_client_configuration    = module.sles12sp5-client.configuration
-  sle12sp5_minion_configuration    = module.sles12sp5-minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5-sshminion.configuration
+  sle12sp5_client_configuration    = module.sle12sp5_client.configuration
+  sle12sp5_minion_configuration    = module.sle12sp5_minion.configuration
+  sle12sp5_sshminion_configuration = module.sle12sp5_ssh_minion.configuration
 
-  sle15sp2_client_configuration    = module.sles15sp2-client.configuration
-  sle15sp2_minion_configuration    = module.sles15sp2-minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2-sshminion.configuration
+  sle15sp2_client_configuration    = module.sle15sp2_client.configuration
+  sle15sp2_minion_configuration    = module.sle15sp2_minion.configuration
+  sle15sp2_sshminion_configuration = module.sle15sp2_ssh_minion.configuration
 
-  sle15sp3_client_configuration    = module.sles15sp3-client.configuration
-  sle15sp3_minion_configuration    = module.sles15sp3-minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3-sshminion.configuration
+  sle15sp3_client_configuration    = module.sle15sp3_client.configuration
+  sle15sp3_minion_configuration    = module.sle15sp3_minion.configuration
+  sle15sp3_sshminion_configuration = module.sle15sp3_ssh_minion.configuration
 
-  sle15sp4_client_configuration    = module.sles15sp4-client.configuration
-  sle15sp4_minion_configuration    = module.sles15sp4-minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4-sshminion.configuration
+  sle15sp4_client_configuration    = module.sle15sp4_client.configuration
+  sle15sp4_minion_configuration    = module.sle15sp4_minion.configuration
+  sle15sp4_sshminion_configuration = module.sle15sp4_ssh_minion.configuration
 
-  sle15sp5_client_configuration    = module.sles15sp5-client.configuration
-  sle15sp5_minion_configuration    = module.sles15sp5-minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5-sshminion.configuration
+  sle15sp5_client_configuration    = module.sle15sp5_client.configuration
+  sle15sp5_minion_configuration    = module.sle15sp5_minion.configuration
+  sle15sp5_sshminion_configuration = module.sle15sp5_ssh_minion.configuration
 
-  sle15sp6_client_configuration    = module.sles15sp6-client.configuration
-  sle15sp6_minion_configuration    = module.sles15sp6-minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6-sshminion.configuration
+  sle15sp6_client_configuration    = module.sle15sp6_client.configuration
+  sle15sp6_minion_configuration    = module.sle15sp6_minion.configuration
+  sle15sp6_sshminion_configuration = module.sle15sp6_ssh_minion.configuration
 
-  alma8_minion_configuration    = module.alma8-minion.configuration
-  alma8_sshminion_configuration = module.alma8-sshminion.configuration
+  alma8_minion_configuration    = module.alma8_minion.configuration
+  alma8_sshminion_configuration = module.alma8_ssh_minion.configuration
 
-  alma9_minion_configuration    = module.alma9-minion.configuration
-  alma9_sshminion_configuration = module.alma9-sshminion.configuration
+  alma9_minion_configuration    = module.alma9_minion.configuration
+  alma9_sshminion_configuration = module.alma9_ssh_minion.configuration
 
-  centos7_client_configuration    = module.centos7-client.configuration
-  centos7_minion_configuration    = module.centos7-minion.configuration
-  centos7_sshminion_configuration = module.centos7-sshminion.configuration
+  centos7_client_configuration    = module.centos7_client.configuration
+  centos7_minion_configuration    = module.centos7_minion.configuration
+  centos7_sshminion_configuration = module.centos7_ssh_minion.configuration
 
-  liberty9_minion_configuration    = module.liberty9-minion.configuration
-  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
+  liberty9_minion_configuration    = module.liberty9_minion.configuration
+  liberty9_sshminion_configuration = module.liberty9_ssh_minion.configuration
 
-  oracle9_minion_configuration    = module.oracle9-minion.configuration
-  oracle9_sshminion_configuration = module.oracle9-sshminion.configuration
+  oracle9_minion_configuration    = module.oracle9_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_ssh_minion.configuration
 
-  rocky8_minion_configuration    = module.rocky8-minion.configuration
-  rocky8_sshminion_configuration = module.rocky8-sshminion.configuration
+  rocky8_minion_configuration    = module.rocky8_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
 
-  rocky9_minion_configuration    = module.rocky9-minion.configuration
-  rocky9_sshminion_configuration = module.rocky9-sshminion.configuration
+  rocky9_minion_configuration    = module.rocky9_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_ssh_minion.configuration
 
-  ubuntu2004_minion_configuration    = module.ubuntu2004-minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004-sshminion.configuration
+  ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
 
-  ubuntu2204_minion_configuration    = module.ubuntu2204-minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204-sshminion.configuration
+  ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
 
-  debian11_minion_configuration    = module.debian11-minion.configuration
-  debian11_sshminion_configuration = module.debian11-sshminion.configuration
+  debian11_minion_configuration    = module.debian11_minion.configuration
+  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
 
-  debian12_minion_configuration    = module.debian12-minion.configuration
-  debian12_sshminion_configuration = module.debian12-sshminion.configuration
+  debian12_minion_configuration    = module.debian12_minion.configuration
+  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
 
-  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm_minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm_ssh_minion.configuration
 
-  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration
 
-  opensuse156arm_minion_configuration    = module.opensuse156arm-minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm-sshminion.configuration
+  opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_ssh_minion.configuration
 
-  sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration
+  sle15sp5s390_minion_configuration    = module.sle15sp5s390_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sle15sp5s390_ssh_minion.configuration
 
-  salt_migration_minion_configuration = module.salt-migration-minion.configuration
+  salt_migration_minion_configuration = module.salt-migration_minion.configuration
 
-  slemicro51_minion_configuration    = module.slemicro51-minion.configuration
+  slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51-sshminion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_ssh_minion.configuration
 
-  slemicro52_minion_configuration    = module.slemicro52-minion.configuration
+  slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52-sshminion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_ssh_minion.configuration
 
-  slemicro53_minion_configuration    = module.slemicro53-minion.configuration
+  slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53-sshminion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_ssh_minion.configuration
 
-  slemicro54_minion_configuration    = module.slemicro54-minion.configuration
+  slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_ssh_minion.configuration
 
-  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_ssh_minion.configuration
 
-  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_ssh_minion.configuration
 
-  sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
-  sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration
+  sle12sp5_buildhost_configuration = module.sle12sp5_buildhost.configuration
+  sle15sp4_buildhost_configuration = module.sle15sp4_buildhost.configuration
 
-  sle12sp5_terminal_configuration = module.sles12sp5-terminal.configuration
-  sle15sp4_terminal_configuration = module.sles15sp4-terminal.configuration
+  sle12sp5_terminal_configuration = module.sle12sp5_terminal.configuration
+  sle15sp4_terminal_configuration = module.sle15sp4_terminal.configuration
 
   monitoringserver_configuration = module.monitoring-server.configuration
 }


### PR DESCRIPTION
# Context
To be able to use directly the minionList to remove the disable minions from the deployment, rename the module names to match the testsuite tag.

## Issue 
https://github.com/SUSE/spacewalk/issues/25063