### PR TITLE
Modify debian11 salt shaker pipeline execution schedule

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian11-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian11-bundle
@@ -4,7 +4,7 @@ node('salt-shaker-tests') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '3')),
         disableConcurrentBuilds(),
-        pipelineTriggers([cron('H 0 * * *')]),
+        pipelineTriggers([cron('H 5 * * *')]),
         parameters([
             choice(name: 'salt_flavor', choices: ['bundle'], description: 'Run testsuite for classic Salt or Salt Bundle'),
             booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),


### PR DESCRIPTION
In an attempt to narrow down the failure of the debian11 execution pipeline, we can modify the default execution schedule. If the pipeline still fails, this excludes CI machine failures due to maintenance windows.