### PR TITLE
Rename build validation 5.0 PRV modules

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -371,7 +371,7 @@ module "proxy_containerized" {
   ssh_key_path              = "./salt/controller/id_rsa.pub"
 }
 
-module "sles12sp5-minion" {
+module "sles12sp5_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -395,7 +395,7 @@ module "sles12sp5-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp2-minion" {
+module "sles15sp2_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -420,7 +420,7 @@ module "sles15sp2-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp3-minion" {
+module "sles15sp3_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -445,7 +445,7 @@ module "sles15sp3-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp4-minion" {
+module "sles15sp4_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -470,7 +470,7 @@ module "sles15sp4-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5-minion" {
+module "sles15sp5_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -495,7 +495,7 @@ module "sles15sp5-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp6-minion" {
+module "sles15sp6_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -520,7 +520,7 @@ module "sles15sp6-minion" {
   install_salt_bundle = true
 }
 
-module "alma8-minion" {
+module "alma8_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -544,7 +544,7 @@ module "alma8-minion" {
   install_salt_bundle = true
 }
 
-module "alma9-minion" {
+module "alma9_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -568,7 +568,7 @@ module "alma9-minion" {
   install_salt_bundle = true
 }
 
-module "centos7-minion" {
+module "centos7_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -592,7 +592,7 @@ module "centos7-minion" {
   install_salt_bundle = true
 }
 
-module "liberty9-minion" {
+module "liberty9_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -616,7 +616,7 @@ module "liberty9-minion" {
   install_salt_bundle = true
 }
 
-module "oracle9-minion" {
+module "oracle9_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -640,7 +640,7 @@ module "oracle9-minion" {
   install_salt_bundle = true
 }
 
-module "rocky8-minion" {
+module "rocky8_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -664,7 +664,7 @@ module "rocky8-minion" {
   install_salt_bundle = true
 }
 
-module "rocky9-minion" {
+module "rocky9_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -688,7 +688,7 @@ module "rocky9-minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004-minion" {
+module "ubuntu2004_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -713,7 +713,7 @@ module "ubuntu2004-minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204-minion" {
+module "ubuntu2204_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -737,7 +737,7 @@ module "ubuntu2204-minion" {
   install_salt_bundle = true
 }
 
-module "debian11-minion" {
+module "debian11_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -762,7 +762,7 @@ module "debian11-minion" {
   install_salt_bundle = true
 }
 
