### PR TITLE
Use latest tag in SLE testsuite containers

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
@@ -126,6 +126,7 @@ module "server_containerized" {
   runtime               = "podman"
   // Temporary workaround to see if we pass proxy stage. Also needs to be updated on next MU
   container_repository  = "registry.suse.de/suse/maintenance/35237/suse_sle-15-sp6_update_products_manager50_update_containerfile"
+  container_tag         = "latest"
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
 
   auto_accept                    = false
@@ -166,6 +167,7 @@ module "proxy_containerized" {
   runtime              = "podman"
   // Temporary workaround to see if we pass proxy stage. Also needs to be updated on next MU
   container_repository = "registry.suse.de/suse/maintenance/35237/suse_sle-15-sp6_update_products_manager50_update_containerfile"
+  container_tag         = "latest"
 
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"


### PR DESCRIPTION
Use latest tag in SLE testsuite containers because otherwise it's trying 5.0.0 and the MI registry of course doesn't have this.