### PR TITLE
Move product_version to base level.

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-SLE-update.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLE-update.tf
@@ -89,19 +89,20 @@ provider "libvirt" {
 }
 
 module "base" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-su-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse155o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-su-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp4o", "opensuse155o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -112,7 +113,6 @@ module "base" {
 module "server" {
   source             = "./modules/server"
   base_configuration = module.base.configuration
-  product_version    = "4.3-released"
   name               = "server"
   provider_settings = {
     mac                = "aa:b2:92:05:00:f9"
@@ -148,7 +148,6 @@ module "server" {
 module "proxy" {
   source             = "./modules/proxy"
   base_configuration = module.base.configuration
-  product_version    = "4.3-released"
   name               = "proxy"
   provider_settings = {
     mac                = "aa:b2:92:05:00:fa"
@@ -176,7 +175,6 @@ module "proxy" {
 module "sles15sp4_minion" {
   source             = "./modules/minion"
   base_configuration = module.base.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp4-minion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -205,7 +203,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  product_version    = "4.3-released"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -144,6 +144,7 @@ module "base" {
   use_avahi                = false
   use_eip_bastion          = false
   is_server_paygo_instance = false
+  product_version            = "4.3-released"
   provider_settings = {
     availability_zone = var.AVAILABILITY_ZONE
     region            = var.REGION
@@ -172,7 +173,6 @@ module "server" {
     mirror = null
   })
   name                       = "server"
-  product_version            = "4.3-released"
   main_disk_size             = 200
   repository_disk_size       = 1500
   database_disk_size         = 0

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -108,19 +108,20 @@ provider "feilong" {
 }
 
 module "base_core" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.suse.de"
+  images            = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -133,20 +134,20 @@ module "base_arm" {
   providers = {
     libvirt = libvirt.suma-arm
   }
+  source            = "./modules/base"
 
-  source = "./modules/base"
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.suse.de"
+  images            = [ "opensuse155armo", "opensuse156armo" ]
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.suse.de"
-  images      = [ "opensuse155armo", "opensuse156armo" ]
-
-  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
 
-  testsuite = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -155,18 +156,17 @@ module "base_arm" {
 }
 
 module "base_s390" {
-  source = "./backend_modules/feilong/base"
+  source            = "./backend_modules/feilong/base"
 
-  name_prefix = "suma-bv-43-"
-  domain      = "mgr.suse.de"
-
-  testsuite   = true
+  name_prefix       = "suma-bv-43-"
+  domain            = "mgr.suse.de"
+  product_version   = "4.3-released"
+  testsuite         = true
 }
 
 module "server" {
   source             = "./modules/server"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "server"
   provider_settings = {
     mac                = "aa:b2:92:42:00:a1"
@@ -206,7 +206,6 @@ module "server" {
 module "proxy" {
   source             = "./modules/proxy"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "proxy"
   provider_settings = {
     mac                = "aa:b2:92:42:00:a2"
@@ -231,7 +230,6 @@ module "proxy" {
 module "sles12sp5_client" {
   source             = "./modules/client"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles12sp5-client"
   image              = "sles12sp5o"
   provider_settings = {
@@ -249,7 +247,6 @@ module "sles12sp5_client" {
 module "sles15sp2_client" {
   source             = "./modules/client"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp2-client"
   image              = "sles15sp2o"
   provider_settings = {
@@ -267,7 +264,6 @@ module "sles15sp2_client" {
 module "sles15sp3_client" {
   source             = "./modules/client"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp3-client"
   image              = "sles15sp3o"
   provider_settings = {
@@ -285,7 +281,6 @@ module "sles15sp3_client" {
 module "sles15sp4_client" {
   source             = "./modules/client"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp4-client"
   image              = "sles15sp4o"
   provider_settings = {
@@ -303,7 +298,6 @@ module "sles15sp4_client" {
 module "sles15sp5_client" {
   source             = "./modules/client"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp5-client"
   image              = "sles15sp5o"
   provider_settings = {
@@ -321,7 +315,6 @@ module "sles15sp5_client" {
 module "sles15sp6_client" {
   source             = "./modules/client"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp6-client"
   image              = "sles15sp6o"
   provider_settings = {
@@ -339,7 +332,6 @@ module "sles15sp6_client" {
 module "centos7_client" {
   source             = "./modules/client"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "centos7-client"
   image              = "centos7o"
   provider_settings = {
@@ -360,7 +352,6 @@ module "centos7_client" {
 module "sles12sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles12sp5-minion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -378,7 +369,6 @@ module "sles12sp5_minion" {
 module "sles15sp2_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp2-minion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -397,7 +387,6 @@ module "sles15sp2_minion" {
 module "sles15sp3_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp3-minion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -416,7 +405,6 @@ module "sles15sp3_minion" {
 module "sles15sp4_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp4-minion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -435,7 +423,6 @@ module "sles15sp4_minion" {
 module "sles15sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp5-minion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -454,7 +441,6 @@ module "sles15sp5_minion" {
 module "sles15sp6_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp6-minion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -473,7 +459,6 @@ module "sles15sp6_minion" {
 module "alma8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "alma8-minion"
   image              = "almalinux8o"
   provider_settings = {
@@ -494,7 +479,6 @@ module "alma8_minion" {
 module "alma9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "alma9-minion"
   image              = "almalinux9o"
   provider_settings = {
@@ -515,7 +499,6 @@ module "alma9_minion" {
 module "centos7_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "centos7-minion"
   image              = "centos7o"
   provider_settings = {
@@ -536,7 +519,6 @@ module "centos7_minion" {
 module "liberty9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "liberty9-minion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -557,7 +539,6 @@ module "liberty9_minion" {
 module "oracle9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "oracle9-minion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -578,7 +559,6 @@ module "oracle9_minion" {
 module "rocky8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "rocky8-minion"
   image              = "rocky8o"
   provider_settings = {
@@ -599,7 +579,6 @@ module "rocky8_minion" {
 module "rocky9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "rocky9-minion"
   image              = "rocky9o"
   provider_settings = {
@@ -620,7 +599,6 @@ module "rocky9_minion" {
 module "ubuntu2004_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2004-minion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -642,7 +620,6 @@ module "ubuntu2004_minion" {
 module "ubuntu2204_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2204-minion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -660,7 +637,6 @@ module "ubuntu2204_minion" {
 module "ubuntu2404_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2404-minion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -678,7 +654,6 @@ module "ubuntu2404_minion" {
 module "debian11_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "debian11-minion"
   image              = "debian11o"
   provider_settings = {
@@ -697,7 +672,6 @@ module "debian11_minion" {
 module "debian12_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "debian12-minion"
   image              = "debian12o"
   provider_settings = {
@@ -722,7 +696,7 @@ module "opensuse155arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
+
   name               = "opensuse155arm-minion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -746,7 +720,7 @@ module "opensuse156arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
+
   name               = "opensuse156arm-minion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -767,7 +741,7 @@ module "opensuse156arm_minion" {
 module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "4.3-released"
+
 
   name               = "sles15sp5s390-minion"
   image              = "s15s5-minimal-2part-xfs"
@@ -787,9 +761,8 @@ module "sles15sp5s390_minion" {
 // dedicated to testing migration from OS Salt to Salt bundle
 module "salt_migration_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  name               = "salt-migration-minion"
-  product_version    = "4.3-released"
+  base_configuration = module.base_core.configuration  name               = "salt-migration-minion"
+
   image              = "sles15sp5o"
   provider_settings  = {
     mac                = "aa:b2:92:42:00:cf"
@@ -807,8 +780,7 @@ module "salt_migration_minion" {
 
 module "slemicro51_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "slemicro51-minion"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -830,8 +802,7 @@ module "slemicro51_minion" {
 
 module "slemicro52_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "slemicro52-minion"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -853,8 +824,7 @@ module "slemicro52_minion" {
 
 module "slemicro53_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "slemicro53-minion"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -876,8 +846,7 @@ module "slemicro53_minion" {
 
 module "slemicro54_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "slemicro54-minion"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -899,8 +868,7 @@ module "slemicro54_minion" {
 
 module "slemicro55_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "slemicro55-minion"
   image              = "slemicro55o"
   provider_settings = {
@@ -922,8 +890,7 @@ module "slemicro55_minion" {
 
 module "slmicro60_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "slmicro60-minion"
   image              = "slmicro60o"
   provider_settings = {
@@ -942,8 +909,7 @@ module "slmicro60_minion" {
 
 module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles12sp5-sshminion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -958,8 +924,7 @@ module "sles12sp5_sshminion" {
 
 module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles15sp2-sshminion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -972,8 +937,7 @@ module "sles15sp2_sshminion" {
 
 module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles15sp3-sshminion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -986,8 +950,7 @@ module "sles15sp3_sshminion" {
 
 module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles15sp4-sshminion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1000,8 +963,7 @@ module "sles15sp4_sshminion" {
 
 module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles15sp5-sshminion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -1014,8 +976,7 @@ module "sles15sp5_sshminion" {
 
 module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles15sp6-sshminion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -1028,8 +989,7 @@ module "sles15sp6_sshminion" {
 
 module "alma8_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "alma8-sshminion"
   image              = "almalinux8o"
   provider_settings = {
@@ -1045,8 +1005,7 @@ module "alma8_sshminion" {
 
 module "alma9_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "alma9-sshminion"
   image              = "almalinux9o"
   provider_settings = {
@@ -1062,8 +1021,7 @@ module "alma9_sshminion" {
 
 module "centos7_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "centos7-sshminion"
   image              = "centos7o"
   provider_settings = {
@@ -1079,8 +1037,7 @@ module "centos7_sshminion" {
 
 module "liberty9_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "liberty9-sshminion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -1096,8 +1053,7 @@ module "liberty9_sshminion" {
 
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "oracle9-sshminion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -1113,8 +1069,7 @@ module "oracle9_sshminion" {
 
 module "rocky8_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "rocky8-sshminion"
   image              = "rocky8o"
   provider_settings = {
@@ -1130,8 +1085,7 @@ module "rocky8_sshminion" {
 
 module "rocky9_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "rocky9-sshminion"
   image              = "rocky9o"
   provider_settings = {
@@ -1147,8 +1101,7 @@ module "rocky9_sshminion" {
 
 module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "ubuntu2004-sshminion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1165,8 +1118,7 @@ module "ubuntu2004_sshminion" {
 
 module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "ubuntu2204-sshminion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1179,8 +1131,7 @@ module "ubuntu2204_sshminion" {
 
 module "ubuntu2404_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "ubuntu2404-sshminion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -1193,8 +1144,7 @@ module "ubuntu2404_sshminion" {
 
 module "debian11_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "debian11-sshminion"
   image              = "debian11o"
   provider_settings = {
@@ -1207,8 +1157,7 @@ module "debian11_sshminion" {
 
 module "debian12_sshminion" {
   source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "debian12-sshminion"
   image              = "debian12o"
   provider_settings = {
@@ -1228,7 +1177,7 @@ module "opensuse155arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
+
   name               = "opensuse155arm-sshminion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1248,7 +1197,7 @@ module "opensuse156arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
+
   name               = "opensuse156arm-sshminion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1265,7 +1214,7 @@ module "opensuse156arm_sshminion" {
 module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "4.3-released"
+
 
   name               = "sles15sp5s390-sshminion"
   image              = "s15s5-minimal-2part-xfs"
@@ -1284,8 +1233,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro51_sshminion" {
 //   source             = "./modules/sshminion"
-//   base_configuration = module.base_core.configuration
-//   product_version    = "4.3-released"
+// //
 //   name               = "slemicro51-sshminion"
 //   image              = "slemicro51-ign"
 //   provider_settings = {
@@ -1299,8 +1247,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro52_sshminion" {
 //   source             = "./modules/sshminion"
-//   base_configuration = module.base_core.configuration
-//   product_version    = "4.3-released"
+// //
 //   name               = "slemicro52-sshminion"
 //   image              = "slemicro52-ign"
 //   provider_settings = {
@@ -1314,8 +1261,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro53_sshminion" {
 //   source             = "./modules/sshminion"
-//   base_configuration = module.base_core.configuration
-//   product_version    = "4.3-released"
+// //
 //   name               = "slemicro53-sshminion"
 //   image              = "slemicro53-ign"
 //   provider_settings = {
@@ -1329,8 +1275,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro54_sshminion" {
 //   source             = "./modules/sshminion"
-//   base_configuration = module.base_core.configuration
-//   product_version    = "4.3-released"
+// //
 //   name               = "slemicro54-sshminion"
 //   image              = "slemicro54-ign"
 //   provider_settings = {
@@ -1344,8 +1289,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro55_sshminion" {
 //   source             = "./modules/sshminion"
-//   base_configuration = module.base_core.configuration
-//   product_version    = "4.3-released"
+// //
 //   name               = "slemicro55-sshminion"
 //   image              = "slemicro55o"
 //   provider_settings = {
@@ -1359,8 +1303,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slmicro60_sshminion" {
 //   source             = "./modules/sshminion"
-//   base_configuration = module.base_core.configuration
-//   product_version    = "4.3-released"
+// //
 //   name               = "slmicro60-sshminion"
 //   image              = "slmicro60o"
 //   provider_settings = {
@@ -1373,8 +1316,7 @@ module "sles15sp5s390_sshminion" {
 
 module "sles12sp5_buildhost" {
   source             = "./modules/build_host"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles12sp5-build"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1407,8 +1349,7 @@ module "sles12sp5_terminal" {
 
 module "sles15sp4_buildhost" {
   source             = "./modules/build_host"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "sles15sp4-build"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1441,8 +1382,7 @@ module "sles15sp4_terminal" {
 
 module "monitoring_server" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
+
   name               = "monitoring"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1467,7 +1407,6 @@ module "controller" {
     memory             = 16384
     vcpu               = 8
   }
-  product_version    = "4.3-released"
   swap_file_size = null
   catch_timeout_message = false
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -696,7 +696,6 @@ module "opensuse155arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-
   name               = "opensuse155arm-minion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -720,7 +719,6 @@ module "opensuse156arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-
   name               = "opensuse156arm-minion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -741,8 +739,6 @@ module "opensuse156arm_minion" {
 module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-
-
   name               = "sles15sp5s390-minion"
   image              = "s15s5-minimal-2part-xfs"
 
@@ -761,8 +757,8 @@ module "sles15sp5s390_minion" {
 // dedicated to testing migration from OS Salt to Salt bundle
 module "salt_migration_minion" {
   source             = "./modules/minion"
-  base_configuration = module.base_core.configuration  name               = "salt-migration-minion"
-
+  base_configuration = module.base_core.configuration
+  name               = "salt-migration-minion"
   image              = "sles15sp5o"
   provider_settings  = {
     mac                = "aa:b2:92:42:00:cf"
@@ -780,7 +776,7 @@ module "salt_migration_minion" {
 
 module "slemicro51_minion" {
   source             = "./modules/minion"
-
+  base_configuration = module.base_core.configuration
   name               = "slemicro51-minion"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -802,7 +798,7 @@ module "slemicro51_minion" {
 
 module "slemicro52_minion" {
   source             = "./modules/minion"
-
+  base_configuration = module.base_core.configuration
   name               = "slemicro52-minion"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -824,7 +820,7 @@ module "slemicro52_minion" {
 
 module "slemicro53_minion" {
   source             = "./modules/minion"
-
+  base_configuration = module.base_core.configuration
   name               = "slemicro53-minion"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -846,7 +842,7 @@ module "slemicro53_minion" {
 
 module "slemicro54_minion" {
   source             = "./modules/minion"
-
+  base_configuration = module.base_core.configuration
   name               = "slemicro54-minion"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -868,7 +864,7 @@ module "slemicro54_minion" {
 
 module "slemicro55_minion" {
   source             = "./modules/minion"
-
+  base_configuration = module.base_core.configuration
   name               = "slemicro55-minion"
   image              = "slemicro55o"
   provider_settings = {
@@ -890,7 +886,7 @@ module "slemicro55_minion" {
 
 module "slmicro60_minion" {
   source             = "./modules/minion"
-
+  base_configuration = module.base_core.configuration
   name               = "slmicro60-minion"
   image              = "slmicro60o"
   provider_settings = {
@@ -909,7 +905,7 @@ module "slmicro60_minion" {
 
 module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "sles12sp5-sshminion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -924,7 +920,7 @@ module "sles12sp5_sshminion" {
 
 module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "sles15sp2-sshminion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -937,7 +933,7 @@ module "sles15sp2_sshminion" {
 
 module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "sles15sp3-sshminion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -950,7 +946,7 @@ module "sles15sp3_sshminion" {
 
 module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "sles15sp4-sshminion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -963,7 +959,7 @@ module "sles15sp4_sshminion" {
 
 module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "sles15sp5-sshminion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -976,7 +972,7 @@ module "sles15sp5_sshminion" {
 
 module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "sles15sp6-sshminion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -989,7 +985,7 @@ module "sles15sp6_sshminion" {
 
 module "alma8_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "alma8-sshminion"
   image              = "almalinux8o"
   provider_settings = {
@@ -1005,7 +1001,7 @@ module "alma8_sshminion" {
 
 module "alma9_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "alma9-sshminion"
   image              = "almalinux9o"
   provider_settings = {
@@ -1021,7 +1017,7 @@ module "alma9_sshminion" {
 
 module "centos7_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "centos7-sshminion"
   image              = "centos7o"
   provider_settings = {
@@ -1037,7 +1033,7 @@ module "centos7_sshminion" {
 
 module "liberty9_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "liberty9-sshminion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -1053,7 +1049,7 @@ module "liberty9_sshminion" {
 
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "oracle9-sshminion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -1069,7 +1065,7 @@ module "oracle9_sshminion" {
 
 module "rocky8_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "rocky8-sshminion"
   image              = "rocky8o"
   provider_settings = {
@@ -1085,7 +1081,7 @@ module "rocky8_sshminion" {
 
 module "rocky9_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "rocky9-sshminion"
   image              = "rocky9o"
   provider_settings = {
@@ -1101,7 +1097,7 @@ module "rocky9_sshminion" {
 
 module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "ubuntu2004-sshminion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1118,7 +1114,7 @@ module "ubuntu2004_sshminion" {
 
 module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "ubuntu2204-sshminion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1131,7 +1127,7 @@ module "ubuntu2204_sshminion" {
 
 module "ubuntu2404_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "ubuntu2404-sshminion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -1144,7 +1140,7 @@ module "ubuntu2404_sshminion" {
 
 module "debian11_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "debian11-sshminion"
   image              = "debian11o"
   provider_settings = {
@@ -1157,7 +1153,7 @@ module "debian11_sshminion" {
 
 module "debian12_sshminion" {
   source             = "./modules/sshminion"
-
+  base_configuration = module.base_core.configuration
   name               = "debian12-sshminion"
   image              = "debian12o"
   provider_settings = {
@@ -1177,7 +1173,6 @@ module "opensuse155arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-
   name               = "opensuse155arm-sshminion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1197,7 +1192,6 @@ module "opensuse156arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-
   name               = "opensuse156arm-sshminion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1214,8 +1208,6 @@ module "opensuse156arm_sshminion" {
 module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-
-
   name               = "sles15sp5s390-sshminion"
   image              = "s15s5-minimal-2part-xfs"
 
@@ -1233,7 +1225,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro51_sshminion" {
 //   source             = "./modules/sshminion"
-// //
+//   base_configuration = module.base_core.configuration
 //   name               = "slemicro51-sshminion"
 //   image              = "slemicro51-ign"
 //   provider_settings = {
@@ -1247,7 +1239,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro52_sshminion" {
 //   source             = "./modules/sshminion"
-// //
+//   base_configuration = module.base_core.configuration
 //   name               = "slemicro52-sshminion"
 //   image              = "slemicro52-ign"
 //   provider_settings = {
@@ -1261,7 +1253,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro53_sshminion" {
 //   source             = "./modules/sshminion"
-// //
+//   base_configuration = module.base_core.configuration
 //   name               = "slemicro53-sshminion"
 //   image              = "slemicro53-ign"
 //   provider_settings = {
@@ -1275,7 +1267,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro54_sshminion" {
 //   source             = "./modules/sshminion"
-// //
+//   base_configuration = module.base_core.configuration
 //   name               = "slemicro54-sshminion"
 //   image              = "slemicro54-ign"
 //   provider_settings = {
@@ -1289,7 +1281,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slemicro55_sshminion" {
 //   source             = "./modules/sshminion"
-// //
+//   base_configuration = module.base_core.configuration
 //   name               = "slemicro55-sshminion"
 //   image              = "slemicro55o"
 //   provider_settings = {
@@ -1303,7 +1295,7 @@ module "sles15sp5s390_sshminion" {
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
 // module "slmicro60_sshminion" {
 //   source             = "./modules/sshminion"
-// //
+//   base_configuration = module.base_core.configuration
 //   name               = "slmicro60-sshminion"
 //   image              = "slmicro60o"
 //   provider_settings = {
@@ -1316,7 +1308,7 @@ module "sles15sp5s390_sshminion" {
 
 module "sles12sp5_buildhost" {
   source             = "./modules/build_host"
-
+  base_configuration = module.base_core.configuration
   name               = "sles12sp5-build"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1349,7 +1341,7 @@ module "sles12sp5_terminal" {
 
 module "sles15sp4_buildhost" {
   source             = "./modules/build_host"
-
+  base_configuration = module.base_core.configuration
   name               = "sles15sp4-build"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1382,7 +1374,7 @@ module "sles15sp4_terminal" {
 
 module "monitoring_server" {
   source             = "./modules/minion"
-
+  base_configuration = module.base_core.configuration
   name               = "monitoring"
   image              = "sles15sp4o"
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -128,16 +128,17 @@ provider "feilong" {
 }
 
 module "base_core" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse155o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp4o", "opensuse155o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
   testsuite          = true
@@ -154,19 +155,20 @@ module "base_old_sle" {
     libvirt = libvirt.endor
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles12sp5o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -179,19 +181,20 @@ module "base_res" {
     libvirt = libvirt.endor
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -204,19 +207,20 @@ module "base_new_sle" {
     libvirt = libvirt.moscowmule
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55o", "slmicro60o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign" , "slemicro54-ign", "slemicro55o", "slmicro60o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "default"
@@ -229,19 +233,20 @@ module "base_retail" {
     libvirt = libvirt.coruscant
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o", "sles15sp3o", "sles15sp4o"]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o"]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -255,19 +260,20 @@ module "base_debian" {
     libvirt = libvirt.mandalore
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404", "debian11o", "debian12o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404", "debian11o", "debian12o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -280,19 +286,20 @@ module "base_arm" {
     libvirt = libvirt.suma-arm
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-43-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "opensuse155armo", "opensuse156armo" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "4.3-released"
+  name_prefix       = "suma-bv-43-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "opensuse155armo", "opensuse156armo" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -301,18 +308,18 @@ module "base_arm" {
 }
 
 module "base_s390" {
-  source = "./backend_modules/feilong/base"
+  source            = "./backend_modules/feilong/base"
 
-  name_prefix = "suma-bv-43-"
-  domain      = "mgr.prv.suse.net"
+  name_prefix       = "suma-bv-43-"
+  domain            = "mgr.prv.suse.net"
+  product_version   = "4.3-released"
 
-  testsuite   = true
+  testsuite         = true
 }
 
 module "server" {
   source             = "./modules/server"
   base_configuration = module.base_core.configuration
-  product_version    = "4.3-released"
   name               = "server"
   provider_settings = {
     mac                = "aa:b2:92:05:00:a1"
@@ -355,7 +362,6 @@ module "proxy" {
   }
   source             = "./modules/proxy"
   base_configuration = module.base_retail.configuration
-  product_version    = "4.3-released"
   name               = "proxy"
   provider_settings = {
     mac                = "aa:b2:92:05:00:a2"
@@ -383,7 +389,6 @@ module "sle12sp5_client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles12sp5-client"
   image              = "sles12sp5o"
   provider_settings = {
@@ -404,7 +409,6 @@ module "sle15sp2_client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp2-client"
   image              = "sles15sp2o"
   provider_settings = {
@@ -425,7 +429,6 @@ module "sle15sp3_client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp3-client"
   image              = "sles15sp3o"
   provider_settings = {
@@ -446,7 +449,6 @@ module "sle15sp4_client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp4-client"
   image              = "sles15sp4o"
   provider_settings = {
@@ -467,7 +469,6 @@ module "sle15sp5_client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp5-client"
   image              = "sles15sp5o"
   provider_settings = {
@@ -488,7 +489,6 @@ module "sle15sp6_client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp6-client"
   image              = "sles15sp6o"
   provider_settings = {
@@ -509,7 +509,6 @@ module "centos7_client" {
   }
   source             = "./modules/client"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "centos7-client"
   image              = "centos7o"
   provider_settings = {
@@ -533,7 +532,6 @@ module "sle12sp5_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles12sp5-minion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -554,7 +552,6 @@ module "sle15sp2_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp2-minion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -576,7 +573,6 @@ module "sle15sp3_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp3-minion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -598,7 +594,6 @@ module "sle15sp4_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp4-minion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -620,7 +615,6 @@ module "sle15sp5_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp5-minion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -642,7 +636,6 @@ module "sle15sp6_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp6-minion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -664,7 +657,6 @@ module "alma8_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "alma8-minion"
   image              = "almalinux8o"
   provider_settings = {
@@ -688,7 +680,6 @@ module "alma9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "alma9-minion"
   image              = "almalinux9o"
   provider_settings = {
@@ -712,7 +703,6 @@ module "centos7_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "centos7-minion"
   image              = "centos7o"
   provider_settings = {
@@ -736,7 +726,6 @@ module "liberty9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "liberty9-minion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -760,7 +749,6 @@ module "oracle9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "oracle9-minion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -784,7 +772,6 @@ module "rocky8_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "rocky8-minion"
   image              = "rocky8o"
   provider_settings = {
@@ -808,7 +795,6 @@ module "rocky9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "rocky9-minion"
   image              = "rocky9o"
   provider_settings = {
@@ -832,7 +818,6 @@ module "ubuntu2004_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2004-minion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -857,7 +842,6 @@ module "ubuntu2204_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2204-minion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -878,7 +862,6 @@ module "ubuntu2404_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2404-minion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -899,7 +882,6 @@ module "debian11_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "debian11-minion"
   image              = "debian11o"
   provider_settings = {
@@ -921,7 +903,6 @@ module "debian12_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "debian12-minion"
   image              = "debian12o"
   provider_settings = {
@@ -946,7 +927,6 @@ module "opensuse155arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
   name               = "opensuse155arm-minion-prv"
   image              = "opensuse155armo"
   provider_settings = {
@@ -970,7 +950,6 @@ module "opensuse156arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
   name               = "opensuse156arm-minion-prv"
   image              = "opensuse156armo"
   provider_settings = {
@@ -991,7 +970,6 @@ module "opensuse156arm_minion" {
 module "sle15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "4.3-released"
 
   name               = "sles15sp5s390-minion"
   image              = "s15s5-minimal-2part-xfs"
@@ -1016,7 +994,6 @@ module "salt_migration_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
   name               = "salt-migration-minion"
-  product_version    = "4.3-released"
   image              = "sles15sp5o"
   provider_settings = {
     mac                = "aa:b2:92:05:00:cf"
@@ -1038,7 +1015,6 @@ module "slemicro51_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "slemicro51-minion"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -1064,7 +1040,6 @@ module "slemicro52_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "slemicro52-minion"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -1090,7 +1065,6 @@ module "slemicro53_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "slemicro53-minion"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -1116,7 +1090,6 @@ module "slemicro54_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "slemicro54-minion"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -1142,7 +1115,6 @@ module "slemicro55_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "slemicro55-minion"
   image              = "slemicro55o"
   provider_settings = {
@@ -1168,7 +1140,6 @@ module "slmicro60_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "slmicro60-minion"
   image              = "slmicro60o"
   provider_settings = {
@@ -1191,7 +1162,6 @@ module "sle12sp5_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles12sp5-sshminion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1210,7 +1180,6 @@ module "sle15sp2_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp2-sshminion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -1227,7 +1196,6 @@ module "sle15sp3_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp3-sshminion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -1244,7 +1212,6 @@ module "sle15sp4_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp4-sshminion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1261,7 +1228,6 @@ module "sle15sp5_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp5-sshminion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -1278,7 +1244,6 @@ module "sle15sp6_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp6-sshminion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -1295,7 +1260,6 @@ module "alma8_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "alma8-sshminion"
   image              = "almalinux8o"
   provider_settings = {
@@ -1315,7 +1279,6 @@ module "alma9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "alma9-sshminion"
   image              = "almalinux9o"
   provider_settings = {
@@ -1335,7 +1298,6 @@ module "centos7_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "centos7-sshminion"
   image              = "centos7o"
   provider_settings = {
@@ -1355,7 +1317,6 @@ module "liberty9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "liberty9-sshminion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -1375,7 +1336,6 @@ module "oracle9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "oracle9-sshminion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -1395,7 +1355,6 @@ module "rocky8_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "rocky8-sshminion"
   image              = "rocky8o"
   provider_settings = {
@@ -1415,7 +1374,6 @@ module "rocky9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "4.3-released"
   name               = "rocky9-sshminion"
   image              = "rocky9o"
   provider_settings = {
@@ -1435,7 +1393,6 @@ module "ubuntu2004_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2004-sshminion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1456,7 +1413,6 @@ module "ubuntu2204_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2204-sshminion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1473,7 +1429,6 @@ module "ubuntu2404_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "ubuntu2404-sshminion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -1490,7 +1445,6 @@ module "debian11_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "debian11-sshminion"
   image              = "debian11o"
   provider_settings = {
@@ -1507,7 +1461,6 @@ module "debian12_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "4.3-released"
   name               = "debian12-sshminion"
   image              = "debian12o"
   provider_settings = {
@@ -1527,7 +1480,6 @@ module "opensuse155arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
   name               = "opensuse155arm-sshminion-prv"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1547,7 +1499,6 @@ module "opensuse156arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "4.3-released"
   name               = "opensuse156arm-sshminion-prv"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1564,7 +1515,6 @@ module "opensuse156arm_sshminion" {
 module "sle15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "4.3-released"
 
   name               = "sles15sp5s390-sshminion"
   image              = "s15s5-minimal-2part-xfs"
@@ -1587,7 +1537,6 @@ module "sle15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "4.3-released"
 //   name               = "slemicro51-sshminion"
 //   image              = "slemicro51-ign"
 //   provider_settings = {
@@ -1605,7 +1554,6 @@ module "sle15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "4.3-released"
 //   name               = "slemicro52-sshminion"
 //   image              = "slemicro52-ign"
 //   provider_settings = {
@@ -1623,7 +1571,6 @@ module "sle15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "4.3-released"
 //   name               = "slemicro53-sshminion"
 //   image              = "slemicro53-ign"
 //   provider_settings = {
@@ -1641,7 +1588,6 @@ module "sle15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "4.3-released"
 //   name               = "slemicro54-sshminion"
 //   image              = "slemicro54-ign"
 //   provider_settings = {
@@ -1659,7 +1605,6 @@ module "sle15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "4.3-released"
 //   name               = "slemicro55-sshminion"
 //   image              = "slemicro55o"
 //   provider_settings = {
@@ -1677,7 +1622,6 @@ module "sle15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "4.3-released"
 //   name               = "slmicro60-sshminion"
 //   image              = "slmicro60o"
 //   provider_settings = {
@@ -1694,7 +1638,6 @@ module "sle12sp5_buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "4.3-released"
   name               = "sles12sp5-build"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1734,7 +1677,6 @@ module "sle15sp4_buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "4.3-released"
   name               = "sles15sp4-build"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1774,7 +1716,6 @@ module "monitoring-server" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_retail.configuration
-  product_version    = "4.3-released"
   name               = "monitoring"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1801,7 +1742,6 @@ module "controller" {
   }
   swap_file_size = null
   catch_timeout_message = false
-  product_version    = "4.3-released"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update.tf
@@ -89,19 +89,20 @@ provider "libvirt" {
 }
 
 module "base" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-su-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp6o", "opensuse155o", "slemicro55o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-su-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp6o", "opensuse155o", "slemicro55o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -112,7 +113,6 @@ module "base" {
 module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base.configuration
-  product_version    = "5.0-released"
   name               = "server"
   image              = "slemicro55o"
   provider_settings = {
@@ -151,7 +151,6 @@ module "server_containerized" {
 module "proxy_containerized" {
   source             = "./modules/proxy_containerized"
   base_configuration = module.base.configuration
-  product_version    = "5.0-released"
   name               = "proxy"
   image              = "slemicro55o"
   provider_settings = {
@@ -179,7 +178,6 @@ module "proxy_containerized" {
 module "sles15sp6_minion" {
   source             = "./modules/minion"
   base_configuration = module.base.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp6-minion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -208,7 +206,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  product_version    = "5.0-released"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -108,19 +108,20 @@ provider "feilong" {
 }
 
 module "base_core" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.suse.de"
+  images            = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156armo" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -134,19 +135,20 @@ module "base_arm" {
     libvirt = libvirt.suma-arm
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.suse.de"
-  images      = [ "opensuse155armo", "opensuse156armo" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.suse.de"
+  images            = [ "opensuse155armo", "opensuse156armo" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
 
-  testsuite = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -155,18 +157,18 @@ module "base_arm" {
 }
 
 module "base_s390" {
-  source = "./backend_modules/feilong/base"
+  source            = "./backend_modules/feilong/base"
 
-  name_prefix = "suma-bv-50-"
-  domain      = "mgr.suse.de"
+  name_prefix       = "suma-bv-50-"
+  domain            = "mgr.suse.de"
+  product_version   = "5.0-released"
 
-  testsuite   = true
+  testsuite         = true
 }
 
 module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "server"
   image              = "slemicro55o"
   provider_settings = {
@@ -205,7 +207,6 @@ module "server_containerized" {
 module "proxy_containerized" {
   source             = "./modules/proxy_containerized"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "proxy"
   provider_settings = {
     mac                = "aa:b2:92:42:00:52"
@@ -225,7 +226,6 @@ module "proxy_containerized" {
 module "sles12sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles12sp5-minion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -243,7 +243,6 @@ module "sles12sp5_minion" {
 module "sles15sp2_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp2-minion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -262,7 +261,6 @@ module "sles15sp2_minion" {
 module "sles15sp3_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp3-minion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -281,7 +279,6 @@ module "sles15sp3_minion" {
 module "sles15sp4_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp4-minion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -300,7 +297,6 @@ module "sles15sp4_minion" {
 module "sles15sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp5-minion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -319,7 +315,6 @@ module "sles15sp5_minion" {
 module "sles15sp6_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp6-minion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -338,7 +333,6 @@ module "sles15sp6_minion" {
 module "alma8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "alma8-minion"
   image              = "almalinux8o"
   provider_settings = {
@@ -356,7 +350,6 @@ module "alma8_minion" {
 module "alma9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "alma9-minion"
   image              = "almalinux9o"
   provider_settings = {
@@ -374,7 +367,6 @@ module "alma9_minion" {
 module "centos7_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "centos7-minion"
   image              = "centos7o"
   provider_settings = {
@@ -392,7 +384,6 @@ module "centos7_minion" {
 module "liberty9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "liberty9-minion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -410,7 +401,6 @@ module "liberty9_minion" {
 module "oracle9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "oracle9-minion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -428,7 +418,6 @@ module "oracle9_minion" {
 module "rocky8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "rocky8-minion"
   image              = "rocky8o"
   provider_settings = {
@@ -446,7 +435,6 @@ module "rocky8_minion" {
 module "rocky9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "rocky9-minion"
   image              = "rocky9o"
   provider_settings = {
@@ -464,7 +452,6 @@ module "rocky9_minion" {
 module "ubuntu2004_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2004-minion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -482,7 +469,6 @@ module "ubuntu2004_minion" {
 module "ubuntu2204_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2204-minion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -500,7 +486,6 @@ module "ubuntu2204_minion" {
 module "ubuntu2404_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2404-minion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -518,7 +503,6 @@ module "ubuntu2404_minion" {
 module "debian11_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "debian11-minion"
   image              = "debian11o"
   provider_settings = {
@@ -537,7 +521,6 @@ module "debian11_minion" {
 module "debian12_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "debian12-minion"
   image              = "debian12o"
   provider_settings = {
@@ -559,7 +542,6 @@ module "opensuse155arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse155arm-minion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -583,7 +565,6 @@ module "opensuse156arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse156arm-minion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -604,7 +585,6 @@ module "opensuse156arm_minion" {
 module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "5.0-released"
 
   name               = "sles15sp5s390-minion"
   image              = "s15s5-minimal-2part-xfs"
@@ -626,7 +606,6 @@ module "salt_migration_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   name               = "salt-migration-minion"
-  product_version    = "5.0-released"
   image              = "sles15sp5o"
   provider_settings  = {
     mac                = "aa:b2:92:42:00:7f"
@@ -645,7 +624,6 @@ module "salt_migration_minion" {
 module "slemicro51_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "slemicro51-minion"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -668,7 +646,6 @@ module "slemicro51_minion" {
 module "slemicro52_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "slemicro52-minion"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -691,7 +668,6 @@ module "slemicro52_minion" {
 module "slemicro53_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "slemicro53-minion"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -714,7 +690,6 @@ module "slemicro53_minion" {
 module "slemicro54_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "slemicro54-minion"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -737,7 +712,6 @@ module "slemicro54_minion" {
 module "slemicro55_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "slemicro55-minion"
   image              = "slemicro55o"
   provider_settings = {
@@ -760,7 +734,6 @@ module "slemicro55_minion" {
 module "slmicro60_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "slmicro60-minion"
   image              = "slmicro60o"
   provider_settings = {
@@ -784,7 +757,6 @@ module "slmicro60_minion" {
 module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles12sp5-sshminion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -800,7 +772,6 @@ module "sles12sp5_sshminion" {
 module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp2-sshminion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -814,7 +785,6 @@ module "sles15sp2_sshminion" {
 module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp3-sshminion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -828,7 +798,6 @@ module "sles15sp3_sshminion" {
 module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp4-sshminion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -842,7 +811,6 @@ module "sles15sp4_sshminion" {
 module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp5-sshminion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -856,7 +824,6 @@ module "sles15sp5_sshminion" {
 module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp6-sshminion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -870,7 +837,6 @@ module "sles15sp6_sshminion" {
 module "alma8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "alma8-sshminion"
   image              = "almalinux8o"
   provider_settings = {
@@ -884,7 +850,6 @@ module "alma8_sshminion" {
 module "alma9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "alma9-sshminion"
   image              = "almalinux9o"
   provider_settings = {
@@ -898,7 +863,6 @@ module "alma9_sshminion" {
 module "centos7_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "centos7-sshminion"
   image              = "centos7o"
   provider_settings = {
@@ -913,7 +877,6 @@ module "centos7_sshminion" {
 module "liberty9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "liberty9-sshminion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -927,7 +890,6 @@ module "liberty9_sshminion" {
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "oracle9-sshminion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -941,7 +903,6 @@ module "oracle9_sshminion" {
 module "rocky8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "rocky8-sshminion"
   image              = "rocky8o"
   provider_settings = {
@@ -955,7 +916,6 @@ module "rocky8_sshminion" {
 module "rocky9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "rocky9-sshminion"
   image              = "rocky9o"
   provider_settings = {
@@ -969,7 +929,6 @@ module "rocky9_sshminion" {
 module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2004-sshminion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -983,7 +942,6 @@ module "ubuntu2004_sshminion" {
 module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2204-sshminion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -997,7 +955,6 @@ module "ubuntu2204_sshminion" {
 module "ubuntu2404_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2404-sshminion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -1011,7 +968,6 @@ module "ubuntu2404_sshminion" {
 module "debian11_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "debian11-sshminion"
   image              = "debian11o"
   provider_settings = {
@@ -1025,7 +981,6 @@ module "debian11_sshminion" {
 module "debian12_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "debian12-sshminion"
   image              = "debian12o"
   provider_settings = {
@@ -1042,7 +997,6 @@ module "opensuse155arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse155arm-sshminion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1062,7 +1016,6 @@ module "opensuse156arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse156arm-sshminion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1079,7 +1032,6 @@ module "opensuse156arm_sshminion" {
 module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "5.0-released"
 
   name               = "sles15sp5s390-sshminion"
   image              = "s15s5-minimal-2part-xfs"
@@ -1099,7 +1051,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro51_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro51-sshminion"
 //   image              = "slemicro51-ign"
 //   provider_settings = {
@@ -1114,7 +1065,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro52_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro52-sshminion"
 //   image              = "slemicro52-ign"
 //   provider_settings = {
@@ -1129,7 +1079,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro53_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro53-sshminion"
 //   image              = "slemicro53-ign"
 //   provider_settings = {
@@ -1144,7 +1093,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro54_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro54-sshminion"
 //   image              = "slemicro54-ign"
 //   provider_settings = {
@@ -1162,7 +1110,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro55_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro55-sshminion"
 //   image              = "slemicro55o"
 //   provider_settings = {
@@ -1179,7 +1126,6 @@ module "sles15sp5s390_sshminion" {
 // module "slmicro60_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "5.0-released"
 //   name               = "slmicro60-sshminion"
 //   image              = "slmicro60o"
 //   provider_settings = {
@@ -1195,7 +1141,6 @@ module "sles15sp5s390_sshminion" {
 module "sles12sp5_buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles12sp5-build"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1232,7 +1177,6 @@ module "sles12sp5_terminal" {
 module "sles15sp4_buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp4-build"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1285,7 +1229,6 @@ module "dhcp_dns" {
 module "monitoring_server" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "monitoring"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1311,7 +1254,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  product_version    = "5.0-released"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -128,19 +128,20 @@ provider "feilong" {
 }
 
 module "base_core" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse155o", "slemicro55o", "sles15sp5o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp4o", "opensuse155o", "slemicro55o", "sles15sp5o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -154,19 +155,20 @@ module "base_old_sle" {
     libvirt = libvirt.tatooine
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles12sp5o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -179,19 +181,20 @@ module "base_res" {
     libvirt = libvirt.tatooine
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "libertylinux9o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "almalinux8o", "almalinux9o", "centos7o", "oraclelinux9o", "rocky8o", "rocky9o", "libertylinux9o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -206,17 +209,18 @@ module "base_new_sle" {
 
   source = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o"  ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o"  ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -229,19 +233,20 @@ module "base_retail" {
     libvirt = libvirt.terminus
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "opensuse155o", "opensuse156o", "slemicro55o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "opensuse155o", "opensuse156o", "slemicro55o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -255,19 +260,20 @@ module "base_debian" {
     libvirt = libvirt.trantor
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -280,19 +286,20 @@ module "base_arm" {
     libvirt = libvirt.suma-arm
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "suma-bv-50-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "opensuse155armo", "opensuse156armo" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "5.0-released"
+  name_prefix       = "suma-bv-50-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "opensuse155armo", "opensuse156armo" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -301,18 +308,18 @@ module "base_arm" {
 }
 
 module "base_s390" {
-  source = "./backend_modules/feilong/base"
+  source            = "./backend_modules/feilong/base"
 
-  name_prefix = "suma-bv-50-"
-  domain      = "mgr.prv.suse.net"
+  name_prefix       = "suma-bv-50-"
+  domain            = "mgr.prv.suse.net"
+  product_version   = "5.0-released"
 
-  testsuite   = true
+  testsuite         = true
 }
 
 module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
-  product_version    = "5.0-released"
   name               = "server"
   image              = "slemicro55o"
   provider_settings = {
@@ -355,7 +362,6 @@ module "proxy_containerized" {
   }
   source             = "./modules/proxy_containerized"
   base_configuration = module.base_retail.configuration
-  product_version    = "5.0-released"
   name               = "proxy"
   provider_settings = {
     mac                = "aa:b2:92:05:00:02"
@@ -378,7 +384,6 @@ module "sles12sp5_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "head"
   name               = "sles12sp5-minion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -399,7 +404,6 @@ module "sles15sp2_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp2-minion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -421,7 +425,6 @@ module "sles15sp3_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp3-minion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -443,7 +446,6 @@ module "sles15sp4_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp4-minion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -465,7 +467,6 @@ module "sles15sp5_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp5-minion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -487,7 +488,6 @@ module "sles15sp6_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp6-minion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -509,7 +509,6 @@ module "alma8_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "alma8-minion"
   image              = "almalinux8o"
   provider_settings = {
@@ -530,7 +529,6 @@ module "alma9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "alma9-minion"
   image              = "almalinux9o"
   provider_settings = {
@@ -551,7 +549,6 @@ module "centos7_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "centos7-minion"
   image              = "centos7o"
   provider_settings = {
@@ -572,7 +569,6 @@ module "liberty9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "liberty9-minion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -593,7 +589,6 @@ module "oracle9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "oracle9-minion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -614,7 +609,6 @@ module "rocky8_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "rocky8-minion"
   image              = "rocky8o"
   provider_settings = {
@@ -635,7 +629,6 @@ module "rocky9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "rocky9-minion"
   image              = "rocky9o"
   provider_settings = {
@@ -656,7 +649,6 @@ module "ubuntu2004_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2004-minion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -677,7 +669,6 @@ module "ubuntu2204_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2204-minion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -698,7 +689,6 @@ module "ubuntu2404_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2404-minion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -719,7 +709,6 @@ module "debian11_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "debian11-minion"
   image              = "debian11o"
   provider_settings = {
@@ -741,7 +730,6 @@ module "debian12_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "debian12-minion"
   image              = "debian12o"
   provider_settings = {
@@ -763,7 +751,6 @@ module "opensuse155arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse155arm-minion-prv"
   image              = "opensuse155armo"
   provider_settings = {
@@ -787,7 +774,6 @@ module "opensuse156arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse156arm-minion-prv"
   image              = "opensuse156armo"
   provider_settings = {
@@ -808,7 +794,6 @@ module "opensuse156arm_minion" {
 module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "5.0-released"
 
   name               = "sles15sp5s390-minion"
   image              = "s15s5-minimal-2part-xfs"
@@ -830,7 +815,6 @@ module "salt_migration_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   name               = "salt-migration-minion"
-  product_version    = "5.0-released"
   image              = "sles15sp5o"
   provider_settings  = {
     mac                = "aa:b2:92:05:00:2f"
@@ -852,7 +836,6 @@ module "slemicro51_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "slemicro51-minion"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -878,7 +861,6 @@ module "slemicro52_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "slemicro52-minion"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -904,7 +886,6 @@ module "slemicro53_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "slemicro53-minion"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -930,7 +911,6 @@ module "slemicro54_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "slemicro54-minion"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -956,7 +936,6 @@ module "slemicro55_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "slemicro55-minion"
   image              = "slemicro55o"
   provider_settings = {
@@ -982,7 +961,6 @@ module "slmicro60_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "slmicro60-minion"
   image              = "slmicro60o"
   provider_settings = {
@@ -1009,7 +987,6 @@ module "sles12sp5_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles12sp5-sshminion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1028,7 +1005,6 @@ module "sles15sp2_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp2-sshminion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -1045,7 +1021,6 @@ module "sles15sp3_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp3-sshminion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -1062,7 +1037,6 @@ module "sles15sp4_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp4-sshminion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1079,7 +1053,6 @@ module "sles15sp5_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp5-sshminion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -1096,7 +1069,6 @@ module "sles15sp6_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp6-sshminion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -1113,7 +1085,6 @@ module "alma8_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "alma8-sshminion"
   image              = "almalinux8o"
   provider_settings = {
@@ -1130,7 +1101,6 @@ module "alma9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "alma9-sshminion"
   image              = "almalinux9o"
   provider_settings = {
@@ -1147,7 +1117,6 @@ module "centos7_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "centos7-sshminion"
   image              = "centos7o"
   provider_settings = {
@@ -1164,7 +1133,6 @@ module "liberty9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "liberty9-sshminion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -1181,7 +1149,6 @@ module "oracle9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "oracle9-sshminion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -1198,7 +1165,6 @@ module "rocky8_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "rocky8-sshminion"
   image              = "rocky8o"
   provider_settings = {
@@ -1215,7 +1181,6 @@ module "rocky9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "rocky9-sshminion"
   image              = "rocky9o"
   provider_settings = {
@@ -1232,7 +1197,6 @@ module "ubuntu2004_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2004-sshminion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1249,7 +1213,6 @@ module "ubuntu2204_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2204-sshminion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1266,7 +1229,6 @@ module "ubuntu2404_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "ubuntu2404-sshminion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -1283,7 +1245,6 @@ module "debian11_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "debian11-sshminion"
   image              = "debian11o"
   provider_settings = {
@@ -1300,7 +1261,6 @@ module "debian12_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "5.0-released"
   name               = "debian12-sshminion"
   image              = "debian12o"
   provider_settings = {
@@ -1317,7 +1277,6 @@ module "opensuse155arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse155arm-sshminion-prv"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1337,7 +1296,6 @@ module "opensuse156arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "5.0-released"
   name               = "opensuse156arm-sshminion-prv"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1354,7 +1312,6 @@ module "opensuse156arm_sshminion" {
 module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "5.0-released"
 
   name               = "sles15sp5s390-sshminion"
   image              = "s15s5-minimal-2part-xfs"
@@ -1377,7 +1334,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro51-sshminion"
 //   image              = "slemicro51-ign"
 //   provider_settings = {
@@ -1398,7 +1354,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro52-sshminion"
 //   image              = "slemicro52-ign"
 //   provider_settings = {
@@ -1419,7 +1374,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro53-sshminion"
 //   image              = "slemicro53-ign"
 //   provider_settings = {
@@ -1440,7 +1394,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro54-sshminion"
 //   image              = "slemicro54-ign"
 //   provider_settings = {
@@ -1461,7 +1414,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "5.0-released"
 //   name               = "slemicro55-sshminion"
 //   image              = "slemicro55o"
 //   provider_settings = {
@@ -1482,7 +1434,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "5.0-released"
 //   name               = "slmicro60-sshminion"
 //   image              = "slmicro60o"
 //   provider_settings = {
@@ -1502,7 +1453,6 @@ module "sles12sp5_buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "5.0-released"
   name               = "sles12sp5-build"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1542,7 +1492,6 @@ module "sles15sp4_buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "5.0-released"
   name               = "sles15sp4-build"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1599,7 +1548,6 @@ module "monitoring_server" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_retail.configuration
-  product_version    = "5.0-released"
   name               = "monitoring"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1625,7 +1573,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  product_version    = "5.0-released"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -108,19 +108,20 @@ provider "feilong" {
 }
 
 module "base_core" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.suse.de"
-  images      = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.suse.de"
+  images            = [ "sles12sp5o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -134,19 +135,20 @@ module "base_arm" {
     libvirt = libvirt.suma-arm
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.suse.de"
-  images      = [ "opensuse155armo", "opensuse156armo" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.suse.de"
+  images            = [ "opensuse155armo", "opensuse156armo" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.suse.de"
+  mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
 
-  testsuite = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -157,16 +159,16 @@ module "base_arm" {
 module "base_s390" {
   source = "./backend_modules/feilong/base"
 
-  name_prefix = "uyuni-bv-master-"
-  domain      = "mgr.suse.de"
+  name_prefix       = "uyuni-bv-master-"
+  domain            = "mgr.suse.de"
+  product_version   = "uyuni-master"
 
-  testsuite   = true
+  testsuite         = true
 }
 
 module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "server"
   image              = "leapmicro55o"
   provider_settings = {
@@ -209,7 +211,6 @@ module "server_containerized" {
 module "proxy_containerized" {
   source             = "./modules/proxy_containerized"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "proxy"
   provider_settings = {
     mac                = "aa:b2:93:02:01:a2"
@@ -233,7 +234,6 @@ module "proxy_containerized" {
 module "sles12sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles12sp5-minion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -251,7 +251,6 @@ module "sles12sp5_minion" {
 module "sles15sp2_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp2-minion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -270,7 +269,6 @@ module "sles15sp2_minion" {
 module "sles15sp3_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp3-minion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -289,7 +287,6 @@ module "sles15sp3_minion" {
 module "sles15sp4_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp4-minion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -308,7 +305,6 @@ module "sles15sp4_minion" {
 module "sles15sp5_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp5-minion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -327,7 +323,6 @@ module "sles15sp5_minion" {
 module "sles15sp6_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp6-minion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -346,7 +341,6 @@ module "sles15sp6_minion" {
 module "alma8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "alma8-minion"
   image              = "almalinux8o"
   provider_settings = {
@@ -367,7 +361,6 @@ module "alma8_minion" {
 module "alma9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "alma9-minion"
   image              = "almalinux9o"
   provider_settings = {
@@ -388,7 +381,6 @@ module "alma9_minion" {
 module "centos7_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "centos7-minion"
   image              = "centos7o"
   provider_settings = {
@@ -409,7 +401,6 @@ module "centos7_minion" {
 module "liberty9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "liberty9-minion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -430,7 +421,6 @@ module "liberty9_minion" {
 module "oracle9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "oracle9-minion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -451,7 +441,6 @@ module "oracle9_minion" {
 module "rocky8_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "rocky8-minion"
   image              = "rocky8o"
   provider_settings = {
@@ -473,7 +462,6 @@ module "rocky8_minion" {
 module "rocky9_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "rocky9-minion"
   image              = "rocky9o"
   provider_settings = {
@@ -494,7 +482,6 @@ module "rocky9_minion" {
 module "ubuntu2004_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2004-minion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -516,7 +503,6 @@ module "ubuntu2004_minion" {
 module "ubuntu2204_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2204-minion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -534,7 +520,6 @@ module "ubuntu2204_minion" {
 module "ubuntu2404_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2404-minion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -552,7 +537,6 @@ module "ubuntu2404_minion" {
 module "debian11_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "debian11-minion"
   image              = "debian11o"
   provider_settings = {
@@ -571,7 +555,6 @@ module "debian11_minion" {
 module "debian12_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "debian12-minion"
   image              = "debian12o"
   provider_settings = {
@@ -596,7 +579,6 @@ module "opensuse155arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse155arm-minion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -620,7 +602,6 @@ module "opensuse156arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse156arm-minion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -641,7 +622,6 @@ module "opensuse156arm_minion" {
 module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "uyuni-master"
 
   name               = "sles15sp5s390-minion"
   image              = "s15s5-minimal-2part-xfs"
@@ -661,7 +641,6 @@ module "salt_migration_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
   name               = "salt-migration-minion"
-  product_version    = "uyuni-master"
   image              = "sles15sp5o"
   provider_settings = {
     mac                = "aa:b2:93:02:01:cf"
@@ -680,7 +659,6 @@ module "salt_migration_minion" {
 module "slemicro51_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro51-minion"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -702,7 +680,6 @@ module "slemicro51_minion" {
 module "slemicro52_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro52-minion"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -724,7 +701,6 @@ module "slemicro52_minion" {
 module "slemicro53_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro53-minion"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -746,7 +722,6 @@ module "slemicro53_minion" {
 module "slemicro54_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro54-minion"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -768,7 +743,6 @@ module "slemicro54_minion" {
 module "slemicro55_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro55-minion"
   image              = "slemicro55o"
   provider_settings = {
@@ -790,7 +764,6 @@ module "slemicro55_minion" {
 module "slmicro60_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "slmicro60-minion"
   image              = "slmicro60o"
   provider_settings = {
@@ -812,7 +785,6 @@ module "slmicro60_minion" {
 module "sles12sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles12sp5-sshminion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -828,7 +800,6 @@ module "sles12sp5_sshminion" {
 module "sles15sp2_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp2-sshminion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -842,7 +813,6 @@ module "sles15sp2_sshminion" {
 module "sles15sp3_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp3-sshminion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -856,7 +826,6 @@ module "sles15sp3_sshminion" {
 module "sles15sp4_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp4-sshminion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -870,7 +839,6 @@ module "sles15sp4_sshminion" {
 module "sles15sp5_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp5-sshminion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -884,7 +852,6 @@ module "sles15sp5_sshminion" {
 module "sles15sp6_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp6-sshminion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -898,7 +865,6 @@ module "sles15sp6_sshminion" {
 module "alma8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "alma8-sshminion"
   image              = "almalinux8o"
   provider_settings = {
@@ -915,7 +881,6 @@ module "alma8_sshminion" {
 module "alma9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "alma9-sshminion"
   image              = "almalinux9o"
   provider_settings = {
@@ -932,7 +897,6 @@ module "alma9_sshminion" {
 module "centos7_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "centos7-sshminion"
   image              = "centos7o"
   provider_settings = {
@@ -949,7 +913,6 @@ module "centos7_sshminion" {
 module "liberty9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "liberty9-sshminion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -966,7 +929,6 @@ module "liberty9_sshminion" {
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "oracle9-sshminion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -983,7 +945,6 @@ module "oracle9_sshminion" {
 module "rocky8_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "rocky8-sshminion"
   image              = "rocky8o"
   provider_settings = {
@@ -1000,7 +961,6 @@ module "rocky8_sshminion" {
 module "rocky9_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "rocky9-sshminion"
   image              = "rocky9o"
   provider_settings = {
@@ -1017,7 +977,6 @@ module "rocky9_sshminion" {
 module "ubuntu2004_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2004-sshminion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1035,7 +994,6 @@ module "ubuntu2004_sshminion" {
 module "ubuntu2204_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2204-sshminion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1049,7 +1007,6 @@ module "ubuntu2204_sshminion" {
 module "ubuntu2404_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2404-sshminion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -1063,7 +1020,6 @@ module "ubuntu2404_sshminion" {
 module "debian11_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "debian11-sshminion"
   image              = "debian11o"
   provider_settings = {
@@ -1077,7 +1033,6 @@ module "debian11_sshminion" {
 module "debian12_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "debian12-sshminion"
   image              = "debian12o"
   provider_settings = {
@@ -1097,7 +1052,6 @@ module "opensuse155arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse155arm-sshminion-nue"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1117,7 +1071,6 @@ module "opensuse156arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse156arm-sshminion-nue"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1134,7 +1087,6 @@ module "opensuse156arm_sshminion" {
 module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "uyuni-master"
 
   name               = "sles15sp5s390-sshminion"
   image              = "s15s5-minimal-2part-xfs"
@@ -1154,7 +1106,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro51_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro51-sshminion"
 //   image              = "slemicro51-ign"
 //   provider_settings = {
@@ -1169,7 +1120,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro52_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro52-sshminion"
 //   image              = "slemicro52-ign"
 //   provider_settings = {
@@ -1184,7 +1134,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro53_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro53-sshminion"
 //   image              = "slemicro53-ign"
 //   provider_settings = {
@@ -1199,7 +1148,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro54_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro54-sshminion"
 //   image              = "slemicro54-ign"
 //   provider_settings = {
@@ -1214,7 +1162,6 @@ module "sles15sp5s390_sshminion" {
 // module "slemicro55_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro55-sshminion"
 //   image              = "slemicro55o"
 //   provider_settings = {
@@ -1229,7 +1176,6 @@ module "sles15sp5s390_sshminion" {
 // module "slmicro60_sshminion" {
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_core.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slmicro60-sshminion"
 //   image              = "slmicro60o"
 //   provider_settings = {
@@ -1243,7 +1189,6 @@ module "sles15sp5s390_sshminion" {
 module "sles12sp5_buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles12sp5-build"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1278,7 +1223,6 @@ module "sles12sp5_terminal" {
 module "sles15sp4_buildhost" {
   source             = "./modules/build_host"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp4-build"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1312,7 +1256,6 @@ module "sles15sp4_terminal" {
 module "monitoring_server" {
   source             = "./modules/minion"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "monitoring"
   image              = "opensuse155o"
   provider_settings = {
@@ -1338,7 +1281,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  product_version    = "uyuni-master"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -128,19 +128,20 @@ provider "feilong" {
 }
 
 module "base_core" {
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp4o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp4o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -154,19 +155,20 @@ module "base_old_sle" {
     libvirt = libvirt.cosmopolitan
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles12sp5o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -179,19 +181,20 @@ module "base_res" {
     libvirt = libvirt.cosmopolitan
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "almalinux8o", "almalinux9o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -204,19 +207,20 @@ module "base_new_sle" {
     libvirt = libvirt.ginfizz
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles15sp2o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -229,19 +233,20 @@ module "base_retail" {
     libvirt = libvirt.margarita
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "opensuse155o", "leapmicro55o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "opensuse155o", "leapmicro55o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -255,19 +260,20 @@ module "base_debian" {
     libvirt = libvirt.caipirinha
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian11o", "debian12o" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite          = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -280,19 +286,20 @@ module "base_arm" {
     libvirt = libvirt.suma-arm
   }
 
-  source = "./modules/base"
+  source            = "./modules/base"
 
-  cc_username = var.SCC_USER
-  cc_password = var.SCC_PASSWORD
-  name_prefix = "uyuni-bv-master-"
-  use_avahi   = false
-  domain      = "mgr.prv.suse.net"
-  images      = [ "opensuse155armo", "opensuse156armo" ]
+  cc_username       = var.SCC_USER
+  cc_password       = var.SCC_PASSWORD
+  product_version   = "uyuni-master"
+  name_prefix       = "uyuni-bv-master-"
+  use_avahi         = false
+  domain            = "mgr.prv.suse.net"
+  images            = [ "opensuse155armo", "opensuse156armo" ]
 
-  mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
+  mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
 
-  testsuite = true
+  testsuite         = true
 
   provider_settings = {
     pool        = "ssd"
@@ -301,18 +308,18 @@ module "base_arm" {
 }
 
 module "base_s390" {
-  source = "./backend_modules/feilong/base"
+  source            = "./backend_modules/feilong/base"
 
-  name_prefix = "uyuni-bv-master-"
-  domain      = "mgr.prv.suse.net"
+  name_prefix       = "uyuni-bv-master-"
+  domain            = "mgr.prv.suse.net"
+  product_version   = "uyuni-master"
 
-  testsuite   = true
+  testsuite         = true
 }
 
 module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
-  product_version    = "uyuni-master"
   name               = "server"
   image              = "leapmicro55o"
   provider_settings = {
@@ -357,7 +364,6 @@ module "proxy_containerized" {
   }
   source             = "./modules/proxy_containerized"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
   name               = "proxy"
   provider_settings = {
     mac                = "aa:b2:93:04:05:6e"
@@ -384,7 +390,6 @@ module "sles12sp5_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles12sp5-minion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -405,7 +410,6 @@ module "sles15sp2_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp2-minion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -427,7 +431,6 @@ module "sles15sp3_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp3-minion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -449,7 +452,6 @@ module "sles15sp4_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp4-minion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -471,7 +473,6 @@ module "sles15sp5_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp5-minion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -493,7 +494,6 @@ module "sles15sp6_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp6-minion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -515,7 +515,6 @@ module "alma8_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "alma8-minion"
   image              = "almalinux8o"
   provider_settings = {
@@ -539,7 +538,6 @@ module "alma9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "alma9-minion"
   image              = "almalinux9o"
   provider_settings = {
@@ -563,7 +561,6 @@ module "centos7_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "centos7-minion"
   image              = "centos7o"
   provider_settings = {
@@ -587,7 +584,6 @@ module "liberty9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "liberty9-minion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -611,7 +607,6 @@ module "oracle9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "oracle9-minion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -635,7 +630,6 @@ module "rocky8_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "rocky8-minion"
   image              = "rocky8o"
   provider_settings = {
@@ -659,7 +653,6 @@ module "rocky9_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "rocky9-minion"
   image              = "rocky9o"
   provider_settings = {
@@ -683,7 +676,6 @@ module "ubuntu2004_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2004-minion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -708,7 +700,6 @@ module "ubuntu2204_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2204-minion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -729,7 +720,6 @@ module "ubuntu2404_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2404-minion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -750,7 +740,6 @@ module "debian11_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "debian11-minion"
   image              = "debian11o"
   provider_settings = {
@@ -772,7 +761,6 @@ module "debian12_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "debian12-minion"
   image              = "debian12o"
   provider_settings = {
@@ -797,7 +785,6 @@ module "opensuse155arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse155arm-minion-prv"
   image              = "opensuse155armo"
   provider_settings = {
@@ -821,7 +808,6 @@ module "opensuse156arm_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse156arm-minion-prv"
   image              = "opensuse156armo"
   provider_settings = {
@@ -842,7 +828,6 @@ module "opensuse156arm_minion" {
 module "sles15sp5s390_minion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "uyuni-master"
 
   name               = "sles15sp5s390-minion"
   image              = "s15s5-minimal-2part-xfs"
@@ -862,7 +847,6 @@ module "salt_migration_minion" {
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
   name               = "salt-migration-minion"
-  product_version    = "uyuni-master"
   image              = "sles15sp5o"
   provider_settings = {
     mac                = "aa:b2:93:04:05:9b"
@@ -885,7 +869,6 @@ module "slemicro51_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro51-minion"
   image              = "slemicro51-ign"
   provider_settings = {
@@ -910,7 +893,6 @@ module "slemicro52_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro52-minion"
   image              = "slemicro52-ign"
   provider_settings = {
@@ -935,7 +917,6 @@ module "slemicro53_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro53-minion"
   image              = "slemicro53-ign"
   provider_settings = {
@@ -960,7 +941,6 @@ module "slemicro54_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro54-minion"
   image              = "slemicro54-ign"
   provider_settings = {
@@ -985,7 +965,6 @@ module "slemicro55_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "slemicro55-minion"
   image              = "slemicro55o"
   provider_settings = {
@@ -1010,7 +989,6 @@ module "slmicro60_minion" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "slmicro60-minion"
   image              = "slmicro60o"
   provider_settings = {
@@ -1035,7 +1013,6 @@ module "sles12sp5_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_old_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles12sp5-sshminion"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1054,7 +1031,6 @@ module "sles15sp2_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp2-sshminion"
   image              = "sles15sp2o"
   provider_settings = {
@@ -1071,7 +1047,6 @@ module "sles15sp3_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp3-sshminion"
   image              = "sles15sp3o"
   provider_settings = {
@@ -1088,7 +1063,6 @@ module "sles15sp4_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp4-sshminion"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1105,7 +1079,6 @@ module "sles15sp5_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp5-sshminion"
   image              = "sles15sp5o"
   provider_settings = {
@@ -1122,7 +1095,6 @@ module "sles15sp6_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_new_sle.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp6-sshminion"
   image              = "sles15sp6o"
   provider_settings = {
@@ -1139,7 +1111,6 @@ module "alma8_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "alma8-sshminion"
   image              = "almalinux8o"
   provider_settings = {
@@ -1159,7 +1130,6 @@ module "alma9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "alma9-sshminion"
   image              = "almalinux9o"
   provider_settings = {
@@ -1179,7 +1149,6 @@ module "centos7_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "centos7-sshminion"
   image              = "centos7o"
   provider_settings = {
@@ -1199,7 +1168,6 @@ module "liberty9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "5.0-released"
   name               = "liberty9-sshminion"
   image              = "libertylinux9o"
   provider_settings = {
@@ -1219,7 +1187,6 @@ module "oracle9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "oracle9-sshminion"
   image              = "oraclelinux9o"
   provider_settings = {
@@ -1239,7 +1206,6 @@ module "rocky8_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "rocky8-sshminion"
   image              = "rocky8o"
   provider_settings = {
@@ -1259,7 +1225,6 @@ module "rocky9_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_res.configuration
-  product_version    = "uyuni-master"
   name               = "rocky9-sshminion"
   image              = "rocky9o"
   provider_settings = {
@@ -1279,7 +1244,6 @@ module "ubuntu2004_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2004-sshminion"
   image              = "ubuntu2004o"
   provider_settings = {
@@ -1300,7 +1264,6 @@ module "ubuntu2204_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2204-sshminion"
   image              = "ubuntu2204o"
   provider_settings = {
@@ -1317,7 +1280,6 @@ module "ubuntu2404_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "ubuntu2404-sshminion"
   image              = "ubuntu2404o"
   provider_settings = {
@@ -1334,7 +1296,6 @@ module "debian11_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "debian11-sshminion"
   image              = "debian11o"
   provider_settings = {
@@ -1351,7 +1312,6 @@ module "debian12_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_debian.configuration
-  product_version    = "uyuni-master"
   name               = "debian12-sshminion"
   image              = "debian12o"
   provider_settings = {
@@ -1371,7 +1331,6 @@ module "opensuse155arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse155arm-sshminion-prv"
   image              = "opensuse155armo"
   provider_settings = {
@@ -1391,7 +1350,6 @@ module "opensuse156arm_sshminion" {
   }
   source             = "./modules/sshminion"
   base_configuration = module.base_arm.configuration
-  product_version    = "uyuni-master"
   name               = "opensuse156arm-sshminion-prv"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1408,7 +1366,6 @@ module "opensuse156arm_sshminion" {
 module "sles15sp5s390_sshminion" {
   source             = "./backend_modules/feilong/host"
   base_configuration = module.base_s390.configuration
-  product_version    = "uyuni-master"
 
   name               = "sles15sp5s390-sshminion"
   image              = "s15s5-minimal-2part-xfs"
@@ -1431,7 +1388,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro51-sshminion"
 //   image              = "slemicro51-ign"
 //   provider_settings = {
@@ -1449,7 +1405,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro52-sshminion"
 //   image              = "slemicro52-ign"
 //   provider_settings = {
@@ -1467,7 +1422,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro53-sshminion"
 //   image              = "slemicro53-ign"
 //   provider_settings = {
@@ -1485,7 +1439,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro54-sshminion"
 //   image              = "slemicro54-ign"
 //   provider_settings = {
@@ -1503,7 +1456,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slemicro55-sshminion"
 //   image              = "slemicro55o"
 //   provider_settings = {
@@ -1521,7 +1473,6 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   source             = "./modules/sshminion"
 //   base_configuration = module.base_new_sle.configuration
-//   product_version    = "uyuni-master"
 //   name               = "slmicro60-sshminion"
 //   image              = "slmicro60o"
 //   provider_settings = {
@@ -1538,7 +1489,6 @@ module "sles12sp5_buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
   name               = "sles12sp5-build"
   image              = "sles12sp5o"
   provider_settings = {
@@ -1578,7 +1528,6 @@ module "sles15sp4_buildhost" {
   }
   source             = "./modules/build_host"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
   name               = "sles15sp4-build"
   image              = "sles15sp4o"
   provider_settings = {
@@ -1618,7 +1567,6 @@ module "monitoring_server" {
   }
   source             = "./modules/minion"
   base_configuration = module.base_retail.configuration
-  product_version    = "uyuni-master"
   name               = "monitoring"
   image              = "opensuse155o"
   provider_settings = {
@@ -1644,7 +1592,6 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  product_version    = "uyuni-master"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER


### PR DESCRIPTION
## What does this PR ? 

After the changes made for sumaform with https://github.com/uyuni-project/sumaform/pull/1713, we can now only declare product_version at the base level and remove it from the individual modules.