### PR TITLE
Refactor to support set custom header in both standalone and containerize versions

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -329,7 +329,11 @@ def run(params) {
                                 println("Keep the environment locked for 24 hours so you can debug")
                                 sh "echo \"rm -f ${env_file}*\" | at now +24 hour"
                                 sh "echo keep:24h >> ${env_file}.info"
-                                sh "python3 ${WORKSPACE}/product/susemanager-utils/testing/automation/run-command-in-server.py --command=\"chmod 755 /tmp/set_custom_header.sh;/tmp/set_custom_header.sh -e ${env_number} -m ${email_to} -t 24\" --username=\"root\" --password=\"linux\" -v -i suma-pr${env_number}-srv.mgr.prv.suse.net"
+                                if (short_product_name.contains("43")) {
+                                    sh "python3 ${WORKSPACE}/product/susemanager-utils/testing/automation/run-command-in-server.py --command=\"chmod 755 /tmp/set_custom_header.sh;/tmp/set_custom_header.sh -e ${env_number} -m ${email_to} -t 24\" --username=\"root\" --password=\"linux\" -v -i suma-pr${env_number}-srv.mgr.prv.suse.net"
+                                }else{
+                                    sh "python3 ${WORKSPACE}/product/susemanager-utils/testing/automation/run-command-in-server.py --command=\"mgrctl cp /tmp/set_custom_header.sh server:/tmp/ ; mgrctl exec 'chmod 755 /tmp/set_custom_header.sh;/tmp/set_custom_header.sh -e ${env_number} -m ${email_to} -t 24\" --username=\"root\" --password=\"linux\" -v -i suma-pr${env_number}-srv.mgr.prv.suse.net'"
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
We were injecting and triggering a script file as it was in the host.
But in the case of a containerized product, we first need to copy that script inside the container, then we can trigger it through mgrctl.