### PR TITLE
Fix container URL in the HEAD CI

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -143,7 +143,7 @@ module "cucumber_testsuite" {
       main_disk_size = 500
       login_timeout = 28800
       runtime = "podman"
-      container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
+      container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile"
       container_tag = "latest"
     }
     proxy_containerized = {
@@ -156,7 +156,7 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
       runtime = "podman"
-      container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64"
+      container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile"
       container_tag = "latest"
     }
     suse-minion = {


### PR DESCRIPTION
Currently we see duplicate parts of the URL due to some parts will get auto-appended with the `mgr*` tools.

```bash
ing to pull registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64/suse/manager/5.0/x86_64/server:latest...
or: initializing source docker://registry.suse.de/devel/galaxy/manager/head/containerfile/suse/manager/5.0/x86_64/suse/manager/5.0/x86_64/server:latest: reading manifest latest in registry.>
or: exit status 125
```
The URL contains 2 times `/suse/manager/5.0/x86_64/`.