### PR TITLE
Use correct container URLs for 5.0 reference CI pipelines

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
@@ -158,7 +158,7 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
       runtime = "podman"
-      container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile"
+      container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile/suse/manager/5.0/x86_64"
       container_tag = "latest"
     }
     suse-minion = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
@@ -144,7 +144,7 @@ module "cucumber_testsuite" {
       main_disk_size = 500
       login_timeout = 28800
       runtime = "podman"
-      container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile/suse/manager/5.0/x86_64"
+      container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile"
       container_tag = "latest"
     }
     proxy_containerized = {
@@ -158,7 +158,7 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
       runtime = "podman"
-      container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile/suse/manager/5.0/x86_64"
+      container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile/suse/manager/5.0/x86_64"
       container_tag = "latest"
     }
     suse-minion = {


### PR DESCRIPTION
5.0 Reference environment uses `5.0-nightly` as `product_version`. Therefore, we also should use the correct container URLs for it.