### PR TITLE
Rename ssh_minion for sshminion and change nodeHandler behavior.

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -540,15 +540,15 @@ def clientTestingStages(capybara_timeout, default_timeout, minion_type = 'defaul
         tests["${node}"] = {
             // Generate a temporary list that comprises of all the minions except the one currently undergoing testing.
             // This list is utilized to establish an SSH session exclusively with the minion undergoing testing.
-            def temporaryList = nodesHandler.envVariableList.toList() - node.replaceAll("ssh_minion", "sshminion").toUpperCase()
+            def temporaryList = nodesHandler.envVariableList.toList() - node.toUpperCase()
             stage("${node}") {
                 echo "Testing ${node}"
             }
             stage("Add MUs ${node}") {
                 if (params.must_add_MU_repositories) {
-                    if (node.contains('ssh_minion')) {
+                    if (node.contains('sshminion')) {
                         // SSH minion need minion MU channel. This section wait until minion finish creating MU channel
-                        def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
+                        def minion_name_without_ssh = node.replaceAll('sshminion', 'minion')
                         println "Waiting for the MU channel creation by ${minion_name_without_ssh} for ${node}."
                         waitUntil {
                             mu_sync_status[minion_name_without_ssh] != 'UNSYNC'
@@ -675,11 +675,11 @@ def getNodesHandler(minionType = 'default') {
     moduleList.each { lane ->
         def nodeName = lane.tokenize(".")[1]
         if ( minionType == 'default' && (nodeName.contains('minion') || nodeName.contains('client'))) {
-            nodeList.add(nodeName.replaceAll('-', '_').replaceAll('sshminion', 'ssh_minion').replaceAll('sles', 'sle'))
+            nodeList.add(nodeName.replaceAll('-', '_').replaceAll('sles', 'sle'))
             envVar.add(nodeName.replaceAll('-', '_').replaceAll('sles', 'sle').toUpperCase())
         }
         else if (( minionType == 'paygo' && (nodeName.contains('paygo') || nodeName.contains('byos')))) {
-            nodeList.add(nodeName.replaceAll('-', '_').replaceAll('sshminion', 'ssh_minion').replaceAll('sles', 'sle'))
+            nodeList.add(nodeName.replaceAll('-', '_').replaceAll('sles', 'sle'))
             envVar.add(nodeName.replaceAll('-', '_').replaceAll('sles', 'sle').toUpperCase())
         }
     }
@@ -692,7 +692,7 @@ def getNodesHandler(minionType = 'default') {
     // This difference will be the nodes to disable
     def disabledNodes = nodeList.findAll { !nodesToRun.contains(it) }
     // Convert this list to cucumber compatible environment variable
-    def envVarDisabledNodes = disabledNodes.collect { it.replaceAll('ssh_minion', 'sshminion').toUpperCase() }
+    def envVarDisabledNodes = disabledNodes.collect { it.toUpperCase() }
     // Create a node list without the disabled nodes. ( use to configure the client stage )
     def nodeListWithDisabledNodes = nodeList - disabledNodes
     // Create a map storing mu synchronization state for each minion.

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -351,7 +351,7 @@ def clientTestingStages() {
         tests["${node}"] = {
             // Generate a temporary list that comprises of all the minions except the one currently undergoing testing.
             // This list is utilized to establish an SSH session exclusively with the minion undergoing testing.
-            def temporaryList = nodesHandler.envVariableList.toList() - node.replaceAll("ssh_minion", "sshminion").toUpperCase()
+            def temporaryList = nodesHandler.envVariableList.toList() - node.toUpperCase()
             stage("${node}") {
                 echo "Testing ${node}"
             }
@@ -402,10 +402,10 @@ def clientTestingStages() {
             stage("Add Activation Keys ${node}") {
                  // skip this stage for Salt migration minion
                 if (params.must_add_keys && !node.contains('salt_migration_minion')) {
-                    if (node.contains('ssh_minion')) {
+                    if (node.contains('sshminion')) {
                         // SSH minion need mandatory custom channel repository. The channel is created during minion stage.
                         // This section wait until minion creates custom channel.
-                        def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
+                        def minion_name_without_ssh = node.replaceAll('sshminion', 'minion')
                         println "Waiting for mandatory custom channel for ${node} to be created by ${minion_name_without_ssh}."
                         waitUntil {
                             required_custom_channel_status[minion_name_without_ssh] != 'NOT_CREATED'
@@ -428,10 +428,10 @@ def clientTestingStages() {
             }
             stage("Create bootstrap repository ${node}") {
                 if (params.must_create_bootstrap_repos) {
-                    if (node.contains('ssh_minion')) {
+                    if (node.contains('sshminion')) {
                         // SSH minion need bootstrap repository. The bootstrap repository is created during minion stage.
                         // This section wait until minion creates bootstrap repository
-                        def minion_name_without_ssh = node.replaceAll('ssh_minion', 'minion')
+                        def minion_name_without_ssh = node.replaceAll('sshminion', 'minion')
                         println "Waiting for bootstrap repository creation by ${minion_name_without_ssh} for ${node}."
                         waitUntil {
                             bootstrap_repository_status[minion_name_without_ssh] != 'NOT_CREATED'
@@ -518,7 +518,7 @@ def getNodesHandler() {
     moduleList.each { lane ->
         def instanceList = lane.tokenize(".")
         if (instanceList[1].contains('minion') || instanceList[1].contains('client')) {
-            nodeList.add(instanceList[1].replaceAll('-', '_').replaceAll('sshminion', 'ssh_minion').replaceAll('sles', 'sle'))
+            nodeList.add(instanceList[1].replaceAll('-', '_').replaceAll('sles', 'sle'))
             envVar.add(instanceList[1].replaceAll('-', '_').replaceAll('sles', 'sle').toUpperCase())
         }
     }
@@ -531,7 +531,7 @@ def getNodesHandler() {
     // This difference will be the nodes to disable
     def disabledNodes = nodeList.findAll { !nodesToRun.contains(it) }
     // Convert this list to cucumber compatible environment variable
-    def envVarDisabledNodes = disabledNodes.collect { it.replaceAll('ssh_minion', 'sshminion').toUpperCase() }
+    def envVarDisabledNodes = disabledNodes.collect { it.toUpperCase() }
     // Create a node list without the disabled nodes. ( use to configure the client stage )
     def nodeListWithDisabledNodes = nodeList - disabledNodes
     // Create a map storing mu synchronization state for each minion.

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -1,22 +1,22 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber-provo') {
-    def minionList = 'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, sle12sp5_paygo_minion, ' +
-            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
-            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
-            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, sle15sp4_byos_minion, ' +
-            'sle15sp5_client, sle15sp5_minion, sle15sp5_ssh_minion, sle15sp5_paygo_minion, ' +
-            'sle15sp6_client, sle15sp6_minion, sle15sp6_ssh_minion, sle15sp6_paygo_minion, ' +
+    def minionList = 'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, sle12sp5_paygo_minion, ' +
+            'sle15sp2_client, sle15sp2_minion, sle15sp2_sshminion, ' +
+            'sle15sp3_client, sle15sp3_minion, sle15sp3_sshminion, ' +
+            'sle15sp4_client, sle15sp4_minion, sle15sp4_sshminion, sle15sp4_byos_minion, ' +
+            'sle15sp5_client, sle15sp5_minion, sle15sp5_sshminion, sle15sp5_paygo_minion, ' +
+            'sle15sp6_client, sle15sp6_minion, sle15sp6_sshminion, sle15sp6_paygo_minion, ' +
             'salt_migration_minion, ' +
-            'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
-            'liberty9_minion, liberty9_ssh_minion, ' +
-            'oracle9_minion, oracle9_ssh_minion, ' +
-            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-            'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
-            'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
+            'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, ' +
+            'centos7_client, centos7_minion, centos7_sshminion, ' +
+            'liberty9_minion, liberty9_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
+            'opensuse155arm_minion, opensuse155arm_sshminion, ' +
+            'opensuse156arm_minion, opensuse156arm_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -1,23 +1,23 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber') {
-    def minionList = 'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
-            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
-            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
-            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
-            'sle15sp5_client, sle15sp5_minion, sle15sp5_ssh_minion, ' +
-            'sle15sp6_client, sle15sp6_minion, sle15sp6_ssh_minion, ' +
+    def minionList = 'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
+            'sle15sp2_client, sle15sp2_minion, sle15sp2_sshminion, ' +
+            'sle15sp3_client, sle15sp3_minion, sle15sp3_sshminion, ' +
+            'sle15sp4_client, sle15sp4_minion, sle15sp4_sshminion, ' +
+            'sle15sp5_client, sle15sp5_minion, sle15sp5_sshminion, ' +
+            'sle15sp6_client, sle15sp6_minion, sle15sp6_sshminion, ' +
             'salt_migration_minion, ' +
-            'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
-            'liberty9_minion, liberty9_ssh_minion, ' +
-            'oracle9_minion, oracle9_ssh_minion, ' +
-            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-            'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
-            'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
+            'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, ' +
+            'centos7_client, centos7_minion, centos7_sshminion, ' +
+            'liberty9_minion, liberty9_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
+            'opensuse155arm_minion, opensuse155arm_sshminion, ' +
+            'opensuse156arm_minion, opensuse156arm_sshminion, ' +
+            'sle15sp5s390_minion, sle15sp5s390_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -1,23 +1,23 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber-provo') {
-    def minionList = 'sle12sp5_client, sle12sp5_minion, sle12sp5_ssh_minion, ' +
-            'sle15sp2_client, sle15sp2_minion, sle15sp2_ssh_minion, ' +
-            'sle15sp3_client, sle15sp3_minion, sle15sp3_ssh_minion, ' +
-            'sle15sp4_client, sle15sp4_minion, sle15sp4_ssh_minion, ' +
-            'sle15sp5_client, sle15sp5_minion, sle15sp5_ssh_minion, ' +
-            'sle15sp6_client, sle15sp6_minion, sle15sp6_ssh_minion, ' +
+    def minionList = 'sle12sp5_client, sle12sp5_minion, sle12sp5_sshminion, ' +
+            'sle15sp2_client, sle15sp2_minion, sle15sp2_sshminion, ' +
+            'sle15sp3_client, sle15sp3_minion, sle15sp3_sshminion, ' +
+            'sle15sp4_client, sle15sp4_minion, sle15sp4_sshminion, ' +
+            'sle15sp5_client, sle15sp5_minion, sle15sp5_sshminion, ' +
+            'sle15sp6_client, sle15sp6_minion, sle15sp6_sshminion, ' +
             'salt_migration_minion, ' +
-            'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_client, centos7_minion, centos7_ssh_minion, ' +
-            'liberty9_minion, liberty9_ssh_minion, ' +
-            'oracle9_minion, oracle9_ssh_minion, ' +
-            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-            'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
-            'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
+            'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, ' +
+            'centos7_client, centos7_minion, centos7_sshminion, ' +
+            'liberty9_minion, liberty9_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
+            'opensuse155arm_minion, opensuse155arm_sshminion, ' +
+            'opensuse156arm_minion, opensuse156arm_sshminion, ' +
+            'sle15sp5s390_minion, sle15sp5s390_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -1,23 +1,23 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber') {
-    def minionList = 'sle12sp5_minion, sle12sp5_ssh_minion, ' +
-            'sle15sp2_minion, sle15sp2_ssh_minion, ' +
-            'sle15sp3_minion, sle15sp3_ssh_minion, ' +
-            'sle15sp4_minion, sle15sp4_ssh_minion, ' +
-            'sle15sp5_minion, sle15sp5_ssh_minion, ' +
-            'sle15sp6_minion, sle15sp6_ssh_minion, ' +
+    def minionList = 'sle12sp5_minion, sle12sp5_sshminion, ' +
+            'sle15sp2_minion, sle15sp2_sshminion, ' +
+            'sle15sp3_minion, sle15sp3_sshminion, ' +
+            'sle15sp4_minion, sle15sp4_sshminion, ' +
+            'sle15sp5_minion, sle15sp5_sshminion, ' +
+            'sle15sp6_minion, sle15sp6_sshminion, ' +
             'salt_migration_minion, ' +
-            'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_minion, centos7_ssh_minion, ' +
-            'liberty9_minion, liberty9_ssh_minion, ' +
-            'oracle9_minion, oracle9_ssh_minion, ' +
-            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-            'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
-            'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
+            'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, ' +
+            'centos7_minion, centos7_sshminion, ' +
+            'liberty9_minion, liberty9_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
+            'opensuse155arm_minion, opensuse155arm_sshminion, ' +
+            'opensuse156arm_minion, opensuse156arm_sshminion, ' +
+            'sle15sp5s390_minion, sle15sp5s390_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -1,23 +1,23 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber-provo') {
-    def minionList = 'sle12sp5_minion, sle12sp5_ssh_minion, ' +
-            'sle15sp2_minion, sle15sp2_ssh_minion, ' +
-            'sle15sp3_minion, sle15sp3_ssh_minion, ' +
-            'sle15sp4_minion, sle15sp4_ssh_minion, ' +
-            'sle15sp5_minion, sle15sp5_ssh_minion, ' +
-            'sle15sp6_minion, sle15sp6_ssh_minion, ' +
+    def minionList = 'sle12sp5_minion, sle12sp5_sshminion, ' +
+            'sle15sp2_minion, sle15sp2_sshminion, ' +
+            'sle15sp3_minion, sle15sp3_sshminion, ' +
+            'sle15sp4_minion, sle15sp4_sshminion, ' +
+            'sle15sp5_minion, sle15sp5_sshminion, ' +
+            'sle15sp6_minion, sle15sp6_sshminion, ' +
             'salt_migration_minion, ' +
-            'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_minion, centos7_ssh_minion, ' +
-            'liberty9_minion, liberty9_ssh_minion, ' +
-            'oracle9_minion, oracle9_ssh_minion, ' +
-            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-            'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
-            'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
+            'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, ' +
+            'centos7_minion, centos7_sshminion, ' +
+            'liberty9_minion, liberty9_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
+            'opensuse155arm_minion, opensuse155arm_sshminion, ' +
+            'opensuse156arm_minion, opensuse156arm_sshminion, ' +
+            'sle15sp5s390_minion, sle15sp5s390_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -1,22 +1,22 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber') {
-    def minionList = 'sle12sp5_minion, sle12sp5_ssh_minion, ' +
-            'sle15sp2_minion, sle15sp2_ssh_minion, ' +
-            'sle15sp3_minion, sle15sp3_ssh_minion, ' +
-            'sle15sp4_minion, sle15sp4_ssh_minion, ' +
-            'sle15sp5_minion, sle15sp5_ssh_minion, ' +
-            'sle15sp6_minion, sle15sp6_ssh_minion, ' +
+    def minionList = 'sle12sp5_minion, sle12sp5_sshminion, ' +
+            'sle15sp2_minion, sle15sp2_sshminion, ' +
+            'sle15sp3_minion, sle15sp3_sshminion, ' +
+            'sle15sp4_minion, sle15sp4_sshminion, ' +
+            'sle15sp5_minion, sle15sp5_sshminion, ' +
+            'sle15sp6_minion, sle15sp6_sshminion, ' +
             'salt_migration_minion, ' +
-            'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_minion, centos7_ssh_minion, ' +
-            'oracle9_minion, oracle9_ssh_minion, ' +
-            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-            'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
-            'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
+            'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, ' +
+            'centos7_minion, centos7_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
+            'opensuse155arm_minion, opensuse155arm_sshminion, ' +
+            'opensuse156arm_minion, opensuse156arm_sshminion, ' +
+            'sle15sp5s390_minion, sle15sp5s390_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -1,22 +1,22 @@
 #!/usr/bin/env groovy
 
 node('sumaform-cucumber-provo') {
-    def minionList = 'sle12sp5_minion, sle12sp5_ssh_minion, ' +
-            'sle15sp2_minion, sle15sp2_ssh_minion, ' +
-            'sle15sp3_minion, sle15sp3_ssh_minion, ' +
-            'sle15sp4_minion, sle15sp4_ssh_minion, ' +
-            'sle15sp5_minion, sle15sp5_ssh_minion, ' +
-            'sle15sp6_minion, sle15sp6_ssh_minion, ' +
+    def minionList = 'sle12sp5_minion, sle12sp5_sshminion, ' +
+            'sle15sp2_minion, sle15sp2_sshminion, ' +
+            'sle15sp3_minion, sle15sp3_sshminion, ' +
+            'sle15sp4_minion, sle15sp4_sshminion, ' +
+            'sle15sp5_minion, sle15sp5_sshminion, ' +
+            'sle15sp6_minion, sle15sp6_sshminion, ' +
             'salt_migration_minion, ' +
-            'alma8_minion, alma8_ssh_minion, alma9_minion, alma9_ssh_minion, ' +
-            'centos7_minion, centos7_ssh_minion, ' +
-            'oracle9_minion, oracle9_ssh_minion, ' +
-            'rocky8_minion, rocky8_ssh_minion, rocky9_minion, rocky9_ssh_minion, ' +
-            'ubuntu2004_minion, ubuntu2004_ssh_minion, ubuntu2204_minion, ubuntu2204_ssh_minion, ' +
-            'debian11_minion, debian11_ssh_minion, debian12_minion, debian12_ssh_minion, ' +
-            'opensuse155arm_minion, opensuse155arm_ssh_minion, ' +
-            'opensuse156arm_minion, opensuse156arm_ssh_minion, ' +
-            'sle15sp5s390_minion, sle15sp5s390_ssh_minion, ' +
+            'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, ' +
+            'centos7_minion, centos7_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
+            'opensuse155arm_minion, opensuse155arm_sshminion, ' +
+            'opensuse156arm_minion, opensuse156arm_sshminion, ' +
+            'sle15sp5s390_minion, sle15sp5s390_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -472,7 +472,7 @@ module "sles15sp6_minion" {
   }
 }
 
-module "ubuntu2004_ssh_minion" {
+module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -486,7 +486,7 @@ module "ubuntu2004_ssh_minion" {
   }
 }
 
-module "rocky8_ssh_minion" {
+module "rocky8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -504,7 +504,7 @@ module "rocky8_ssh_minion" {
 
 }
 
-module "sles12sp5_ssh_minion" {
+module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -520,7 +520,7 @@ module "sles12sp5_ssh_minion" {
   additional_packages = [ "chrony" ]
 }
 
-module "sles15sp2_ssh_minion" {
+module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -534,7 +534,7 @@ module "sles15sp2_ssh_minion" {
   }
 }
 
-module "sles15sp3_ssh_minion" {
+module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -548,7 +548,7 @@ module "sles15sp3_ssh_minion" {
   }
 }
 
-module "sles15sp4_ssh_minion" {
+module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -562,7 +562,7 @@ module "sles15sp4_ssh_minion" {
   }
 }
 
-module "sles15sp5_ssh_minion" {
+module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -576,7 +576,7 @@ module "sles15sp5_ssh_minion" {
   }
 }
 
-module "sles15sp6_ssh_minion" {
+module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -610,7 +610,7 @@ module "rhel9_minion" {
 
 }
 
-module "ubuntu2204_ssh_minion" {
+module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -666,44 +666,44 @@ module "controller" {
 
   sle12sp5_client_configuration    = module.sles12sp5_client.configuration
   sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5_ssh_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_sshminion.configuration
 
   sle15sp2_client_configuration    = module.sles15sp2_client.configuration
   sle15sp2_minion_configuration    = module.sles15sp2_minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2_ssh_minion.configuration
+  sle15sp2_sshminion_configuration = module.sles15sp2_sshminion.configuration
 
   sle15sp3_client_configuration    = module.sles15sp3_client.configuration
   sle15sp3_minion_configuration    = module.sles15sp3_minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3_ssh_minion.configuration
+  sle15sp3_sshminion_configuration = module.sles15sp3_sshminion.configuration
 
   sle15sp4_client_configuration    = module.sles15sp4_client.configuration
   sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4_ssh_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_sshminion.configuration
 
   sle15sp5_client_configuration    = module.sles15sp5_client.configuration
   sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5_ssh_minion.configuration
+  sle15sp5_sshminion_configuration = module.sles15sp5_sshminion.configuration
 
   salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
   sle15sp6_client_configuration    = module.sles15sp6_client.configuration
   sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6_ssh_minion.configuration
+  sle15sp6_sshminion_configuration = module.sles15sp6_sshminion.configuration
 
   rocky8_minion_configuration    = module.rocky8_minion.configuration
-  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_sshminion.configuration
 
   ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_sshminion.configuration
 
   ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_sshminion.configuration
 
 //  debian11_minion_configuration    = module.debian11_minion.configuration
-//  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
+//  debian11_sshminion_configuration = module.debian11_sshminion.configuration
 
 //  debian12_minion_configuration    = module.debian12_minion.configuration
-//  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
+//  debian12_sshminion_configuration = module.debian12_sshminion.configuration
 
   rhel9_minion_configuration          = module.rhel9_minion.configuration
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -533,27 +533,26 @@ module "centos7_minion" {
   install_salt_bundle = true
 }
 
+module "liberty9_minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "4.3-released"
+  name               = "liberty9-minion"
+  image              = "libertylinux9o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:c5"
+    memory             = 4096
+  }
+  server_configuration = {
+    hostname = "suma-bv-43-proxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-# module "liberty9_minion" {
-#   source             = "./modules/minion"
-#   base_configuration = module.base_core.configuration
-#   product_version    = "4.3-released"
-#   name               = "liberty9-minion"
-#   image              = "libertylinux9o"
-#   provider_settings = {
-#     mac                = "aa:b2:92:42:00:c5"
-#     memory             = 4096
-#   }
-#   server_configuration = {
-#     hostname = "suma-bv-43-proxy.mgr.suse.de"
-#   }
-#   auto_connect_to_master  = false
-#   use_os_released_updates = false
-#   ssh_key_path            = "./salt/controller/id_rsa.pub"
-#
-#   additional_packages = [ "venv-salt-minion" ]
-#   install_salt_bundle = true
-# }
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
 
 module "oracle9_minion" {
   source             = "./modules/minion"
@@ -1060,22 +1059,22 @@ module "centos7_sshminion" {
   install_salt_bundle = true
 }
 
-# module "liberty9_sshminion" {
-#   source             = "./modules/sshminion"
-#   base_configuration = module.base_core.configuration
-#   product_version    = "4.3-released"
-#   name               = "liberty9-sshminion"
-#   image              = "libertylinux9o"
-#   provider_settings = {
-#     mac                = "aa:b2:92:42:00:e5"
-#     memory             = 4096
-#   }
-#   use_os_released_updates = false
-#   ssh_key_path            = "./salt/controller/id_rsa.pub"
-#
-#   additional_packages = [ "venv-salt-minion" ]
-#   install_salt_bundle = true
-# }
+module "liberty9_sshminion" {
+  source             = "./modules/sshminion"
+  base_configuration = module.base_core.configuration
+  product_version    = "4.3-released"
+  name               = "liberty9-sshminion"
+  image              = "libertylinux9o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:e5"
+    memory             = 4096
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
 
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
@@ -1483,8 +1482,8 @@ module "controller" {
   centos7_minion_configuration    = module.centos7_minion.configuration
   centos7_sshminion_configuration = module.centos7_sshminion.configuration
 
-#  liberty9_minion_configuration    = module.liberty9_minion.configuration
-#  liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
+ liberty9_minion_configuration    = module.liberty9_minion.configuration
+ liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
   oracle9_sshminion_configuration = module.oracle9_sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -923,7 +923,7 @@ module "slmicro60_minion" {
   install_salt_bundle = false
 }
 
-module "sles12sp5_ssh_minion" {
+module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -939,7 +939,7 @@ module "sles12sp5_ssh_minion" {
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
-module "sles15sp2_ssh_minion" {
+module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -953,7 +953,7 @@ module "sles15sp2_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp3_ssh_minion" {
+module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -967,7 +967,7 @@ module "sles15sp3_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp4_ssh_minion" {
+module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -981,7 +981,7 @@ module "sles15sp4_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5_ssh_minion" {
+module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -995,7 +995,7 @@ module "sles15sp5_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp6_ssh_minion" {
+module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1009,7 +1009,7 @@ module "sles15sp6_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "alma8_ssh_minion" {
+module "alma8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1026,7 +1026,7 @@ module "alma8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "alma9_ssh_minion" {
+module "alma9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1043,7 +1043,7 @@ module "alma9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "centos7_ssh_minion" {
+module "centos7_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1060,7 +1060,7 @@ module "centos7_ssh_minion" {
   install_salt_bundle = true
 }
 
-# module "liberty9_ssh_minion" {
+# module "liberty9_sshminion" {
 #   source             = "./modules/sshminion"
 #   base_configuration = module.base_core.configuration
 #   product_version    = "4.3-released"
@@ -1077,7 +1077,7 @@ module "centos7_ssh_minion" {
 #   install_salt_bundle = true
 # }
 
-module "oracle9_ssh_minion" {
+module "oracle9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1094,7 +1094,7 @@ module "oracle9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky8_ssh_minion" {
+module "rocky8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1111,7 +1111,7 @@ module "rocky8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky9_ssh_minion" {
+module "rocky9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1128,7 +1128,7 @@ module "rocky9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004_ssh_minion" {
+module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1146,7 +1146,7 @@ module "ubuntu2004_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204_ssh_minion" {
+module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1160,7 +1160,7 @@ module "ubuntu2204_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian11_ssh_minion" {
+module "debian11_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1174,7 +1174,7 @@ module "debian11_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian12_ssh_minion" {
+module "debian12_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "4.3-released"
@@ -1191,7 +1191,7 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm_ssh_minion" {
+module "opensuse155arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1211,7 +1211,7 @@ module "opensuse155arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse156arm_ssh_minion" {
+module "opensuse156arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1231,7 +1231,7 @@ module "opensuse156arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5s390_ssh_minion" {
+module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "4.3-released"
@@ -1251,7 +1251,7 @@ module "sles15sp5s390_ssh_minion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51_ssh_minion" {
+// module "slemicro51_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "4.3-released"
@@ -1266,7 +1266,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52_ssh_minion" {
+// module "slemicro52_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "4.3-released"
@@ -1281,7 +1281,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53_ssh_minion" {
+// module "slemicro53_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "4.3-released"
@@ -1296,7 +1296,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54_ssh_minion" {
+// module "slemicro54_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "4.3-released"
@@ -1311,7 +1311,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55_ssh_minion" {
+// module "slemicro55_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "4.3-released"
@@ -1326,7 +1326,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60_ssh_minion" {
+// module "slmicro60_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "4.3-released"
@@ -1451,96 +1451,96 @@ module "controller" {
 
   sle12sp5_client_configuration    = module.sles12sp5_client.configuration
   sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5_ssh_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_sshminion.configuration
 
   sle15sp2_client_configuration    = module.sles15sp2_client.configuration
   sle15sp2_minion_configuration    = module.sles15sp2_minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2_ssh_minion.configuration
+  sle15sp2_sshminion_configuration = module.sles15sp2_sshminion.configuration
 
   sle15sp3_client_configuration    = module.sles15sp3_client.configuration
   sle15sp3_minion_configuration    = module.sles15sp3_minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3_ssh_minion.configuration
+  sle15sp3_sshminion_configuration = module.sles15sp3_sshminion.configuration
 
   sle15sp4_client_configuration    = module.sles15sp4_client.configuration
   sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4_ssh_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_sshminion.configuration
 
   sle15sp5_client_configuration    = module.sles15sp5_client.configuration
   sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5_ssh_minion.configuration
+  sle15sp5_sshminion_configuration = module.sles15sp5_sshminion.configuration
 
   sle15sp6_client_configuration    = module.sles15sp6_client.configuration
   sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6_ssh_minion.configuration
+  sle15sp6_sshminion_configuration = module.sles15sp6_sshminion.configuration
 
   alma8_minion_configuration    = module.alma8_minion.configuration
-  alma8_sshminion_configuration = module.alma8_ssh_minion.configuration
+  alma8_sshminion_configuration = module.alma8_sshminion.configuration
 
   alma9_minion_configuration    = module.alma9_minion.configuration
-  alma9_sshminion_configuration = module.alma9_ssh_minion.configuration
+  alma9_sshminion_configuration = module.alma9_sshminion.configuration
 
   centos7_client_configuration    = module.centos7_client.configuration
   centos7_minion_configuration    = module.centos7_minion.configuration
-  centos7_sshminion_configuration = module.centos7_ssh_minion.configuration
+  centos7_sshminion_configuration = module.centos7_sshminion.configuration
 
 #  liberty9_minion_configuration    = module.liberty9_minion.configuration
-#  liberty9_sshminion_configuration = module.liberty9_ssh_minion.configuration
+#  liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
-  oracle9_sshminion_configuration = module.oracle9_ssh_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_sshminion.configuration
 
   rocky8_minion_configuration    = module.rocky8_minion.configuration
-  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_sshminion.configuration
 
   rocky9_minion_configuration    = module.rocky9_minion.configuration
-  rocky9_sshminion_configuration = module.rocky9_ssh_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_sshminion.configuration
 
   ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_sshminion.configuration
 
   ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_sshminion.configuration
 
   debian11_minion_configuration    = module.debian11_minion.configuration
-  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
+  debian11_sshminion_configuration = module.debian11_sshminion.configuration
 
   debian12_minion_configuration    = module.debian12_minion.configuration
-  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
+  debian12_sshminion_configuration = module.debian12_sshminion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_sshminion.configuration
 
   opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm_ssh_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390_minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_ssh_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_sshminion.configuration
 
   salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
   slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51_ssh_minion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_sshminion.configuration
 
   slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52_ssh_minion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_sshminion.configuration
 
   slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53_ssh_minion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_sshminion.configuration
 
   slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54_ssh_minion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_sshminion.configuration
 
   slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55_ssh_minion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_sshminion.configuration
 
   slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60_ssh_minion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5_buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4_buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1164,7 +1164,7 @@ module "slmicro60_minion" {
   install_salt_bundle = false
 }
 
-module "sle12sp5_ssh_minion" {
+module "sle12sp5_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1183,7 +1183,7 @@ module "sle12sp5_ssh_minion" {
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
-module "sle15sp2_ssh_minion" {
+module "sle15sp2_sshminion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1200,7 +1200,7 @@ module "sle15sp2_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sle15sp3_ssh_minion" {
+module "sle15sp3_sshminion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1217,7 +1217,7 @@ module "sle15sp3_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sle15sp4_ssh_minion" {
+module "sle15sp4_sshminion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1234,7 +1234,7 @@ module "sle15sp4_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sle15sp5_ssh_minion" {
+module "sle15sp5_sshminion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1251,7 +1251,7 @@ module "sle15sp5_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sle15sp6_ssh_minion" {
+module "sle15sp6_sshminion" {
   providers = {
     libvirt = libvirt.moscowmule
   }
@@ -1268,7 +1268,7 @@ module "sle15sp6_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "alma8_ssh_minion" {
+module "alma8_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1288,7 +1288,7 @@ module "alma8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "alma9_ssh_minion" {
+module "alma9_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1308,7 +1308,7 @@ module "alma9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "centos7_ssh_minion" {
+module "centos7_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1328,7 +1328,7 @@ module "centos7_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "liberty9_ssh_minion" {
+module "liberty9_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1348,7 +1348,7 @@ module "liberty9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "oracle9_ssh_minion" {
+module "oracle9_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1368,7 +1368,7 @@ module "oracle9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky8_ssh_minion" {
+module "rocky8_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1388,7 +1388,7 @@ module "rocky8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky9_ssh_minion" {
+module "rocky9_sshminion" {
   providers = {
     libvirt = libvirt.endor
   }
@@ -1408,7 +1408,7 @@ module "rocky9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004_ssh_minion" {
+module "ubuntu2004_sshminion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1429,7 +1429,7 @@ module "ubuntu2004_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204_ssh_minion" {
+module "ubuntu2204_sshminion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1446,7 +1446,7 @@ module "ubuntu2204_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian11_ssh_minion" {
+module "debian11_sshminion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1463,7 +1463,7 @@ module "debian11_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian12_ssh_minion" {
+module "debian12_sshminion" {
   providers = {
     libvirt = libvirt.mandalore
   }
@@ -1483,7 +1483,7 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm_ssh_minion" {
+module "opensuse155arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1503,7 +1503,7 @@ module "opensuse155arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse156arm_ssh_minion" {
+module "opensuse156arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1523,7 +1523,7 @@ module "opensuse156arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sle15sp5s390_ssh_minion" {
+module "sle15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "4.3-released"
@@ -1543,7 +1543,7 @@ module "sle15sp5s390_ssh_minion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51_ssh_minion" {
+// module "slemicro51_sshminion" {
 //   providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1561,7 +1561,7 @@ module "sle15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52_ssh_minion" {
+// module "slemicro52_sshminion" {
 //   providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1579,7 +1579,7 @@ module "sle15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53_ssh_minion" {
+// module "slemicro53_sshminion" {
 //   providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1597,7 +1597,7 @@ module "sle15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54_ssh_minion" {
+// module "slemicro54_sshminion" {
 //  providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1615,7 +1615,7 @@ module "sle15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55_ssh_minion" {
+// module "slemicro55_sshminion" {
 //  providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1633,7 +1633,7 @@ module "sle15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60_ssh_minion" {
+// module "slmicro60_sshminion" {
 //  providers = {
 //     libvirt = libvirt.moscowmule
 //   }
@@ -1776,96 +1776,96 @@ module "controller" {
 
   sle12sp5_client_configuration    = module.sle12sp5_client.configuration
   sle12sp5_minion_configuration    = module.sle12sp5_minion.configuration
-  sle12sp5_sshminion_configuration = module.sle12sp5_ssh_minion.configuration
+  sle12sp5_sshminion_configuration = module.sle12sp5_sshminion.configuration
 
   sle15sp2_client_configuration    = module.sle15sp2_client.configuration
   sle15sp2_minion_configuration    = module.sle15sp2_minion.configuration
-  sle15sp2_sshminion_configuration = module.sle15sp2_ssh_minion.configuration
+  sle15sp2_sshminion_configuration = module.sle15sp2_sshminion.configuration
 
   sle15sp3_client_configuration    = module.sle15sp3_client.configuration
   sle15sp3_minion_configuration    = module.sle15sp3_minion.configuration
-  sle15sp3_sshminion_configuration = module.sle15sp3_ssh_minion.configuration
+  sle15sp3_sshminion_configuration = module.sle15sp3_sshminion.configuration
 
   sle15sp4_client_configuration    = module.sle15sp4_client.configuration
   sle15sp4_minion_configuration    = module.sle15sp4_minion.configuration
-  sle15sp4_sshminion_configuration = module.sle15sp4_ssh_minion.configuration
+  sle15sp4_sshminion_configuration = module.sle15sp4_sshminion.configuration
 
   sle15sp5_client_configuration    = module.sle15sp5_client.configuration
   sle15sp5_minion_configuration    = module.sle15sp5_minion.configuration
-  sle15sp5_sshminion_configuration = module.sle15sp5_ssh_minion.configuration
+  sle15sp5_sshminion_configuration = module.sle15sp5_sshminion.configuration
 
   sle15sp6_client_configuration    = module.sle15sp6_client.configuration
   sle15sp6_minion_configuration    = module.sle15sp6_minion.configuration
-  sle15sp6_sshminion_configuration = module.sle15sp6_ssh_minion.configuration
+  sle15sp6_sshminion_configuration = module.sle15sp6_sshminion.configuration
 
   alma8_minion_configuration    = module.alma8_minion.configuration
-  alma8_sshminion_configuration = module.alma8_ssh_minion.configuration
+  alma8_sshminion_configuration = module.alma8_sshminion.configuration
 
   alma9_minion_configuration    = module.alma9_minion.configuration
-  alma9_sshminion_configuration = module.alma9_ssh_minion.configuration
+  alma9_sshminion_configuration = module.alma9_sshminion.configuration
 
   centos7_client_configuration    = module.centos7_client.configuration
   centos7_minion_configuration    = module.centos7_minion.configuration
-  centos7_sshminion_configuration = module.centos7_ssh_minion.configuration
+  centos7_sshminion_configuration = module.centos7_sshminion.configuration
 
   liberty9_minion_configuration    = module.liberty9_minion.configuration
-  liberty9_sshminion_configuration = module.liberty9_ssh_minion.configuration
+  liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
-  oracle9_sshminion_configuration = module.oracle9_ssh_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_sshminion.configuration
 
   rocky8_minion_configuration    = module.rocky8_minion.configuration
-  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_sshminion.configuration
 
   rocky9_minion_configuration    = module.rocky9_minion.configuration
-  rocky9_sshminion_configuration = module.rocky9_ssh_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_sshminion.configuration
 
   ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_sshminion.configuration
 
   ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_sshminion.configuration
 
   debian11_minion_configuration    = module.debian11_minion.configuration
-  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
+  debian11_sshminion_configuration = module.debian11_sshminion.configuration
 
   debian12_minion_configuration    = module.debian12_minion.configuration
-  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
+  debian12_sshminion_configuration = module.debian12_sshminion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_sshminion.configuration
 
   opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm_ssh_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sle15sp5s390_minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sle15sp5s390_ssh_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sle15sp5s390_sshminion.configuration
 
   salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
   slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51_ssh_minion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_sshminion.configuration
 
   slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52_ssh_minion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_sshminion.configuration
 
   slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53_ssh_minion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_sshminion.configuration
 
   slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54_ssh_minion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_sshminion.configuration
 
   slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55_ssh_minion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_sshminion.configuration
 
   slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60_ssh_minion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sle12sp5_buildhost.configuration
   sle15sp4_buildhost_configuration = module.sle15sp4_buildhost.configuration

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-paygo-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-paygo-AWS.tf
@@ -409,7 +409,7 @@ module "sles15sp6_minion" {
 
 }
 
-module "sles12sp5_ssh_minion" {
+module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -425,7 +425,7 @@ module "sles12sp5_ssh_minion" {
   additional_packages = [ "chrony" ]
 }
 
-module "sles15sp4_ssh_minion" {
+module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -440,7 +440,7 @@ module "sles15sp4_ssh_minion" {
 }
 
 
-module "sles15sp5_ssh_minion" {
+module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -455,7 +455,7 @@ module "sles15sp5_ssh_minion" {
 
 }
 
-module "sles15sp6_ssh_minion" {
+module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
@@ -507,11 +507,11 @@ module "controller" {
 
   sle12sp5_client_configuration    = module.sles12sp5_client.configuration
   sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5_ssh_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_sshminion.configuration
 
   sle15sp4_client_configuration    = module.sles15sp4_client.configuration
   sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4_ssh_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_sshminion.configuration
 
   sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
   sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -220,7 +220,7 @@ module "proxy_containerized" {
   ssh_key_path              = "./salt/controller/id_rsa.pub"
 }
 
-module "sles12sp5-minion" {
+module "sles12sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -241,7 +241,7 @@ module "sles12sp5-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp2-minion" {
+module "sles15sp2_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -263,7 +263,7 @@ module "sles15sp2-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp3-minion" {
+module "sles15sp3_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -285,7 +285,7 @@ module "sles15sp3-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp4-minion" {
+module "sles15sp4_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -307,7 +307,7 @@ module "sles15sp4-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5-minion" {
+module "sles15sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -329,7 +329,7 @@ module "sles15sp5-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp6-minion" {
+module "sles15sp6_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -351,7 +351,7 @@ module "sles15sp6-minion" {
   install_salt_bundle = true
 }
 
-module "alma8-minion" {
+module "alma8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -372,7 +372,7 @@ module "alma8-minion" {
   install_salt_bundle = true
 }
 
-module "alma9-minion" {
+module "alma9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -393,7 +393,7 @@ module "alma9-minion" {
   install_salt_bundle = true
 }
 
-module "centos7-minion" {
+module "centos7_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -414,7 +414,7 @@ module "centos7-minion" {
   install_salt_bundle = true
 }
 
-module "liberty9-minion" {
+module "liberty9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -435,7 +435,7 @@ module "liberty9-minion" {
   install_salt_bundle = true
 }
 
-module "oracle9-minion" {
+module "oracle9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -456,7 +456,7 @@ module "oracle9-minion" {
   install_salt_bundle = true
 }
 
-module "rocky8-minion" {
+module "rocky8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -477,7 +477,7 @@ module "rocky8-minion" {
   install_salt_bundle = true
 }
 
-module "rocky9-minion" {
+module "rocky9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -498,7 +498,7 @@ module "rocky9-minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004-minion" {
+module "ubuntu2004_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -520,7 +520,7 @@ module "ubuntu2004-minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204-minion" {
+module "ubuntu2204_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -541,7 +541,7 @@ module "ubuntu2204-minion" {
   install_salt_bundle = true
 }
 
-module "debian11-minion" {
+module "debian11_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -563,7 +563,7 @@ module "debian11-minion" {
   install_salt_bundle = true
 }
 
-module "debian12-minion" {
+module "debian12_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -585,7 +585,7 @@ module "debian12-minion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm-minion" {
+module "opensuse155arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -612,7 +612,7 @@ module "opensuse155arm-minion" {
   install_salt_bundle = true
 }
 
-module "opensuse156arm-minion" {
+module "opensuse156arm_minion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -639,7 +639,7 @@ module "opensuse156arm-minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5s390-minion" {
+module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "5.0-released"
@@ -662,7 +662,7 @@ module "sles15sp5s390-minion" {
 }
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
 // dedicated to testing migration from OS Salt to Salt bundle
-module "salt-migration-minion" {
+module "salt_migration_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   name               = "min-salt-migration"
@@ -682,7 +682,7 @@ module "salt-migration-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro51-minion" {
+module "slemicro51_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -705,7 +705,7 @@ module "slemicro51-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro52-minion" {
+module "slemicro52_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -728,7 +728,7 @@ module "slemicro52-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro53-minion" {
+module "slemicro53_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -751,7 +751,7 @@ module "slemicro53-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro54-minion" {
+module "slemicro54_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -774,7 +774,7 @@ module "slemicro54-minion" {
   install_salt_bundle = false
 }
 
-module "slemicro55-minion" {
+module "slemicro55_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -797,7 +797,7 @@ module "slemicro55-minion" {
   install_salt_bundle = false
 }
 
-module "slmicro60-minion" {
+module "slmicro60_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -821,7 +821,7 @@ module "slmicro60-minion" {
   install_salt_bundle = false
 }
 
-module "sles12sp5-sshminion" {
+module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -840,7 +840,7 @@ module "sles12sp5-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp2-sshminion" {
+module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -857,7 +857,7 @@ module "sles15sp2-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp3-sshminion" {
+module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -874,7 +874,7 @@ module "sles15sp3-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp4-sshminion" {
+module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -891,7 +891,7 @@ module "sles15sp4-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5-sshminion" {
+module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -908,7 +908,7 @@ module "sles15sp5-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp6-sshminion" {
+module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -925,7 +925,7 @@ module "sles15sp6-sshminion" {
   install_salt_bundle = true
 }
 
-module "alma8-sshminion" {
+module "alma8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -942,7 +942,7 @@ module "alma8-sshminion" {
   install_salt_bundle = true
 }
 
-module "alma9-sshminion" {
+module "alma9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -959,7 +959,7 @@ module "alma9-sshminion" {
   install_salt_bundle = true
 }
 
-module "centos7-sshminion" {
+module "centos7_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -977,7 +977,7 @@ module "centos7-sshminion" {
 }
 
 
-module "liberty9-sshminion" {
+module "liberty9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -994,7 +994,7 @@ module "liberty9-sshminion" {
   install_salt_bundle = true
 }
 
-module "oracle9-sshminion" {
+module "oracle9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1011,7 +1011,7 @@ module "oracle9-sshminion" {
   install_salt_bundle = true
 }
 
-module "rocky8-sshminion" {
+module "rocky8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1028,7 +1028,7 @@ module "rocky8-sshminion" {
   install_salt_bundle = true
 }
 
-module "rocky9-sshminion" {
+module "rocky9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1045,7 +1045,7 @@ module "rocky9-sshminion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004-sshminion" {
+module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1063,7 +1063,7 @@ module "ubuntu2004-sshminion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204-sshminion" {
+module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1080,7 +1080,7 @@ module "ubuntu2204-sshminion" {
   install_salt_bundle = true
 }
 
-module "debian11-sshminion" {
+module "debian11_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1097,7 +1097,7 @@ module "debian11-sshminion" {
   install_salt_bundle = true
 }
 
-module "debian12-sshminion" {
+module "debian12_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1114,7 +1114,7 @@ module "debian12-sshminion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm-sshminion" {
+module "opensuse155arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1137,7 +1137,7 @@ module "opensuse155arm-sshminion" {
   install_salt_bundle = true
 }
 
-module "opensuse156arm-sshminion" {
+module "opensuse156arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1160,7 +1160,7 @@ module "opensuse156arm-sshminion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5s390-sshminion" {
+module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "5.0-released"
@@ -1183,7 +1183,7 @@ module "sles15sp5s390-sshminion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51-sshminion" {
+// module "slemicro51_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "5.0-released"
@@ -1201,7 +1201,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52-sshminion" {
+// module "slemicro52_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "5.0-released"
@@ -1219,7 +1219,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53-sshminion" {
+// module "slemicro53_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "5.0-released"
@@ -1237,7 +1237,7 @@ module "sles15sp5s390-sshminion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54-sshminion" {
+// module "slemicro54_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "5.0-released"
@@ -1255,7 +1255,7 @@ module "sles15sp5s390-sshminion" {
 //}
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55-sshminion" {
+// module "slemicro55_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "5.0-released"
@@ -1272,7 +1272,7 @@ module "sles15sp5s390-sshminion" {
 //}
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60-sshminion" {
+// module "slmicro60_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "5.0-released"
@@ -1288,7 +1288,7 @@ module "sles15sp5s390-sshminion" {
 //  install_salt_bundle = true
 //}
 
-module "sles12sp5-buildhost" {
+module "sles12sp5_buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1310,7 +1310,7 @@ module "sles12sp5-buildhost" {
   install_salt_bundle = true
 }
 
-module "sles12sp5-terminal" {
+module "sles12sp5_terminal" {
   source             = "./modules/pxe_boot"
   base_configuration = module.base_core.configuration
   name               = "terminal-sles12sp5"
@@ -1325,7 +1325,7 @@ module "sles12sp5-terminal" {
   private_name       = "sle12sp5terminal"
 }
 
-module "sles15sp4-buildhost" {
+module "sles15sp4_buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1347,7 +1347,7 @@ module "sles15sp4-buildhost" {
   install_salt_bundle = true
 }
 
-module "sles15sp4-terminal" {
+module "sles15sp4_terminal" {
   source             = "./modules/pxe_boot"
   base_configuration = module.base_core.configuration
   name               = "terminal-sles15sp4"
@@ -1362,15 +1362,15 @@ module "sles15sp4-terminal" {
   private_name       = "sle15sp4terminal"
 }
 
-module "dhcp-dns" {
+module "dhcp_dns" {
   source             = "./modules/dhcp_dns"
   base_configuration = module.base_core.configuration
   name               = "dhcp-dns"
   image              = "opensuse155o"
   private_hosts = [
     module.proxy_containerized.configuration,
-    module.sles12sp5-terminal.configuration,
-    module.sles15sp4-terminal.configuration
+    module.sles12sp5_terminal.configuration,
+    module.sles15sp4_terminal.configuration
   ]
   hypervisor = {
     host        = "suma-06.mgr.suse.de"
@@ -1379,7 +1379,7 @@ module "dhcp-dns" {
   }
 }
 
-module "monitoring-server" {
+module "monitoring_server" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   product_version    = "5.0-released"
@@ -1423,99 +1423,99 @@ module "controller" {
 
   proxy_configuration  = module.proxy_containerized.configuration
 
-  sle12sp5_minion_configuration    = module.sles12sp5-minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5-sshminion.configuration
+  sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_sshminion.configuration
 
-  sle15sp2_minion_configuration    = module.sles15sp2-minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2-sshminion.configuration
+  sle15sp2_minion_configuration    = module.sles15sp2_minion.configuration
+  sle15sp2_sshminion_configuration = module.sles15sp2_sshminion.configuration
 
-  sle15sp3_minion_configuration    = module.sles15sp3-minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3-sshminion.configuration
+  sle15sp3_minion_configuration    = module.sles15sp3_minion.configuration
+  sle15sp3_sshminion_configuration = module.sles15sp3_sshminion.configuration
 
-  sle15sp4_minion_configuration    = module.sles15sp4-minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4-sshminion.configuration
+  sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_sshminion.configuration
 
-  sle15sp5_minion_configuration    = module.sles15sp5-minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5-sshminion.configuration
+  sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
+  sle15sp5_sshminion_configuration = module.sles15sp5_sshminion.configuration
 
-  sle15sp6_minion_configuration    = module.sles15sp6-minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6-sshminion.configuration
+  sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
+  sle15sp6_sshminion_configuration = module.sles15sp6_sshminion.configuration
 
-  alma8_minion_configuration    = module.alma8-minion.configuration
-  alma8_sshminion_configuration = module.alma8-sshminion.configuration
+  alma8_minion_configuration    = module.alma8_minion.configuration
+  alma8_sshminion_configuration = module.alma8_sshminion.configuration
 
-  alma9_minion_configuration    = module.alma9-minion.configuration
-  alma9_sshminion_configuration = module.alma9-sshminion.configuration
+  alma9_minion_configuration    = module.alma9_minion.configuration
+  alma9_sshminion_configuration = module.alma9_sshminion.configuration
 
-  centos7_minion_configuration    = module.centos7-minion.configuration
-  centos7_sshminion_configuration = module.centos7-sshminion.configuration
+  centos7_minion_configuration    = module.centos7_minion.configuration
+  centos7_sshminion_configuration = module.centos7_sshminion.configuration
 
-  liberty9_minion_configuration    = module.liberty9-minion.configuration
-  liberty9_sshminion_configuration = module.liberty9-sshminion.configuration
+  liberty9_minion_configuration    = module.liberty9_minion.configuration
+  liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
-  oracle9_minion_configuration    = module.oracle9-minion.configuration
-  oracle9_sshminion_configuration = module.oracle9-sshminion.configuration
+  oracle9_minion_configuration    = module.oracle9_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_sshminion.configuration
 
-  rocky8_minion_configuration    = module.rocky8-minion.configuration
-  rocky8_sshminion_configuration = module.rocky8-sshminion.configuration
+  rocky8_minion_configuration    = module.rocky8_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_sshminion.configuration
 
-  rocky9_minion_configuration    = module.rocky9-minion.configuration
-  rocky9_sshminion_configuration = module.rocky9-sshminion.configuration
+  rocky9_minion_configuration    = module.rocky9_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_sshminion.configuration
 
-  ubuntu2004_minion_configuration    = module.ubuntu2004-minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004-sshminion.configuration
+  ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_sshminion.configuration
 
-  ubuntu2204_minion_configuration    = module.ubuntu2204-minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204-sshminion.configuration
+  ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_sshminion.configuration
 
-  debian11_minion_configuration    = module.debian11-minion.configuration
-  debian11_sshminion_configuration = module.debian11-sshminion.configuration
+  debian11_minion_configuration    = module.debian11_minion.configuration
+  debian11_sshminion_configuration = module.debian11_sshminion.configuration
 
-  debian12_minion_configuration    = module.debian12-minion.configuration
-  debian12_sshminion_configuration = module.debian12-sshminion.configuration
+  debian12_minion_configuration    = module.debian12_minion.configuration
+  debian12_sshminion_configuration = module.debian12_sshminion.configuration
 
-  opensuse155arm_minion_configuration    = module.opensuse155arm-minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm-sshminion.configuration
+  opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_sshminion.configuration
 
-  opensuse156arm_minion_configuration    = module.opensuse156arm-minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm-sshminion.configuration
+  opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_sshminion.configuration
 
-  sle15sp5s390_minion_configuration    = module.sles15sp5s390-minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390-sshminion.configuration
+  sle15sp5s390_minion_configuration    = module.sles15sp5s390_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_sshminion.configuration
 
-  salt_migration_minion_configuration = module.salt-migration-minion.configuration
+  salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
-  slemicro51_minion_configuration    = module.slemicro51-minion.configuration
+  slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51-sshminion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_sshminion.configuration
 
-  slemicro52_minion_configuration    = module.slemicro52-minion.configuration
+  slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52-sshminion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_sshminion.configuration
 
-  slemicro53_minion_configuration    = module.slemicro53-minion.configuration
+  slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53-sshminion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_sshminion.configuration
 
-  slemicro54_minion_configuration    = module.slemicro54-minion.configuration
+  slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54-sshminion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_sshminion.configuration
 
-  slemicro55_minion_configuration    = module.slemicro55-minion.configuration
+  slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55-sshminion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_sshminion.configuration
 
-  slmicro60_minion_configuration    = module.slmicro60-minion.configuration
+  slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60-sshminion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_sshminion.configuration
 
-  sle12sp5_buildhost_configuration = module.sles12sp5-buildhost.configuration
-  sle15sp4_buildhost_configuration = module.sles15sp4-buildhost.configuration
+  sle12sp5_buildhost_configuration = module.sles12sp5_buildhost.configuration
+  sle15sp4_buildhost_configuration = module.sles15sp4_buildhost.configuration
 
-  sle12sp5_terminal_configuration = module.sles12sp5-terminal.configuration
-  sle15sp4_terminal_configuration = module.sles15sp4-terminal.configuration
+  sle12sp5_terminal_configuration = module.sles12sp5_terminal.configuration
+  sle15sp4_terminal_configuration = module.sles15sp4_terminal.configuration
 
-  monitoringserver_configuration = module.monitoring-server.configuration
+  monitoringserver_configuration = module.monitoring_server.configuration
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -1040,7 +1040,7 @@ module "slmicro60_minion" {
   install_salt_bundle = false
 }
 
-module "sles12sp5_ssh_minion" {
+module "sles12sp5_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1062,7 +1062,7 @@ module "sles12sp5_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp2_ssh_minion" {
+module "sles15sp2_sshminion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1082,7 +1082,7 @@ module "sles15sp2_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp3_ssh_minion" {
+module "sles15sp3_sshminion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1102,7 +1102,7 @@ module "sles15sp3_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp4_ssh_minion" {
+module "sles15sp4_sshminion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1122,7 +1122,7 @@ module "sles15sp4_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5_ssh_minion" {
+module "sles15sp5_sshminion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1142,7 +1142,7 @@ module "sles15sp5_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp6_ssh_minion" {
+module "sles15sp6_sshminion" {
   providers = {
     libvirt = libvirt.florina
   }
@@ -1162,7 +1162,7 @@ module "sles15sp6_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "alma8_ssh_minion" {
+module "alma8_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1182,7 +1182,7 @@ module "alma8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "alma9_ssh_minion" {
+module "alma9_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1202,7 +1202,7 @@ module "alma9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "centos7_ssh_minion" {
+module "centos7_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1222,7 +1222,7 @@ module "centos7_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "liberty9_ssh_minion" {
+module "liberty9_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1242,7 +1242,7 @@ module "liberty9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "oracle9_ssh_minion" {
+module "oracle9_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1262,7 +1262,7 @@ module "oracle9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky8_ssh_minion" {
+module "rocky8_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1282,7 +1282,7 @@ module "rocky8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky9_ssh_minion" {
+module "rocky9_sshminion" {
   providers = {
     libvirt = libvirt.tatooine
   }
@@ -1302,7 +1302,7 @@ module "rocky9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004_ssh_minion" {
+module "ubuntu2004_sshminion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1323,7 +1323,7 @@ module "ubuntu2004_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204_ssh_minion" {
+module "ubuntu2204_sshminion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1343,7 +1343,7 @@ module "ubuntu2204_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "debian11_ssh_minion" {
+module "debian11_sshminion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1363,7 +1363,7 @@ module "debian11_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "debian12_ssh_minion" {
+module "debian12_sshminion" {
   providers = {
     libvirt = libvirt.trantor
   }
@@ -1383,7 +1383,7 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm_ssh_minion" {
+module "opensuse155arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1406,7 +1406,7 @@ module "opensuse155arm_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse156arm_ssh_minion" {
+module "opensuse156arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1429,7 +1429,7 @@ module "opensuse156arm_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "sles15sp5s390_ssh_minion" {
+module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "5.0-released"
@@ -1452,7 +1452,7 @@ module "sles15sp5s390_ssh_minion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51_ssh_minion" {
+// module "slemicro51_sshminion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1473,7 +1473,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52_ssh_minion" {
+// module "slemicro52_sshminion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1494,7 +1494,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53_ssh_minion" {
+// module "slemicro53_sshminion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1515,7 +1515,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54_ssh_minion" {
+// module "slemicro54_sshminion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1536,7 +1536,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55_ssh_minion" {
+// module "slemicro55_sshminion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1557,7 +1557,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60_ssh_minion" {
+// module "slmicro60_sshminion" {
 //   providers = {
 //     libvirt = libvirt.florina
 //   }
@@ -1728,90 +1728,90 @@ module "controller" {
   proxy_configuration  = module.proxy_containerized.configuration
 
   sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5_ssh_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_sshminion.configuration
 
   sle15sp2_minion_configuration    = module.sles15sp2_minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2_ssh_minion.configuration
+  sle15sp2_sshminion_configuration = module.sles15sp2_sshminion.configuration
 
   sle15sp3_minion_configuration    = module.sles15sp3_minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3_ssh_minion.configuration
+  sle15sp3_sshminion_configuration = module.sles15sp3_sshminion.configuration
 
   sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4_ssh_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_sshminion.configuration
 
   sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5_ssh_minion.configuration
+  sle15sp5_sshminion_configuration = module.sles15sp5_sshminion.configuration
 
   sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6_ssh_minion.configuration
+  sle15sp6_sshminion_configuration = module.sles15sp6_sshminion.configuration
 
   alma8_minion_configuration    = module.alma8_minion.configuration
-  alma8_sshminion_configuration = module.alma8_ssh_minion.configuration
+  alma8_sshminion_configuration = module.alma8_sshminion.configuration
 
   alma9_minion_configuration    = module.alma9_minion.configuration
-  alma9_sshminion_configuration = module.alma9_ssh_minion.configuration
+  alma9_sshminion_configuration = module.alma9_sshminion.configuration
 
   centos7_minion_configuration    = module.centos7_minion.configuration
-  centos7_sshminion_configuration = module.centos7_ssh_minion.configuration
+  centos7_sshminion_configuration = module.centos7_sshminion.configuration
 
   liberty9_minion_configuration    = module.liberty9_minion.configuration
-  liberty9_sshminion_configuration = module.liberty9_ssh_minion.configuration
+  liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
-  oracle9_sshminion_configuration = module.oracle9_ssh_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_sshminion.configuration
 
   rocky8_minion_configuration    = module.rocky8_minion.configuration
-  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_sshminion.configuration
 
   rocky9_minion_configuration    = module.rocky9_minion.configuration
-  rocky9_sshminion_configuration = module.rocky9_ssh_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_sshminion.configuration
 
   ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_sshminion.configuration
 
   ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_sshminion.configuration
 
   debian11_minion_configuration    = module.debian11_minion.configuration
-  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
+  debian11_sshminion_configuration = module.debian11_sshminion.configuration
 
   debian12_minion_configuration    = module.debian12_minion.configuration
-  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
+  debian12_sshminion_configuration = module.debian12_sshminion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_sshminion.configuration
 
   opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm_ssh_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390_minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_ssh_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_sshminion.configuration
 
   salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
   slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51_ssh_minion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_sshminion.configuration
 
   slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52_ssh_minion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_sshminion.configuration
 
   slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53_ssh_minion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_sshminion.configuration
 
   slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54_ssh_minion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_sshminion.configuration
 
   slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55_ssh_minion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_sshminion.configuration
 
   slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60_ssh_minion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5_buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4_buildhost.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -770,7 +770,7 @@ module "slmicro60_minion" {
   install_salt_bundle = false
 }
 
-module "sles12sp5_ssh_minion" {
+module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -786,7 +786,7 @@ module "sles12sp5_ssh_minion" {
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
-module "sles15sp2_ssh_minion" {
+module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -800,7 +800,7 @@ module "sles15sp2_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp3_ssh_minion" {
+module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -814,7 +814,7 @@ module "sles15sp3_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp4_ssh_minion" {
+module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -828,7 +828,7 @@ module "sles15sp4_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5_ssh_minion" {
+module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -842,7 +842,7 @@ module "sles15sp5_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp6_ssh_minion" {
+module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -856,7 +856,7 @@ module "sles15sp6_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "alma8_ssh_minion" {
+module "alma8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -873,7 +873,7 @@ module "alma8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "alma9_ssh_minion" {
+module "alma9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -890,7 +890,7 @@ module "alma9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "centos7_ssh_minion" {
+module "centos7_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -907,7 +907,7 @@ module "centos7_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "oracle9_ssh_minion" {
+module "oracle9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -924,7 +924,7 @@ module "oracle9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky8_ssh_minion" {
+module "rocky8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -941,7 +941,7 @@ module "rocky8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky9_ssh_minion" {
+module "rocky9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -958,7 +958,7 @@ module "rocky9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004_ssh_minion" {
+module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -976,7 +976,7 @@ module "ubuntu2004_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204_ssh_minion" {
+module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -990,7 +990,7 @@ module "ubuntu2204_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian11_ssh_minion" {
+module "debian11_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -1004,7 +1004,7 @@ module "debian11_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian12_ssh_minion" {
+module "debian12_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
   product_version    = "uyuni-master"
@@ -1021,7 +1021,7 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm_ssh_minion" {
+module "opensuse155arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1041,7 +1041,7 @@ module "opensuse155arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse156arm_ssh_minion" {
+module "opensuse156arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1061,7 +1061,7 @@ module "opensuse156arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5s390_ssh_minion" {
+module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "uyuni-master"
@@ -1081,7 +1081,7 @@ module "sles15sp5s390_ssh_minion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51_ssh_minion" {
+// module "slemicro51_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "uyuni-master"
@@ -1096,7 +1096,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52_ssh_minion" {
+// module "slemicro52_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "uyuni-master"
@@ -1111,7 +1111,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53_ssh_minion" {
+// module "slemicro53_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "uyuni-master"
@@ -1126,7 +1126,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54_ssh_minion" {
+// module "slemicro54_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "uyuni-master"
@@ -1141,7 +1141,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55_ssh_minion" {
+// module "slemicro55_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "uyuni-master"
@@ -1156,7 +1156,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60_ssh_minion" {
+// module "slmicro60_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
 //   product_version    = "uyuni-master"
@@ -1280,87 +1280,87 @@ module "controller" {
   proxy_configuration  = module.proxy_containerized.configuration
 
   sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5_ssh_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_sshminion.configuration
 
   sle15sp2_minion_configuration    = module.sles15sp2_minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2_ssh_minion.configuration
+  sle15sp2_sshminion_configuration = module.sles15sp2_sshminion.configuration
 
   sle15sp3_minion_configuration    = module.sles15sp3_minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3_ssh_minion.configuration
+  sle15sp3_sshminion_configuration = module.sles15sp3_sshminion.configuration
 
   sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4_ssh_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_sshminion.configuration
 
   sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5_ssh_minion.configuration
+  sle15sp5_sshminion_configuration = module.sles15sp5_sshminion.configuration
 
   sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6_ssh_minion.configuration
+  sle15sp6_sshminion_configuration = module.sles15sp6_sshminion.configuration
 
   alma8_minion_configuration    = module.alma8_minion.configuration
-  alma8_sshminion_configuration = module.alma8_ssh_minion.configuration
+  alma8_sshminion_configuration = module.alma8_sshminion.configuration
 
   alma9_minion_configuration    = module.alma9_minion.configuration
-  alma9_sshminion_configuration = module.alma9_ssh_minion.configuration
+  alma9_sshminion_configuration = module.alma9_sshminion.configuration
 
   centos7_minion_configuration    = module.centos7_minion.configuration
-  centos7_sshminion_configuration = module.centos7_ssh_minion.configuration
+  centos7_sshminion_configuration = module.centos7_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
-  oracle9_sshminion_configuration = module.oracle9_ssh_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_sshminion.configuration
 
   rocky8_minion_configuration    = module.rocky8_minion.configuration
-  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_sshminion.configuration
 
   rocky9_minion_configuration    = module.rocky9_minion.configuration
-  rocky9_sshminion_configuration = module.rocky9_ssh_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_sshminion.configuration
 
   ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_sshminion.configuration
 
   ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_sshminion.configuration
 
   debian11_minion_configuration    = module.debian11_minion.configuration
-  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
+  debian11_sshminion_configuration = module.debian11_sshminion.configuration
 
   debian12_minion_configuration    = module.debian12_minion.configuration
-  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
+  debian12_sshminion_configuration = module.debian12_sshminion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_sshminion.configuration
 
   opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm_ssh_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390_minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_ssh_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_sshminion.configuration
 
   salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
   slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51_ssh_minion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_sshminion.configuration
 
   slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52_ssh_minion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_sshminion.configuration
 
   slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53_ssh_minion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_sshminion.configuration
 
   slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54_ssh_minion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_sshminion.configuration
 
   slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55_ssh_minion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_sshminion.configuration
 
   slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60_ssh_minion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5_buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4_buildhost.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -985,7 +985,7 @@ module "slmicro60_minion" {
   install_salt_bundle = false
 }
 
-module "sles12sp5_ssh_minion" {
+module "sles12sp5_sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
@@ -1004,7 +1004,7 @@ module "sles12sp5_ssh_minion" {
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
-module "sles15sp2_ssh_minion" {
+module "sles15sp2_sshminion" {
   providers = {
     libvirt = libvirt.ginfizz
   }
@@ -1021,7 +1021,7 @@ module "sles15sp2_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp3_ssh_minion" {
+module "sles15sp3_sshminion" {
   providers = {
     libvirt = libvirt.ginfizz
   }
@@ -1038,7 +1038,7 @@ module "sles15sp3_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp4_ssh_minion" {
+module "sles15sp4_sshminion" {
   providers = {
     libvirt = libvirt.ginfizz
   }
@@ -1055,7 +1055,7 @@ module "sles15sp4_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5_ssh_minion" {
+module "sles15sp5_sshminion" {
   providers = {
     libvirt = libvirt.ginfizz
   }
@@ -1072,7 +1072,7 @@ module "sles15sp5_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp6_ssh_minion" {
+module "sles15sp6_sshminion" {
   providers = {
     libvirt = libvirt.ginfizz
   }
@@ -1089,7 +1089,7 @@ module "sles15sp6_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "alma8_ssh_minion" {
+module "alma8_sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
@@ -1109,7 +1109,7 @@ module "alma8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "alma9_ssh_minion" {
+module "alma9_sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
@@ -1129,7 +1129,7 @@ module "alma9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "centos7_ssh_minion" {
+module "centos7_sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
@@ -1149,7 +1149,7 @@ module "centos7_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "oracle9_ssh_minion" {
+module "oracle9_sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
@@ -1169,7 +1169,7 @@ module "oracle9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky8_ssh_minion" {
+module "rocky8_sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
@@ -1189,7 +1189,7 @@ module "rocky8_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "rocky9_ssh_minion" {
+module "rocky9_sshminion" {
   providers = {
     libvirt = libvirt.cosmopolitan
   }
@@ -1209,7 +1209,7 @@ module "rocky9_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2004_ssh_minion" {
+module "ubuntu2004_sshminion" {
   providers = {
     libvirt = libvirt.caipirinha
   }
@@ -1230,7 +1230,7 @@ module "ubuntu2004_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "ubuntu2204_ssh_minion" {
+module "ubuntu2204_sshminion" {
   providers = {
     libvirt = libvirt.caipirinha
   }
@@ -1247,7 +1247,7 @@ module "ubuntu2204_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian11_ssh_minion" {
+module "debian11_sshminion" {
   providers = {
     libvirt = libvirt.caipirinha
   }
@@ -1264,7 +1264,7 @@ module "debian11_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "debian12_ssh_minion" {
+module "debian12_sshminion" {
   providers = {
     libvirt = libvirt.caipirinha
   }
@@ -1284,7 +1284,7 @@ module "debian12_ssh_minion" {
   install_salt_bundle = true
 }
 
-module "opensuse155arm_ssh_minion" {
+module "opensuse155arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1304,7 +1304,7 @@ module "opensuse155arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "opensuse156arm_ssh_minion" {
+module "opensuse156arm_sshminion" {
   providers = {
     libvirt = libvirt.suma-arm
   }
@@ -1324,7 +1324,7 @@ module "opensuse156arm_ssh_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
-module "sles15sp5s390_ssh_minion" {
+module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
   product_version    = "uyuni-master"
@@ -1344,7 +1344,7 @@ module "sles15sp5s390_ssh_minion" {
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro51_ssh_minion" {
+// module "slemicro51_sshminion" {
 //   providers = {
 //     libvirt = libvirt.ginfizz
 //   }
@@ -1362,7 +1362,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro52_ssh_minion" {
+// module "slemicro52_sshminion" {
 //   providers = {
 //     libvirt = libvirt.ginfizz
 //   }
@@ -1380,7 +1380,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro53_ssh_minion" {
+// module "slemicro53_sshminion" {
 //   providers = {
 //     libvirt = libvirt.ginfizz
 //   }
@@ -1398,7 +1398,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro54_ssh_minion" {
+// module "slemicro54_sshminion" {
 //   providers = {
 //     libvirt = libvirt.ginfizz
 //   }
@@ -1416,7 +1416,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slemicro55_ssh_minion" {
+// module "slemicro55_sshminion" {
 //   providers = {
 //     libvirt = libvirt.ginfizz
 //   }
@@ -1434,7 +1434,7 @@ module "sles15sp5s390_ssh_minion" {
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-// module "slmicro60_ssh_minion" {
+// module "slmicro60_sshminion" {
 //   providers = {
 //     libvirt = libvirt.ginfizz
 //   }
@@ -1575,87 +1575,87 @@ module "controller" {
   proxy_configuration  = module.proxy_containerized.configuration
 
   sle12sp5_minion_configuration    = module.sles12sp5_minion.configuration
-  sle12sp5_sshminion_configuration = module.sles12sp5_ssh_minion.configuration
+  sle12sp5_sshminion_configuration = module.sles12sp5_sshminion.configuration
 
   sle15sp2_minion_configuration    = module.sles15sp2_minion.configuration
-  sle15sp2_sshminion_configuration = module.sles15sp2_ssh_minion.configuration
+  sle15sp2_sshminion_configuration = module.sles15sp2_sshminion.configuration
 
   sle15sp3_minion_configuration    = module.sles15sp3_minion.configuration
-  sle15sp3_sshminion_configuration = module.sles15sp3_ssh_minion.configuration
+  sle15sp3_sshminion_configuration = module.sles15sp3_sshminion.configuration
 
   sle15sp4_minion_configuration    = module.sles15sp4_minion.configuration
-  sle15sp4_sshminion_configuration = module.sles15sp4_ssh_minion.configuration
+  sle15sp4_sshminion_configuration = module.sles15sp4_sshminion.configuration
 
   sle15sp5_minion_configuration    = module.sles15sp5_minion.configuration
-  sle15sp5_sshminion_configuration = module.sles15sp5_ssh_minion.configuration
+  sle15sp5_sshminion_configuration = module.sles15sp5_sshminion.configuration
 
   sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
-  sle15sp6_sshminion_configuration = module.sles15sp6_ssh_minion.configuration
+  sle15sp6_sshminion_configuration = module.sles15sp6_sshminion.configuration
 
   alma8_minion_configuration    = module.alma8_minion.configuration
-  alma8_sshminion_configuration = module.alma8_ssh_minion.configuration
+  alma8_sshminion_configuration = module.alma8_sshminion.configuration
 
   alma9_minion_configuration    = module.alma9_minion.configuration
-  alma9_sshminion_configuration = module.alma9_ssh_minion.configuration
+  alma9_sshminion_configuration = module.alma9_sshminion.configuration
 
   centos7_minion_configuration    = module.centos7_minion.configuration
-  centos7_sshminion_configuration = module.centos7_ssh_minion.configuration
+  centos7_sshminion_configuration = module.centos7_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
-  oracle9_sshminion_configuration = module.oracle9_ssh_minion.configuration
+  oracle9_sshminion_configuration = module.oracle9_sshminion.configuration
 
   rocky8_minion_configuration    = module.rocky8_minion.configuration
-  rocky8_sshminion_configuration = module.rocky8_ssh_minion.configuration
+  rocky8_sshminion_configuration = module.rocky8_sshminion.configuration
 
   rocky9_minion_configuration    = module.rocky9_minion.configuration
-  rocky9_sshminion_configuration = module.rocky9_ssh_minion.configuration
+  rocky9_sshminion_configuration = module.rocky9_sshminion.configuration
 
   ubuntu2004_minion_configuration    = module.ubuntu2004_minion.configuration
-  ubuntu2004_sshminion_configuration = module.ubuntu2004_ssh_minion.configuration
+  ubuntu2004_sshminion_configuration = module.ubuntu2004_sshminion.configuration
 
   ubuntu2204_minion_configuration    = module.ubuntu2204_minion.configuration
-  ubuntu2204_sshminion_configuration = module.ubuntu2204_ssh_minion.configuration
+  ubuntu2204_sshminion_configuration = module.ubuntu2204_sshminion.configuration
 
   debian11_minion_configuration    = module.debian11_minion.configuration
-  debian11_sshminion_configuration = module.debian11_ssh_minion.configuration
+  debian11_sshminion_configuration = module.debian11_sshminion.configuration
 
   debian12_minion_configuration    = module.debian12_minion.configuration
-  debian12_sshminion_configuration = module.debian12_ssh_minion.configuration
+  debian12_sshminion_configuration = module.debian12_sshminion.configuration
 
   opensuse155arm_minion_configuration    = module.opensuse155arm_minion.configuration
-  opensuse155arm_sshminion_configuration = module.opensuse155arm_ssh_minion.configuration
+  opensuse155arm_sshminion_configuration = module.opensuse155arm_sshminion.configuration
 
   opensuse156arm_minion_configuration    = module.opensuse156arm_minion.configuration
-  opensuse156arm_sshminion_configuration = module.opensuse156arm_ssh_minion.configuration
+  opensuse156arm_sshminion_configuration = module.opensuse156arm_sshminion.configuration
 
   sle15sp5s390_minion_configuration    = module.sles15sp5s390_minion.configuration
-  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_ssh_minion.configuration
+  sle15sp5s390_sshminion_configuration = module.sles15sp5s390_sshminion.configuration
 
   salt_migration_minion_configuration = module.salt_migration_minion.configuration
 
   slemicro51_minion_configuration    = module.slemicro51_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro51_sshminion_configuration = module.slemicro51_ssh_minion.configuration
+//  slemicro51_sshminion_configuration = module.slemicro51_sshminion.configuration
 
   slemicro52_minion_configuration    = module.slemicro52_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro52_sshminion_configuration = module.slemicro52_ssh_minion.configuration
+//  slemicro52_sshminion_configuration = module.slemicro52_sshminion.configuration
 
   slemicro53_minion_configuration    = module.slemicro53_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro53_sshminion_configuration = module.slemicro53_ssh_minion.configuration
+//  slemicro53_sshminion_configuration = module.slemicro53_sshminion.configuration
 
   slemicro54_minion_configuration    = module.slemicro54_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro54_sshminion_configuration = module.slemicro54_ssh_minion.configuration
+//  slemicro54_sshminion_configuration = module.slemicro54_sshminion.configuration
 
   slemicro55_minion_configuration    = module.slemicro55_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slemicro55_sshminion_configuration = module.slemicro55_ssh_minion.configuration
+//  slemicro55_sshminion_configuration = module.slemicro55_sshminion.configuration
 
   slmicro60_minion_configuration    = module.slmicro60_minion.configuration
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
-//  slmicro60_sshminion_configuration = module.slmicro60_ssh_minion.configuration
+//  slmicro60_sshminion_configuration = module.slmicro60_sshminion.configuration
 
   sle12sp5_buildhost_configuration = module.sles12sp5_buildhost.configuration
   sle15sp4_buildhost_configuration = module.sles15sp4_buildhost.configuration


### PR DESCRIPTION
## Context

After discussion about the minion renaming, we decided to see sshminion as one word without seperation.

## Solution
Rename modules names and references to change ssh_minion to sshminion.
Update the minion list to use sshminion.
Update nodeHandler to not convert sshminion into ssh_minion.

## Specific 5.0 BV NUE changes 

Move the changes from https://github.com/SUSE/susemanager-ci/pull/1310 into this PR to avoid conflicts

## Tests
Changes tested during https://ci.suse.de/blue/organizations/jenkins/manager-4.3-qe-build-validation-NUE/detail/manager-4.3-qe-build-validation-NUE/355/pipeline 