### PR TITLE
Add support for Ubuntu 24.04 in BV

### DIFF
--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -13,7 +13,7 @@ node('sumaform-cucumber') {
             'liberty9_minion, liberty9_sshminion, ' +
             'oracle9_minion, oracle9_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
-            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ' +
             'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
             'opensuse155arm_minion, opensuse155arm_sshminion, ' +
             'opensuse156arm_minion, opensuse156arm_sshminion, ' +

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -13,7 +13,7 @@ node('sumaform-cucumber-provo') {
             'liberty9_minion, liberty9_sshminion, ' +
             'oracle9_minion, oracle9_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
-            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ' +
             'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
             'opensuse155arm_minion, opensuse155arm_sshminion, ' +
             'opensuse156arm_minion, opensuse156arm_sshminion, ' +

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -12,7 +12,7 @@ node('sumaform-cucumber') {
             'centos7_minion, centos7_sshminion, ' +
             'oracle9_minion, oracle9_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
-            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ' +
             'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
             'opensuse155arm_minion, opensuse155arm_sshminion, ' +
             'opensuse156arm_minion, opensuse156arm_sshminion, ' +

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -12,7 +12,7 @@ node('sumaform-cucumber-provo') {
             'centos7_minion, centos7_sshminion, ' +
             'oracle9_minion, oracle9_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, ' +
-            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ' +
+            'ubuntu2004_minion, ubuntu2004_sshminion, ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ' +
             'debian11_minion, debian11_sshminion, debian12_minion, debian12_sshminion, ' +
             'opensuse155arm_minion, opensuse155arm_sshminion, ' +
             'opensuse156arm_minion, opensuse156arm_sshminion, ' +

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -63,6 +63,7 @@ v43_client_tools: dict[str, set[str]] = {
     "alma8_minion": {"/SUSE_Updates_RES_8-CLIENT-TOOLS_x86_64/"},
     "ubuntu2004_minion": {"/SUSE_Updates_Ubuntu_20.04-CLIENT-TOOLS_x86_64/"},
     "ubuntu2204_minion": {"/SUSE_Updates_Ubuntu_22.04-CLIENT-TOOLS_x86_64/"},
+    # no Ubuntu 24.04 on 4.3
     "debian11_minion": {"/SUSE_Updates_Debian_11-CLIENT-TOOLS_x86_64/"},
     "debian12_minion": {"/SUSE_Updates_Debian_12-CLIENT-TOOLS_x86_64/"},
     "opensuse154arm_minion": {"/SUSE_Updates_openSUSE-SLE_15.4/",
@@ -122,6 +123,8 @@ v50_client_tools_beta: dict[str, set[str]] = {
     "alma8_minion": {"/SUSE_Updates_RES_8-CLIENT-TOOLS-BETA_x86_64/"},
     "ubuntu2004_minion": {"/SUSE_Updates_Ubuntu_20.04-CLIENT-TOOLS-BETA_x86_64/"},
     "ubuntu2204_minion": {"/SUSE_Updates_Ubuntu_22.04-CLIENT-TOOLS-BETA_x86_64/"},
+    "ubuntu2404_minion": {"/SUSE_Updates_Ubuntu_24.04-CLIENT-TOOLS-BETA_x86_64/",
+                          "/SUSE_Updates_Ubuntu_24.04-CLIENT-TOOLS_x86_64/"},
     "debian11_minion": {"/SUSE_Updates_Debian_11-CLIENT-TOOLS-BETA_x86_64/"},
     "debian12_minion": {"/SUSE_Updates_Debian_12-CLIENT-TOOLS-BETA_x86_64/"},
     "opensuse154arm_minion": {"/SUSE_Updates_SLE-Manager-Tools_15-BETA_aarch64/"},

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -541,6 +541,27 @@ module "ubuntu2204_minion" {
   install_salt_bundle = true
 }
 
+module "ubuntu2404_minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "5.0-released"
+  name               = "ubuntu2404-minion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:6d"
+    memory             = 4096
+  }
+  server_configuration = {
+    hostname = "suma-bv-50-proxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
 module "debian11_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
@@ -1071,6 +1092,23 @@ module "ubuntu2204_sshminion" {
   image              = "ubuntu2204o"
   provider_settings = {
     mac                = "aa:b2:92:42:00:8b"
+    memory             = 4096
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "ubuntu2404_sshminion" {
+  source             = "./modules/sshminion"
+  base_configuration = module.base_core.configuration
+  product_version    = "5.0-released"
+  name               = "ubuntu2404-sshminion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:92:42:00:8d"
     memory             = 4096
   }
   use_os_released_updates = false

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
+  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -262,7 +262,7 @@ module "base_debian" {
   name_prefix = "suma-bv-50-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o" ]
+  images      = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -735,6 +735,30 @@ module "ubuntu2204_minion" {
   install_salt_bundle = true
 }
 
+module "ubuntu2404_minion" {
+  providers = {
+    libvirt = libvirt.trantor
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_debian.configuration
+  product_version    = "5.0-released"
+  name               = "ubuntu2404-minion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:92:05:00:1d"
+    memory             = 4096
+  }
+  server_configuration = {
+    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
 module "debian11_minion" {
   providers = {
     libvirt = libvirt.trantor
@@ -1334,6 +1358,26 @@ module "ubuntu2204_sshminion" {
   image              = "ubuntu2204o"
   provider_settings = {
     mac                = "aa:b2:92:05:00:3b"
+    memory             = 4096
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+
+  additional_packages = [ "venv-salt-minion" ]
+  install_salt_bundle = true
+}
+
+module "ubuntu2404_sshminion" {
+  providers = {
+    libvirt = libvirt.trantor
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_debian.configuration
+  product_version    = "5.0-released"
+  name               = "ubuntu2404-sshminion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:92:05:00:3d"
     memory             = 4096
   }
   use_os_released_updates = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -510,6 +510,24 @@ module "ubuntu2204_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "ubuntu2404_minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base_core.configuration
+  product_version    = "uyuni-master"
+  name               = "ubuntu2404-minion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:bd"
+    memory             = 4096
+  }
+  server_configuration = {
+    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "debian11_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
@@ -984,6 +1002,20 @@ module "ubuntu2204_sshminion" {
   image              = "ubuntu2204o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:db"
+    memory             = 4096
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "ubuntu2404_sshminion" {
+  source             = "./modules/sshminion"
+  base_configuration = module.base_core.configuration
+  product_version    = "uyuni-master"
+  name               = "ubuntu2404-sshminion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:93:02:01:dd"
     memory             = 4096
   }
   use_os_released_updates = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -115,7 +115,7 @@ module "base_core" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
+  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -700,6 +700,27 @@ module "ubuntu2204_minion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
 
+module "ubuntu2404_minion" {
+  providers = {
+    libvirt = libvirt.caipirinha
+  }
+  source             = "./modules/minion"
+  base_configuration = module.base_debian.configuration
+  product_version    = "uyuni-master"
+  name               = "ubuntu2404-minion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:93:04:05:89"
+    memory             = 4096
+  }
+  server_configuration = {
+    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
+  }
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
 module "debian11_minion" {
   providers = {
     libvirt = libvirt.caipirinha
@@ -1241,6 +1262,23 @@ module "ubuntu2204_sshminion" {
   image              = "ubuntu2204o"
   provider_settings = {
     mac                = "aa:b2:93:04:05:a7"
+    memory             = 4096
+  }
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+}
+
+module "ubuntu2404_sshminion" {
+  providers = {
+    libvirt = libvirt.caipirinha
+  }
+  source             = "./modules/sshminion"
+  base_configuration = module.base_debian.configuration
+  product_version    = "uyuni-master"
+  name               = "ubuntu2404-sshminion"
+  image              = "ubuntu2404o"
+  provider_settings = {
+    mac                = "aa:b2:93:04:05:a9"
     memory             = 4096
   }
   use_os_released_updates = false

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -262,7 +262,7 @@ module "base_debian" {
   name_prefix = "uyuni-bv-master-"
   use_avahi   = false
   domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2004o", "ubuntu2204o", "debian11o", "debian12o" ]
+  images      = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
 
   mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true


### PR DESCRIPTION
This PR adds support for Ubuntu 24.04. Part of SUSE/spacewalk#23851.

Continuation of #1354 (Dominik absent)

Note: there is no ubuntu 24.04 support on 4.3.
