### PR TITLE
Fix proxy in PR testing

### DIFF
--- a/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
@@ -2,7 +2,7 @@
 
 IMAGE                  = "opensuse155-ci-pro"
 SERVER_IMAGE           = "leapmicro55o"
-PROXY_IMAGE            = "opensuse155o"
+PROXY_IMAGE            = "leapmicro55o"
 IMAGES                 = ["rocky9o", "opensuse155o", "opensuse155-ci-pro", "ubuntu2204o", "sles15sp4o", "leapmicro55o"]
 SUSE_MINION_IMAGE      = "opensuse155o"
 PRODUCT_VERSION        = "uyuni-pr"


### PR DESCRIPTION
We need to use the micro version of openSUSE Leap. This is what it is expected and what we have already in the "podman pipeline".

Otherwise, we would need to install NetworkManager, which is not in the openSUSE Leap "non-micro" version.