-module "debian12-minion" {
+module "debian12_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -787,7 +787,7 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm-minion" {
+module "opensuse154arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -814,7 +814,7 @@ module "opensuse154arm-minion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm-minion" {
+module "opensuse155arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -841,7 +841,7 @@ module "opensuse155arm-minion" {
   install_salt_bundle = true
 }
 
-module "opensuse156arm-minion" {
+module "opensuse156arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -868,7 +868,7 @@ module "opensuse156arm-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5s390-minion" {
+module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "5.0-released"
@@ -892,7 +892,7 @@ module "sles15sp5s390-minion" {
 
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
 // dedicated to testing migration from OS Salt to Salt bundle
-module "salt-migration-minion" {
+module "salt_migration_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   name               = "min-salt-migration"
@@ -912,7 +912,7 @@ module "salt-migration-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro51-minion" {
+module "slemicro51_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -938,7 +938,7 @@ module "slemicro51-minion" {
 //  install_salt_bundle = true
 }
 
-module "slemicro52-minion" {
+module "slemicro52_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -964,7 +964,7 @@ module "slemicro52-minion" {
 //  install_salt_bundle = true
 }
 
-module "slemicro53-minion" {
+module "slemicro53_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -990,7 +990,7 @@ module "slemicro53-minion" {
 //  install_salt_bundle = true
 }
 
-module "slemicro54-minion" {
+module "slemicro54_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1016,7 +1016,7 @@ module "slemicro54-minion" {
 //  install_salt_bundle = true
 }
 
-module "slemicro55-minion" {
+module "slemicro55_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1042,7 +1042,7 @@ module "slemicro55-minion" {
 //  install_salt_bundle = true
 }
 
-module "slmicro60-minion" {
+module "slmicro60_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1069,7 +1069,7 @@ module "slmicro60-minion" {
   install_salt_bundle = false
 }
 
-module "sles12sp5-sshminion" {
+module "sles12sp5_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1091,7 +1091,7 @@ module "sles12sp5-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp2-sshminion" {
+module "sles15sp2_ssh_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1111,7 +1111,7 @@ module "sles15sp2-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp3-sshminion" {
+module "sles15sp3_ssh_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1131,7 +1131,7 @@ module "sles15sp3-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp4-sshminion" {
+module "sles15sp4_ssh_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1151,7 +1151,7 @@ module "sles15sp4-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5-sshminion" {
+module "sles15sp5_ssh_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1171,7 +1171,7 @@ module "sles15sp5-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp6-sshminion" {
+module "sles15sp6_ssh_minion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1191,7 +1191,7 @@ module "sles15sp6-sshminion" {
   install_salt_bundle = true
 }
 
-module "alma8-sshminion" {
+module "alma8_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1211,7 +1211,7 @@ module "alma8-sshminion" {
   install_salt_bundle = true
 }
 
-module "alma9-sshminion" {
+module "alma9_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1231,7 +1231,7 @@ module "alma9-sshminion" {
   install_salt_bundle = true
 }
 
-module "centos7-sshminion" {
+module "centos7_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1251,7 +1251,7 @@ module "centos7-sshminion" {
   install_salt_bundle = true
 }
 
-module "liberty9-sshminion" {
+module "liberty9_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1271,7 +1271,7 @@ module "liberty9-sshminion" {
   install_salt_bundle = true
 }
 
-module "oracle9-sshminion" {
+module "oracle9_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1291,7 +1291,7 @@ module "oracle9-sshminion" {
   install_salt_bundle = true
 }
 
-module "rocky8-sshminion" {
+module "rocky8_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1311,7 +1311,7 @@ module "rocky8-sshminion" {
   install_salt_bundle = true
 }
 
-module "rocky9-sshminion" {
+module "rocky9_ssh_minion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1331,7 +1331,7 @@ module "rocky9-sshminion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004-sshminion" {
+module "ubuntu2004_ssh_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1352,7 +1352,7 @@ module "ubuntu2004-sshminion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204-sshminion" {
+module "ubuntu2204_ssh_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1372,7 +1372,7 @@ module "ubuntu2204-sshminion" {
   install_salt_bundle = true
 }
 
-module "debian11-sshminion" {
+module "debian11_ssh_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1392,7 +1392,7 @@ module "debian11-sshminion" {
   install_salt_bundle = true
 }
 
-module "debian12-sshminion" {
+module "debian12_ssh_minion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1412,7 +1412,7 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm-sshminion" {
+module "opensuse154arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1435,7 +1435,7 @@ module "opensuse154arm-sshminion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm-sshminion" {
+module "opensuse155arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1458,7 +1458,7 @@ module "opensuse155arm-sshminion" {
   install_salt_bundle = true
 }
 
-module "opensuse156arm-sshminion" {
+module "opensuse156arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1481,7 +1481,7 @@ module "opensuse156arm-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5s390-sshminion" {
+module "sles15sp5s390_ssh_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "5.0-released"
@@ -1504,7 +1504,7 @@ module "sles15sp5s390-sshminion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51-sshminion" {
+// module "slemicro51_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1525,7 +1525,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52-sshminion" {
+// module "slemicro52_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1546,7 +1546,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53-sshminion" {
+// module "slemicro53_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1567,7 +1567,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54-sshminion" {
+// module "slemicro54_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1588,7 +1588,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55-sshminion" {
+// module "slemicro55_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1609,7 +1609,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60-sshminion" {
+// module "slmicro60_ssh_minion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1629,7 +1629,7 @@ module "sles15sp5s390-sshminion" {
 //  install_salt_bundle = true
 // }
 
-module "sles12sp5-buildhost" {
+module "sles12sp5_buildhost" {
   providers = {
     libvirt = libvirt.terminus
   }
@@ -1654,7 +1654,7 @@ module "sles12sp5-buildhost" {
   install_salt_bundle = true
 }
 
-module "sles12sp5-terminal" {
+module "sles12sp5_terminal" {
   providers = {
     libvirt = libvirt.terminus
   }
@@ -1672,7 +1672,7 @@ module "sles12sp5-terminal" {
   private_name       = "sle12sp5terminal"
 }
 
-module "sles15sp4-buildhost" {
+module "sles15sp4_buildhost" {
   providers = {
     libvirt = libvirt.terminus
   }
@@ -1697,7 +1697,7 @@ module "sles15sp4-buildhost" {
   install_salt_bundle = true
 }
 
-module "sles15sp4-terminal" {
+module "sles15sp4_terminal" {
   providers = {
     libvirt = libvirt.terminus
   }
@@ -1715,15 +1715,15 @@ module "sles15sp4-terminal" {
   private_name       = "sle15sp4terminal"
 }
 
-module "dhcp-dns" {
+module "dhcp_dns" {
   source             = "./modules/dhcp_dns"
   base_configuration = module.base_retail.configuration
   name               = "dhcp-dns"
   image              = "opensuse155o"
   private_hosts = [
     module.proxy_containerized.configuration,
-    module.sles12sp5-terminal.configuration,
-    module.sles15sp4-terminal.configuration
+    module.sles12sp5_terminal.configuration,
+    module.sles15sp4_terminal.configuration
   ]
   hypervisor = {
     host        = "terminus.mgr.prv.suse.net"
@@ -1732,7 +1732,7 @@ module "dhcp-dns" {
   }
 }
 
-module "monitoring-server" {
+module "monitoring_server" {
   providers = {
     libvirt = libvirt.terminus
   }
@@ -1778,102 +1778,102 @@ module "controller" {
 
   proxy_configuration  = module.proxy_containerized.configuration
 
-  sle12sp5_minion_configuration    = module.sles12sp5-minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5-sshminion.configuration
+  sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_ssh_minion.configuration
 
-  sle15sp2_minion_configuration    = module.sles15sp2-minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2-sshminion.configuration
+  sle15sp2_minion_configuration    = module.sles15sp2_minion.configuration
+  sle15sp2_sshminion_configuration = module.sles15sp2_ssh_minion.configuration
 
-  sle15sp3_minion_configuration    = module.sles15sp3-minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3-sshminion.configuration
+  sle15sp3_minion_configuration    = module.sles15sp3_minion.configuration
+  sle15sp3_sshminion_configuration = module.sles15sp3_ssh_minion.configuration
 
-  sle15sp4_minion_configuration    = module.sles15sp4-minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4-sshminion.configuration
+  sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_ssh_minion.configuration
 
-  sle15sp5_minion_configuration    = module.sles15sp5-minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5-sshminion.configuration
+  sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
+  sle15sp5_sshminion_configuration = module.sles15sp5_ssh_minion.configuration
 
-  sle15sp6_minion_configuration    = module.sles15sp6-minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6-sshminion.configuration
+  sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
+  sle15sp6_sshminion_configuration = module.sles15sp6_ssh_minion.configuration
 
-  alma8_minion_configuration    = module.alma8-minion.configuration
-  alma8_sshminion_configuration = module.alma8-sshminion.configuration
+  alma8_minion_configuration    = module.alma8_minion.configuration
+  alma8_sshminion_configuration = module.alma8_ssh_minion.configuration
 
-  alma9_minion_configuration    = module.alma9-minion.configuration
-  alma9_sshminion_configuration = module.alma9-sshminion.configuration
+  alma9_minion_configuration    = module.alma9_minion.configuration
+  alma9_sshminion_configuration = module.alma9_ssh_minion.configuration
 
-  centos7_minion_configuration    = module.centos7-minion.configuration
-  centos7_sshminion_configuration = module.centos7-sshminion.configuration
+  centos7_minion_configuration    = module.centos7_minion.configuration
+  centos7_sshminion_configuration = module.centos7_ssh_minion.configuration
 
-  liberty9_minion_configuration    = module.liberty9-minion.configuration
-  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
+  liberty9_minion_configuration    = module.liberty9_minion.configuration
+  liberty9_sshminion_configuration = module.liberty9_ssh_minion.configuration
 
-  oracle9_minion_configuration    = module.oracle9-minion.configuration
-  oracle9_sshminion_configuration = module.oracle9-sshminion.configuration
+  oracle9_minion_configuration    = module.oracle9_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_ssh_minion.configuration
 
-  rocky8_minion_configuration    = module.rocky8-minion.configuration
-  rocky8_sshminion_configuration = module.rocky8-sshminion.configuration
+  rocky8_minion_configuration    = module.rocky8_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
 
-  rocky9_minion_configuration    = module.rocky9-minion.configuration
-  rocky9_sshminion_configuration = module.rocky9-sshminion.configuration
+  rocky9_minion_configuration    = module.rocky9_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_ssh_minion.configuration
 
-  ubuntu2004_minion_configuration    = module.ubuntu2004-minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004-sshminion.configuration
+  ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
 
-  ubuntu2204_minion_configuration    = module.ubuntu2204-minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204-sshminion.configuration
+  ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
 
-  debian11_minion_configuration    = module.debian11-minion.configuration
-  debian11_sshminion_configuration = module.debian11-sshminion.configuration
+  debian11_minion_configuration    = module.debian11_minion.configuration
+  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
 
-  debian12_minion_configuration    = module.debian12-minion.configuration
-  debian12_sshminion_configuration = module.debian12-sshminion.configuration
+  debian12_minion_configuration    = module.debian12_minion.configuration
+  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
 
-  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
+  opensuse154arm_minion_configuration    = module.opensuse154arm_minion.configuration
+  opensuse154arm_sshminion_configuration = module.opensuse154arm_ssh_minion.configuration
 
-  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration
 
-  opensuse156arm_minion_configuration    = module.opensuse156arm-minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm-sshminion.configuration
+  opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_ssh_minion.configuration
 
-  sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration
+  sle15sp5s390_minion_configuration    = module.sles15sp5s390_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_ssh_minion.configuration
 
-  salt_migration_minion_configuration = module.salt-migration-minion.configuration
+  salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
-  slemicro51_minion_configuration    = module.slemicro51-minion.configuration
+  slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51-sshminion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_ssh_minion.configuration
 
-  slemicro52_minion_configuration    = module.slemicro52-minion.configuration
+  slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52-sshminion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_ssh_minion.configuration
 
-  slemicro53_minion_configuration    = module.slemicro53-minion.configuration
+  slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53-sshminion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_ssh_minion.configuration
 
-  slemicro54_minion_configuration    = module.slemicro54-minion.configuration
+  slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_ssh_minion.configuration
 
-  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_ssh_minion.configuration
 
-  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_ssh_minion.configuration
 
-  sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
-  sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration
+  sle12sp5_buildhost_configuration = module.sles12sp5_buildhost.configuration
+  sle15sp4_buildhost_configuration = module.sles15sp4_buildhost.configuration
 
-  sle12sp5_terminal_configuration = module.sles12sp5-terminal.configuration
-  sle15sp4_terminal_configuration = module.sles15sp4-terminal.configuration
+  sle12sp5_terminal_configuration = module.sles12sp5_terminal.configuration
+  sle15sp4_terminal_configuration = module.sles15sp4_terminal.configuration
 
-  monitoringserver_configuration = module.monitoring-server.configuration
+  monitoringserver_configuration = module.monitoring_server.configuration
 }
 
 output "configuration" {


### PR DESCRIPTION
## Context
Minion naming through the project is not consistent. Those differences complexify the use of script and increase the difficulty to add new minions.
Those naming issue are mainly for BV.

## Solution

Rename main.tf ref modules to match minion names in testsuite.