### PR TITLE
Add support for Ubuntu 24.04 in BV

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -13,7 +13,7 @@ node('sumaform-cucumber') {
             'liberty9_minion, liberty9_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ubuntu2404_minion, ubuntu2404_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -13,7 +13,7 @@ node('sumaform-cucumber-provo') {
             'liberty9_minion, liberty9_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ubuntu2404_minion, ubuntu2404_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -13,7 +13,7 @@ node('sumaform-cucumber') {
             'liberty9_minion, liberty9_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ubuntu2404_minion, ubuntu2404_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -13,7 +13,7 @@ node('sumaform-cucumber-provo') {
             'liberty9_minion, liberty9_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ubuntu2404_minion, ubuntu2404_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -12,7 +12,7 @@ node('sumaform-cucumber') {
             'centos7_minion, centos7_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ubuntu2404_minion, ubuntu2404_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -12,7 +12,7 @@ node('sumaform-cucumber-provo') {
             'centos7_minion, centos7_ssh_minion, ' +
             'oracle9_minion, oracle9_ssh_minion, ' +
             'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
+            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ubuntu2404_minion, ubuntu2404_ssh_minion, ' +
             'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
             'opensuse154arm_minion, opensuse154arm_ssh_minion, ' +
             'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
+  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -262,7 +262,7 @@ module "base_debian" {
   name_prefix = "suma-bv-43-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o" ]
+  images      = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
+  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -262,7 +262,7 @@ module "base_debian" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2204o", "debian11o", "debian12o" ]
+  images      = [ "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
+  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -262,7 +262,7 @@ module "base_debian" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o" ]
+  images      = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true


### PR DESCRIPTION
This PR adds support for Ubuntu 24.04. Part of https://github.com/SUSE/spacewalk/issues/23851.

## TODO

- [x] Wait for @Bischoff 's changes to infra
- [ ] add the Minions/SSH Minions entries to the `main.tf` files.