### PR TITLE
Fixes for the Uyuni BV

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -8,7 +8,7 @@ node('sumaform-cucumber-provo') {
             'sle15sp5_minion, sle15sp5_ssh_minion, ' +
             'sle15sp6_minion, sle15sp6_ssh_minion, ' +
             'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
+            'centos7_minion, centos7_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -168,6 +168,7 @@ module "server_containerized" {
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
   name               = "srv"
+  image              = "leapmicro55o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:a1"
     memory             = 40960
@@ -176,9 +177,7 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
-  main_disk_size        = 20
-  repository_disk_size  = 3072
-  database_disk_size    = 150
+  main_disk_size = 3000
 
   java_debugging                 = false
   auto_accept                    = false
@@ -1311,7 +1310,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  catch_timeout_message = false
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -177,7 +177,9 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
-  main_disk_size = 3000
+  main_disk_size        = 20
+  repository_disk_size  = 3072
+  database_disk_size    = 150
 
   java_debugging                 = false
   auto_accept                    = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -314,6 +314,7 @@ module "server_containerized" {
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
   name               = "srv"
+  image              = "leapmicro55o"
   provider_settings = {
     mac                = "aa:b2:93:04:05:6d"
     memory             = 40960
@@ -322,9 +323,7 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-  main_disk_size        = 20
-  repository_disk_size  = 3072
-  database_disk_size    = 150
+  main_disk_size = 3000
 
   java_debugging                 = false
   auto_accept                    = false
@@ -1606,7 +1605,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  catch_timeout_message = false
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -323,7 +323,9 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-  main_disk_size = 3000
+  main_disk_size        = 20
+  repository_disk_size  = 3072
+  database_disk_size    = 150
 
   java_debugging                 = false
   auto_accept                    = false


### PR DESCRIPTION
This PR

- ~fixes the main disk image size~
- removes the CentOS 7 client
- explicitly defines the server OS image version
- removes `catch_timeout_message = false` from the controller

for the Uyuni BV.