### PR TITLE
Remove unneeded images

### DIFF
--- a/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-uyuni.tfvars
@@ -1,9 +1,9 @@
 ############ Uyuni unique variables ############
 
-IMAGE                  = "opensuse155-ci-pro"
+IMAGE                  = "opensuse155o"
 SERVER_IMAGE           = "leapmicro55o"
 PROXY_IMAGE            = "leapmicro55o"
-IMAGES                 = ["rocky9o", "opensuse155o", "opensuse155-ci-pro", "ubuntu2204o", "sles15sp4o", "leapmicro55o"]
+IMAGES                 = ["rocky9o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "leapmicro55o"]
 SUSE_MINION_IMAGE      = "opensuse155o"
 PRODUCT_VERSION        = "uyuni-pr"
 MAIL_TEMPLATE_ENV_FAIL = "../../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"


### PR DESCRIPTION
We do not need anymore our own leap 5.5 custom image. That image was used for preinstalling packages for the server and the proxy. Given we use the leap micro version for those images, our custom image can be removed.

Instead, the default is the opensuse 5.5 . This image is used for kvm-host.