### PR TITLE
fix missing nmcli in proxy

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -79,7 +79,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["proxy"]
       }
-      additional_packages = [ "venv-salt-minion" ]
+      additional_packages = [ "venv-salt-minion, NetworkManager" ]
       install_salt_bundle = true
       runtime = "podman"
     }


### PR DESCRIPTION
nmcli is being used for testing, see https://github.com/uyuni-project/uyuni/blob/ce8e2e104d4bf181e949e0a57275e2657a9421b8/testsuite/features/build_validation/retail/proxy_container_branch_network.feature

nmcli belongs to the NetworkManager RPM.

However, the proxy vm does not have that package installed.

This PR installs this package, so we can use it during the tests.