### PR TITLE
fix tomcat restart in uyuni-master-dev-acceptance-tests-code-coverage

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -87,9 +87,9 @@ node('sumaform-cucumber-provo') {
                 def jacocoagent_url = "https://search.maven.org/remotecontent?filepath=org/jacoco/org.jacoco.agent/0.8.7/org.jacoco.agent-0.8.7-runtime.jar"
                 def jacococli_url = "https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.7/org.jacoco.cli-0.8.7-nodeps.jar"
                 def uyuni_master = "https://github.com/uyuni-project/uyuni/archive/refs/heads/master.zip"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"wget -O /tmp/jacocoagent.jar ${jacocoagent_url}; wget ${jacococli_url} -O /tmp/jacococli.jar\"'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"systemctl restart tomcat.service\"'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"wget -O /tmp/uyuni_master.zip ${uyuni_master}; unzip -d /tmp /tmp/uyuni_master.zip\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"mgrctl exec \\\"wget -O /tmp/jacocoagent.jar ${jacocoagent_url}; wget ${jacococli_url} -O /tmp/jacococli.jar\\\"\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"mgrctl exec \\\"systemctl restart tomcat.service\\\"\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"mgrctl exec \\\"wget -O /tmp/uyuni_master.zip ${uyuni_master}; unzip -d /tmp /tmp/uyuni_master.zip\\\"\"'"
             }
 
 


### PR DESCRIPTION
We need to use "mgrctl exec" to restart tomcat inside the container