### PR TITLE
Remove KVM host from HEAD and Master

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -147,16 +147,6 @@ module "cucumber_testsuite" {
         tools_update_pr = var.SLE_CLIENT_REPO
       }
     }
-    kvm_host = {
-      image = var.IMAGE
-
-      provider_settings = {
-        mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["kvm-host"]
-      }
-      additional_repos_only = var.ADDITIONAL_REPOS_ONLY
-      additional_repos = local.additional_repos["kvm-host"]
-      additional_packages = [ "mkisofs" ]
-    }
   }
   
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -219,14 +219,6 @@ module "cucumber_testsuite" {
         private_key = file("~/.ssh/id_rsa")
       }
     }
-    kvm_host = {
-      image             = "sles15sp4o"
-      provider_settings = {
-        mac = "aa:b2:93:01:00:be"
-        vcpu = 4
-        memory = 4096
-      }
-    }
   }
 
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -210,14 +210,6 @@ module "cucumber_testsuite" {
         memory = 2048
       }
     }
-    kvm_host = {
-      image = "sles15sp4o"
-      provider_settings = {
-        mac = "aa:b2:93:01:00:ce"
-        vcpu = 2
-        memory = 2048
-      }
-    }
   }
   provider_settings = {
     pool = "ssd"

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -202,13 +202,6 @@ module "cucumber_testsuite" {
     pxeboot_minion = {
       image = "sles15sp4o"
     }
-    kvm_host = {
-      image = "opensuse155o"
-      
-      provider_settings = {
-        mac = "aa:b2:93:01:00:1e"
-      }
-    }
   }
   
   provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -216,14 +216,6 @@ module "cucumber_testsuite" {
         private_key = file("~/.ssh/id_rsa")
       }
     }
-    kvm_host = {
-      image = "opensuse155o"
-      provider_settings = {
-        mac     = "aa:b2:93:01:00:de"
-        vcpu    = 4
-        memory  = 4096
-      }
-    }
   }
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -200,14 +200,6 @@ module "cucumber_testsuite" {
     pxeboot_minion = {
       image = "sles15sp4o"
     }
-    kvm_host = {
-      image = "opensuse155o"
-      provider_settings = {
-        mac = "aa:b2:92:03:00:de"
-        vcpu = 4
-        memory = 4096
-      }
-    }
   }
   
   provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -205,12 +205,6 @@ module "cucumber_testsuite" {
         private_key = file("~/.ssh/id_rsa")
       }
     }
-    kvm_host = {
-      image             = "opensuse155o"
-      provider_settings = {
-        mac = "aa:b2:93:01:00:2e"
-      }
-    }
   }
   provider_settings = {
     pool               = "ssd"

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -200,14 +200,6 @@ module "cucumber_testsuite" {
         memory = 2048
       }
     }
-    kvm_host = {
-      image = "opensuse155o"
-      provider_settings = {
-        mac = "aa:b2:93:01:00:ee"
-        vcpu = 2
-        memory = 2048
-      }
-    }
   }
   provider_settings = {
     pool = "ssd"

--- a/terracumber_config/tf_files/tfvars/PR-testing-NUE-environments.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-NUE-environments.tfvars
@@ -16,7 +16,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:93:01:03:56"
       deblike-minion  = "aa:b2:93:01:03:57"
       build-host     = "aa:b2:93:01:03:59"
-      kvm-host       = "aa:b2:93:01:03:5a"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.111.0/24"
@@ -33,7 +32,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:93:01:03:62"
       deblike-minion  = "aa:b2:93:01:03:63"
       build-host     = "aa:b2:93:01:03:65"
-      kvm-host       = "aa:b2:93:01:03:66"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.112.0/24"
@@ -50,7 +48,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:93:01:03:6e"
       deblike-minion  = "aa:b2:93:01:03:6f"
       build-host     = "aa:b2:93:01:03:71"
-      kvm-host       = "aa:b2:93:01:03:72"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.113.0/24"
@@ -67,7 +64,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:93:01:03:7a"
       deblike-minion  = "aa:b2:93:01:03:7b"
       build-host     = "aa:b2:93:01:03:7d"
-      kvm-host       = "aa:b2:93:01:03:7e"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.114.0/24"
@@ -84,7 +80,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:93:01:03:86"
       deblike-minion  = "aa:b2:93:01:03:87"
       build-host     = "aa:b2:93:01:03:89"
-      kvm-host       = "aa:b2:93:01:03:8a"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.115.0/24"
@@ -101,7 +96,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:93:01:03:92"
       deblike-minion  = "aa:b2:93:01:03:93"
       build-host     = "aa:b2:93:01:03:95"
-      kvm-host       = "aa:b2:93:01:03:96"
     }
     hypervisor = "suma-08.mgr.suse.de"
     additional_network = "192.168.116.0/24"

--- a/terracumber_config/tf_files/tfvars/PR-testing-PRV-environments.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-testing-PRV-environments.tfvars
@@ -16,7 +16,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:06"
       deblike-minion = "aa:b2:92:04:00:07"
       build-host     = "aa:b2:92:04:00:09"
