### PR TITLE
Dinamically select the right Rubocop version for each Ruby version

### DIFF
--- a/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
@@ -1,6 +1,17 @@
 #! /bin/bash
 
 echo "running rubocop on step files"
-rubocop.ruby2.5 -v
-cd testsuite
-rubocop.ruby2.5 features/*
+rubocop_file="testsuite/.rubocop.yml"
+if [[ -f "$rubocop_file" ]]; then
+  # Extract the Ruby version from the file
+  ruby_version=$(grep "TargetRubyVersion:" "$rubocop_file" | awk '{print $2}')
+  if [[ -n "$ruby_version" ]]; then
+    rubocop.ruby"$ruby_version" -v
+    cd testsuite
+    rubocop.ruby"$ruby_version" features/*
+  else
+    echo "No TargetRubyVersion found in $rubocop_file."
+  fi
+else
+  echo "File $rubocop_file does not exist."
+fi


### PR DESCRIPTION
Manager-4.3 branch will for now use Ruby 2.5, while on Manager-5.0 we want to start using Ruby 3.3, therefore the Rubocop version will change accordly.

It means we need to handle both versions of Rubocop and Ruby at same time.
This PR improves the Rubocop version that will be triggered depending the Ruby version targeted.