### PR TITLE
Remove openSUSE Leap 15.4 due to EOL

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -15,7 +15,6 @@ node('sumaform-cucumber-provo') {
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -15,7 +15,6 @@ node('sumaform-cucumber') {
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -15,7 +15,6 @@ node('sumaform-cucumber-provo') {
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -15,7 +15,6 @@ node('sumaform-cucumber') {
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -15,7 +15,6 @@ node('sumaform-cucumber-provo') {
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -14,7 +14,6 @@ node('sumaform-cucumber') {
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -14,7 +14,6 @@ node('sumaform-cucumber-provo') {
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
             'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
             'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
             'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -141,7 +141,7 @@ module "base_arm" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "opensuse154armo", "opensuse155armo", "opensuse156armo" ]
+  images      = [ "opensuse155armo", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -699,30 +699,6 @@ module "debian12_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
-  name               = "nue-min-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:bf"
-    overwrite_fqdn     = "suma-bv-43-min-opensuse154arm.mgr.suse.de"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.suse.de"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "opensuse155arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1215,26 +1191,6 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm_ssh_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
-  name               = "nue-minssh-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:df"
-    overwrite_fqdn     = "suma-bv-43-minssh-opensuse154arm.mgr.suse.de"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "opensuse155arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1549,9 +1505,6 @@ module "controller" {
 
   debian12_minion_configuration    = module.debian12_minion.configuration
   debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
-
-  opensuse154arm_minion_configuration    = module.opensuse154arm_minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm_ssh_minion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
   opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -287,7 +287,7 @@ module "base_arm" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "opensuse154armo", "opensuse155armo", "opensuse156armo" ]
+  images      = [ "opensuse155armo", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -919,30 +919,6 @@ module "debian12_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
-  name               = "prv-min-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:00"
-    overwrite_fqdn     = "suma-bv-43-min-opensuse154arm.mgr.prv.suse.net"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "suma-bv-43-pxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "opensuse155arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1507,26 +1483,6 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm_ssh_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
-  name               = "prv-minssh-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:01"
-    overwrite_fqdn     = "suma-bv-43-minssh-opensuse154arm.mgr.prv.suse.net"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "opensuse155arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1874,9 +1830,6 @@ module "controller" {
 
   debian12_minion_configuration    = module.debian12_minion.configuration
   debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
-
-  opensuse154arm_minion_configuration    = module.opensuse154arm_minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm_ssh_minion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
   opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -141,7 +141,7 @@ module "base_arm" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "opensuse154armo", "opensuse155armo", "opensuse156armo" ]
+  images      = [ "opensuse155armo", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -574,33 +574,6 @@ module "debian12-minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-srv.mgr.suse.de"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
-
-module "opensuse154arm-minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
-  name               = "nue-min-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:6f"
-    overwrite_fqdn     = "suma-bv-50-min-opensuse154arm.mgr.suse.de"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
   server_configuration = {
     hostname = "suma-bv-50-srv.mgr.suse.de"
   }
@@ -1141,29 +1114,6 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm-sshminion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
-  name               = "nue-minssh-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:8f"
-    overwrite_fqdn     = "suma-bv-50-minssh-opensuse154arm.mgr.suse.de"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
-
 module "opensuse155arm-sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1522,9 +1472,6 @@ module "controller" {
 
   debian12_minion_configuration    = module.debian12-minion.configuration
   debian12_sshminion_configuration = module.debian12-sshminion.configuration
-
-  opensuse154arm_minion_configuration    = module.opensuse154arm-minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm-sshminion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
   opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -287,7 +287,7 @@ module "base_arm" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "opensuse154armo", "opensuse155armo", "opensuse156armo" ]
+  images      = [ "opensuse155armo", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -774,33 +774,6 @@ module "debian12_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-srv.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
-
-module "opensuse154arm_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
-  name               = "prv-min-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:06"
-    overwrite_fqdn     = "suma-bv-50-min-opensuse154arm.mgr.prv.suse.net"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
   server_configuration = {
     hostname = "suma-bv-50-srv.mgr.prv.suse.net"
   }
@@ -1410,29 +1383,6 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm_ssh_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
-  name               = "prv-minssh-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:07"
-    overwrite_fqdn     = "suma-bv-50-minssh-opensuse154arm.mgr.prv.suse.net"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
-}
-
 module "opensuse155arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1826,9 +1776,6 @@ module "controller" {
 
   debian12_minion_configuration    = module.debian12_minion.configuration
   debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
-
-  opensuse154arm_minion_configuration    = module.opensuse154arm_minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm_ssh_minion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
   opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -141,7 +141,7 @@ module "base_arm" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "opensuse154armo", "opensuse155armo", "opensuse156armo" ]
+  images      = [ "opensuse155armo", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -549,30 +549,6 @@ module "debian12_minion" {
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
-}
-
-module "opensuse154arm_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
-  name               = "nue-min-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:bf"
-    overwrite_fqdn     = "uyuni-bv-master-min-opensuse154arm.mgr.suse.de"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.suse.de"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
 module "opensuse155arm_minion" {
@@ -1045,26 +1021,6 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm_ssh_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
-  name               = "nue-minssh-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:df"
-    overwrite_fqdn     = "uyuni-bv-master-minssh-opensuse154arm.mgr.suse.de"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "opensuse155arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1369,9 +1325,6 @@ module "controller" {
 
   debian12_minion_configuration    = module.debian12_minion.configuration
   debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
-
-  opensuse154arm_minion_configuration    = module.opensuse154arm_minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm_ssh_minion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
   opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -287,7 +287,7 @@ module "base_arm" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "opensuse154armo", "opensuse155armo", "opensuse156armo" ]
+  images      = [ "opensuse155armo", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -745,30 +745,6 @@ module "debian12_minion" {
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
-}
-
-module "opensuse154arm_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
-  name               = "prv-min-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:0c"
-    overwrite_fqdn     = "uyuni-bv-master-min-opensuse154arm.mgr.prv.suse.net"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-pxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
 module "opensuse155arm_minion" {
@@ -1308,26 +1284,6 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse154arm_ssh_minion" {
-  providers = {
-    libvirt = libvirt.suma-arm
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
-  name               = "prv-minssh-opensuse154arm"
-  image              = "opensuse154armo"
-  provider_settings = {
-    mac                = "aa:b2:92:42:00:0d"
-    overwrite_fqdn     = "uyuni-bv-master-minssh-opensuse154arm.mgr.prv.suse.net"
-    memory             = 2048
-    vcpu               = 2
-    xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-}
-
 module "opensuse155arm_ssh_minion" {
   providers = {
     libvirt = libvirt.suma-arm
@@ -1664,9 +1620,6 @@ module "controller" {
 
   debian12_minion_configuration    = module.debian12_minion.configuration
   debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
-
-  opensuse154arm_minion_configuration    = module.opensuse154arm_minion.configuration
-  opensuse154arm_sshminion_configuration = module.opensuse154arm_ssh_minion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
   opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration


### PR DESCRIPTION
openSUSE 15.4 is EOL since the end of 2023. See [en.opensuse.org/Lifetime](https://en.opensuse.org/Lifetime)