### PR TITLE
Remove unuse references to venv-salt package and use sperate disks for server for 5.0 BVs

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -175,9 +175,11 @@ module "server_containerized" {
     vcpu               = 10
     data_pool          = "ssd"
   }
-  main_disk_size = 3000
   runtime = "podman"
   container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile"
+  main_disk_size        = 40
+  repository_disk_size  = 3072
+  database_disk_size    = 150
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.suse.de"
   java_debugging                 = false

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -236,9 +236,6 @@ module "sles12sp5_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp2_minion" {
@@ -258,9 +255,6 @@ module "sles15sp2_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp3_minion" {
@@ -280,9 +274,6 @@ module "sles15sp3_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp4_minion" {
@@ -302,9 +293,6 @@ module "sles15sp4_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5_minion" {
@@ -324,9 +312,6 @@ module "sles15sp5_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp6_minion" {
@@ -346,9 +331,6 @@ module "sles15sp6_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma8_minion" {
@@ -367,9 +349,6 @@ module "alma8_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_minion" {
@@ -388,9 +367,6 @@ module "alma9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_minion" {
@@ -409,9 +385,6 @@ module "centos7_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "liberty9_minion" {
@@ -430,9 +403,6 @@ module "liberty9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_minion" {
@@ -451,9 +421,6 @@ module "oracle9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_minion" {
@@ -472,9 +439,6 @@ module "rocky8_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_minion" {
@@ -493,9 +457,6 @@ module "rocky9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_minion" {
@@ -514,10 +475,6 @@ module "ubuntu2004_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_minion" {
@@ -536,9 +493,6 @@ module "ubuntu2204_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2404_minion" {
@@ -557,9 +511,6 @@ module "ubuntu2404_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian11_minion" {
@@ -579,9 +530,6 @@ module "debian11_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian12_minion" {
@@ -601,9 +549,6 @@ module "debian12_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_minion" {
@@ -628,9 +573,6 @@ module "opensuse155arm_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse156arm_minion" {
@@ -655,9 +597,6 @@ module "opensuse156arm_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5s390_minion" {
@@ -677,10 +616,8 @@ module "sles15sp5s390_minion" {
 
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
+
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
 // dedicated to testing migration from OS Salt to Salt bundle
 module "salt_migration_minion" {
@@ -856,9 +793,6 @@ module "sles12sp5_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp2_sshminion" {
@@ -873,9 +807,6 @@ module "sles15sp2_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp3_sshminion" {
@@ -890,9 +821,6 @@ module "sles15sp3_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp4_sshminion" {
@@ -907,9 +835,6 @@ module "sles15sp4_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5_sshminion" {
@@ -924,9 +849,6 @@ module "sles15sp5_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp6_sshminion" {
@@ -941,9 +863,6 @@ module "sles15sp6_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma8_sshminion" {
@@ -958,9 +877,6 @@ module "alma8_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_sshminion" {
@@ -975,9 +891,6 @@ module "alma9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_sshminion" {
@@ -992,9 +905,6 @@ module "centos7_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 
@@ -1010,9 +920,6 @@ module "liberty9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_sshminion" {
@@ -1027,9 +934,6 @@ module "oracle9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_sshminion" {
@@ -1044,9 +948,6 @@ module "rocky8_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_sshminion" {
@@ -1061,9 +962,6 @@ module "rocky9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_sshminion" {
@@ -1078,10 +976,6 @@ module "ubuntu2004_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_sshminion" {
@@ -1096,9 +990,6 @@ module "ubuntu2204_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2404_sshminion" {
@@ -1113,9 +1004,6 @@ module "ubuntu2404_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian11_sshminion" {
@@ -1130,9 +1018,6 @@ module "debian11_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian12_sshminion" {
@@ -1147,9 +1032,6 @@ module "debian12_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_sshminion" {
@@ -1170,9 +1052,6 @@ module "opensuse155arm_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse156arm_sshminion" {
@@ -1193,9 +1072,6 @@ module "opensuse156arm_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5s390_sshminion" {
@@ -1215,9 +1091,6 @@ module "sles15sp5s390_sshminion" {
 
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1233,9 +1106,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1251,9 +1121,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1269,9 +1136,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1288,8 +1152,8 @@ module "sles15sp5s390_sshminion" {
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
 //
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+//  
+//
 //}
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1305,8 +1169,8 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+//  
+//
 //}
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1322,8 +1186,8 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+//  
+//
 //}
 
 module "sles12sp5_buildhost" {
@@ -1344,8 +1208,8 @@ module "sles12sp5_buildhost" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+  
+
 }
 
 module "sles12sp5_terminal" {
@@ -1381,8 +1245,7 @@ module "sles15sp4_buildhost" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
+
 }
 
 module "sles15sp4_terminal" {
@@ -1434,9 +1297,6 @@ module "monitoring_server" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -321,9 +321,12 @@ module "server_containerized" {
     vcpu               = 10
     data_pool          = "ssd"
   }
-  main_disk_size = 3000
+
   runtime = "podman"
   container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile"
+  main_disk_size        = 40
+  repository_disk_size  = 3072
+  database_disk_size    = 150
 
   server_mounted_mirror          = "minima-mirror-ci-bv.mgr.prv.suse.net"
   java_debugging                 = false
@@ -388,9 +391,6 @@ module "sles12sp5_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp2_minion" {
@@ -413,9 +413,6 @@ module "sles15sp2_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp3_minion" {
@@ -438,9 +435,6 @@ module "sles15sp3_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp4_minion" {
@@ -463,9 +457,6 @@ module "sles15sp4_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5_minion" {
@@ -488,9 +479,6 @@ module "sles15sp5_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp6_minion" {
@@ -513,9 +501,6 @@ module "sles15sp6_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma8_minion" {
@@ -537,9 +522,6 @@ module "alma8_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_minion" {
@@ -561,9 +543,6 @@ module "alma9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_minion" {
@@ -585,9 +564,6 @@ module "centos7_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "liberty9_minion" {
@@ -609,9 +585,6 @@ module "liberty9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_minion" {
@@ -633,9 +606,6 @@ module "oracle9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_minion" {
@@ -657,9 +627,6 @@ module "rocky8_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_minion" {
@@ -681,9 +648,6 @@ module "rocky9_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_minion" {
@@ -705,10 +669,6 @@ module "ubuntu2004_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_minion" {
@@ -730,9 +690,6 @@ module "ubuntu2204_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2404_minion" {
@@ -754,9 +711,6 @@ module "ubuntu2404_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian11_minion" {
@@ -779,9 +733,6 @@ module "debian11_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian12_minion" {
@@ -804,9 +755,6 @@ module "debian12_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_minion" {
@@ -831,9 +779,6 @@ module "opensuse155arm_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse156arm_minion" {
@@ -858,9 +803,6 @@ module "opensuse156arm_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5s390_minion" {
@@ -880,9 +822,6 @@ module "sles15sp5s390_minion" {
 
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
@@ -1081,9 +1020,6 @@ module "sles12sp5_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp2_sshminion" {
@@ -1101,9 +1037,6 @@ module "sles15sp2_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp3_sshminion" {
@@ -1121,9 +1054,6 @@ module "sles15sp3_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp4_sshminion" {
@@ -1141,9 +1071,6 @@ module "sles15sp4_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5_sshminion" {
@@ -1161,9 +1088,6 @@ module "sles15sp5_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp6_sshminion" {
@@ -1181,9 +1105,6 @@ module "sles15sp6_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma8_sshminion" {
@@ -1201,9 +1122,6 @@ module "alma8_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_sshminion" {
@@ -1221,9 +1139,6 @@ module "alma9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_sshminion" {
@@ -1241,9 +1156,6 @@ module "centos7_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "liberty9_sshminion" {
@@ -1261,9 +1173,6 @@ module "liberty9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_sshminion" {
@@ -1281,9 +1190,6 @@ module "oracle9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_sshminion" {
@@ -1301,9 +1207,6 @@ module "rocky8_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_sshminion" {
@@ -1321,9 +1224,6 @@ module "rocky9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_sshminion" {
@@ -1341,10 +1241,6 @@ module "ubuntu2004_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_sshminion" {
@@ -1362,9 +1258,6 @@ module "ubuntu2204_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2404_sshminion" {
@@ -1382,9 +1275,6 @@ module "ubuntu2404_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian11_sshminion" {
@@ -1402,9 +1292,6 @@ module "debian11_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "debian12_sshminion" {
@@ -1422,9 +1309,6 @@ module "debian12_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_sshminion" {
@@ -1445,9 +1329,6 @@ module "opensuse155arm_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse156arm_sshminion" {
@@ -1468,9 +1349,6 @@ module "opensuse156arm_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp5s390_sshminion" {
@@ -1490,9 +1368,6 @@ module "sles15sp5s390_sshminion" {
 
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1641,9 +1516,6 @@ module "sles12sp5_buildhost" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles12sp5_terminal" {
@@ -1684,9 +1556,6 @@ module "sles15sp4_buildhost" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "sles15sp4_terminal" {
@@ -1744,9 +1613,6 @@ module "monitoring_server" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "controller" {


### PR DESCRIPTION
## What does this PR

Align 5.0 BV pipeline to 4.3 BV pipeline.
By default, we assume that client is using the salt-bundle and so venv-salt-minion is going to be installed during cloud init and also during testsuite requirement high-state.
 - `additional_packages = ['venv-salt-minion']` value is not necessary because this package is installed by default.
 - `install_salt_bundle` is set to True by default in sumaform and should only be set when we want to use pure salt ( like for salt-migration-minion ). 
 - Use separate disk from main disk / repository / pgsql ( as recommended in documentation and done in 4.3 and uyuni )

I supposed this declaration is coming from CI example where we need to set install_salt_bundle to true because the cucumber module is setting this value to false by default. I think this behavior should also be changed.
