### PR TITLE
Add DHCP-DNS VM to tests on PRs

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -55,6 +55,14 @@ module "cucumber_testsuite" {
         memory = 2048
       }
     }
+    dhcp-dns = {
+      name = "dhcp-dns"
+      image = "opensuse155o"
+      hypervisor = {
+        host        = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].hypervisor
+        user        = "root"
+        private_key = file("~/.ssh/id_rsa")
+    }
     server_containerized = {
       provider_settings = {
         mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["server"]


### PR DESCRIPTION
... so we do not lose 2.5 minutes waiting for a DHCP address on the containerized proxy