### PR TITLE
coverage pipeline: fix unzip

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -87,9 +87,9 @@ node('sumaform-cucumber-provo') {
                 def jacocoagent_url = "https://search.maven.org/remotecontent?filepath=org/jacoco/org.jacoco.agent/0.8.7/org.jacoco.agent-0.8.7-runtime.jar"
                 def jacococli_url = "https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.7/org.jacoco.cli-0.8.7-nodeps.jar"
                 def uyuni_master = "https://github.com/uyuni-project/uyuni/archive/refs/heads/master.zip"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"mgrctl exec \\\"wget -O /tmp/jacocoagent.jar ${jacocoagent_url}; wget ${jacococli_url} -O /tmp/jacococli.jar\\\"\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"wget -O /var/lib/containers/storage/volumes/var-cache/_data/jacocoagent.jar ${jacocoagent_url}; wget ${jacococli_url} -O /var/lib/containers/storage/volumes/var-cache/_data/jacococli.jar\"'"
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"mgrctl exec \\\"systemctl restart tomcat.service\\\"\"'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"mgrctl exec \\\"wget -O /tmp/uyuni_master.zip ${uyuni_master}; cd tmp;gzip -d /tmp/uyuni_master.zip\\\"\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"wget -O /var/lib/containers/storage/volumes/var-cache/_data/uyuni_master.zip ${uyuni_master}; cd /var/lib/containers/storage/volumes/var-cache/_data/;unzip //var/lib/containers/storage/volumes/var-cache/_data/uyuni_master.zip\"'"
             }
 
 
@@ -119,9 +119,9 @@ node('sumaform-cucumber-provo') {
                 archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
             }
             stage('Dump Test Coverage results') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"java -jar /tmp/jacococli.jar dump --address localhost --destfile /tmp/jacoco-last.exec --port 6300 --reset\"'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"java -jar /tmp/jacococli.jar merge \\\$(ls /tmp/*.exec) --destfile /tmp/jacoco-all.exec\"'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"java -jar /tmp/jacococli.jar report /tmp/jacoco-all.exec --html /srv/www/htdocs/pub/jacoco-cucumber-report --xml /srv/www/htdocs/pub/jacoco-cucumber-report.xml --sourcefiles /tmp/uyuni-master/java/code/src --classfiles /srv/tomcat/webapps/rhn/WEB-INF/lib/rhn.jar\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"java -jar /var/cache/jacococli.jar dump --address localhost --destfile /var/cache/jacoco-last.exec --port 6300 --reset\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"java -jar /var/cache/jacococli.jar merge \\\$(ls /var/cache/*.exec) --destfile /var/cache/jacoco-all.exec\"'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'ssh -o StrictHostKeyChecking=no \$SERVER \"java -jar /var/cache/jacococli.jar report /var/cache/jacoco-all.exec --html /srv/www/htdocs/pub/jacoco-cucumber-report --xml /srv/www/htdocs/pub/jacoco-cucumber-report.xml --sourcefiles /var/cache/uyuni-master/java/code/src --classfiles /srv/tomcat/webapps/rhn/WEB-INF/lib/rhn.jar\"'"
             }
             stage('Get results') {
                 def error = 0


### PR DESCRIPTION
unzip is not installed in the server container. Let's unzip it at the host and copy that to the volume mapped to /var/cache

gzip can't uncompress .zip files.