### PR TITLE
Fix url for proxy registry in SLE

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
@@ -166,7 +166,7 @@ module "proxy_containerized" {
 
   runtime              = "podman"
   // Temporary workaround to see if we pass proxy stage. Also needs to be updated on next MU
-  container_repository = "registry.suse.de/suse/maintenance/35237/suse_sle-15-sp6_update_products_manager50_update_containerfile"
+  container_repository = "registry.suse.de/suse/maintenance/35237/suse_sle-15-sp6_update_products_manager50_update_containerfile/suse/manager/5.0/x86_64"
   container_tag         = "latest"
 
   auto_configure            = false


### PR DESCRIPTION
This url works, the mgradm appends the namespace end, but mgrpxy doesn't.