### PR TITLE
Increase main disk size for uyuni BVs

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -177,7 +177,7 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
-  main_disk_size        = 20
+  main_disk_size        = 40
   repository_disk_size  = 3072
   database_disk_size    = 150
 

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -323,7 +323,7 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-  main_disk_size        = 20
+  main_disk_size        = 40
   repository_disk_size  = 3072
   database_disk_size    = 150
 


### PR DESCRIPTION
## Context

Repo synchronization is failing for uyuni BV because of disk space shortage.

```bash
uyuni-bv-master-server:/var/lib/containers/storage # df -h
Filesystem                                   Size  Used Avail Use% Mounted on
devtmpfs                                     4.0M  4.0K  4.0M   1% /dev
tmpfs                                         20G   92K   20G   1% /dev/shm
tmpfs                                        7.9G  1.2M  7.9G   1% /run
tmpfs                                        4.0M     0  4.0M   0% /sys/fs/cgroup
/dev/vda3                                     15G  2.0G   13G  14% /
/dev/vda3                                     15G  2.0G   13G  14% /root
/dev/vda4                                    5.1G  4.6G  106M  98% /var
overlay                                      5.1G  4.6G  106M  98% /etc
tmpfs                                         20G  1.1M   20G   1% /tmp
/dev/vda2                                     20M  3.0M   17M  15% /boot/efi
/dev/vda3                                     15G  2.0G   13G  14% /.snapshots
/dev/vda3                                     15G  2.0G   13G  14% /boot/grub2/i386-pc
/dev/vda3                                     15G  2.0G   13G  14% /boot/grub2/x86_64-efi
/dev/vda3                                     15G  2.0G   13G  14% /boot/writable
/dev/vda3                                     15G  2.0G   13G  14% /home
/dev/vda3                                     15G  2.0G   13G  14% /opt
/dev/vda3                                     15G  2.0G   13G  14% /srv
/dev/vda3                                     15G  2.0G   13G  14% /usr/local
overlay                                      5.1G  4.6G  106M  98% /var/lib/overlay/1/sync/etc
/dev/vdb1                                    3.0T  250G  2.6T   9% /srv/spacewalk_storage
/dev/vdc1                                    147G   30G  110G  22% /srv/pgsql_storage
minima-mirror-ci-bv.mgr.suse.de:/srv/mirror  5.9T  2.9T  3.1T  49% /srv/mirror
overlay                                      5.1G  4.6G  106M  98% /var/lib/containers/storage/overlay/529c2e95e225e8166ba8d8b8b3ffb1cb6ccacc0cb76188599da179bc08d1b012/merged
```
```bash
uyuni-bv-master-server:/var/lib/containers/storage # lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
vda    253:0    0   20G  0 disk 
├─vda1 253:1    0    2M  0 part 
├─vda2 253:2    0   20M  0 part /boot/efi
├─vda3 253:3    0   15G  0 part /usr/local
│                               /srv
│                               /opt
│                               /home
│                               /boot/writable
│                               /boot/grub2/x86_64-efi
│                               /boot/grub2/i386-pc
│                               /.snapshots
│                               /root
│                               /
└─vda4 253:4    0    5G  0 part /var/lib/containers/storage/overlay
                                /var
vdb    253:16   0    3T  0 disk 
└─vdb1 253:17   0    3T  0 part /srv/spacewalk_storage
vdc    253:32   0  150G  0 disk 
└─vdc1 253:33   0  150G  0 part /srv/pgsql_storage
```

This shortage is explained because the host storage and default container data are sharing the same disk ( 20 Go ). I can see that the host is taking about 15 GB space and so only 5 GB is left for the container space ( excluding var-spacewalk and var-pgsql ).

## Solution

Increase the main disk to give enough space for the host and the container default storage. I want 20 GB for the container and 20 GB for the host