-      kvm-host       = "aa:b2:92:04:00:0a"
     }
     hypervisor = "romulus.mgr.prv.suse.net"
     additional_network = "192.168.101.0/24"
@@ -33,7 +32,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:16"
       deblike-minion = "aa:b2:92:04:00:17"
       build-host     = "aa:b2:92:04:00:19"
-      kvm-host       = "aa:b2:92:04:00:1a"
     }
     hypervisor = "romulus.mgr.prv.suse.net"
     additional_network = "192.168.102.0/24"
@@ -50,7 +48,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:26"
       deblike-minion = "aa:b2:92:04:00:27"
       build-host     = "aa:b2:92:04:00:29"
-      kvm-host       = "aa:b2:92:04:00:2a"
     }
     hypervisor = "vulcan.mgr.prv.suse.net"
     additional_network = "192.168.103.0/24"
@@ -67,7 +64,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:36"
       deblike-minion = "aa:b2:92:04:00:37"
       build-host     = "aa:b2:92:04:00:39"
-      kvm-host       = "aa:b2:92:04:00:3a"
     }
     hypervisor = "vulcan.mgr.prv.suse.net"
     additional_network = "192.168.104.0/24"
@@ -84,7 +80,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:46"
       deblike-minion = "aa:b2:92:04:00:47"
       build-host     = "aa:b2:92:04:00:49"
-      kvm-host       = "aa:b2:92:04:00:4a"
     }
     hypervisor = "hyperion.mgr.prv.suse.net"
     additional_network = "192.168.105.0/24"
@@ -101,7 +96,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:56"
       deblike-minion = "aa:b2:92:04:00:57"
       build-host     = "aa:b2:92:04:00:59"
-      kvm-host       = "aa:b2:92:04:00:5a"
     }
     hypervisor = "hyperion.mgr.prv.suse.net"
     additional_network = "192.168.106.0/24"
@@ -118,7 +112,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:66"
       deblike-minion = "aa:b2:92:04:00:67"
       build-host     = "aa:b2:92:04:00:69"
-      kvm-host       = "aa:b2:92:04:00:6a"
     }
     hypervisor = "daiquiri.mgr.prv.suse.net"
     additional_network = "192.168.107.0/24"
@@ -135,7 +128,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:76"
       deblike-minion = "aa:b2:92:04:00:77"
       build-host     = "aa:b2:92:04:00:79"
-      kvm-host       = "aa:b2:92:04:00:7a"
     }
     hypervisor = "daiquiri.mgr.prv.suse.net"
     additional_network = "192.168.108.0/24"
@@ -152,7 +144,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:86"
       deblike-minion = "aa:b2:92:04:00:87"
       build-host     = "aa:b2:92:04:00:89"
-      kvm-host       = "aa:b2:92:04:00:8a"
     }
     hypervisor = "mojito.mgr.prv.suse.net"
     additional_network = "192.168.109.0/24"
@@ -169,7 +160,6 @@ ENVIRONMENT_CONFIGURATION = {
       rhlike-minion  = "aa:b2:92:04:00:96"
       deblike-minion = "aa:b2:92:04:00:97"
       build-host     = "aa:b2:92:04:00:99"
-      kvm-host       = "aa:b2:92:04:00:9a"
     }
     hypervisor = "mojito.mgr.prv.suse.net"
     additional_network = "192.168.110.0/24"

--- a/terracumber_config/tf_files/tfvars/PR-testing-additionnal-repos.tf
+++ b/terracumber_config/tf_files/tfvars/PR-testing-additionnal-repos.tf
@@ -29,15 +29,6 @@ locals {
     suse-minion = {
       tools_update_pr = "${var.SLE_CLIENT_REPO}"
     }
-    kvm-host = {
-      client_repo = "${var.OPENSUSE_CLIENT_REPO}"
-      // master_sumaform_tools_repo = "${var.MASTER_SUMAFORM_TOOLS_REPO}"
-      test_packages_repo = "${var.TEST_PACKAGES_REPO}"
-      non_os_pool = "http://${var.MIRROR}/distribution/leap/15.5/repo/non-oss/"
-      os_pool = "http://${var.MIRROR}/distribution/leap/15.5/repo/oss/"
-      os_update = "${var.UPDATE_REPO}"
-      os_additional_repo = "${var.ADDITIONAL_REPO_URL}"
-    }
   } : {
     server = {
       pull_request_repo = "${var.PULL_REQUEST_REPO}"
@@ -46,9 +37,6 @@ locals {
       pull_request_repo = "${var.PULL_REQUEST_REPO}"
     }
     suse-minion = {
-      tools_update_pr = "${var.SLE_CLIENT_REPO}"
-    }
-    kvm-host = {
       tools_update_pr = "${var.SLE_CLIENT_REPO}"
     }
   }


### PR DESCRIPTION
Not removing it from the test projects since those could test 4.3 still. Each squad should decide what to do with it.