### PR TITLE
Update libvirt provider to v0.8.1

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-PRV.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-VM-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-VM-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
     feilong = {
       source = "bischoff/feilong"

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
     feilong = {
       source = "bischoff/feilong"

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
@@ -73,7 +73,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
@@ -84,7 +84,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-PRV.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -87,7 +87,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
     feilong = {
       source = "bischoff/feilong"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -87,7 +87,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
     feilong = {
       source = "bischoff/feilong"

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
@@ -78,7 +78,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -87,7 +87,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
     feilong = {
       source = "bischoff/feilong"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -87,7 +87,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
     feilong = {
       source = "bischoff/feilong"

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -84,7 +84,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -94,7 +94,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/local_mirror.tf
+++ b/terracumber_config/tf_files/local_mirror.tf
@@ -86,7 +86,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux8.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux9-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-AlmaLinux9-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-CENTOS7-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-CENTOS7-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian10.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian11-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian11-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian12-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Debian12-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Leap155.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES12SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES12SP5-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP1.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP2.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP3.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP4.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP5.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLES15SP6.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro60.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu1804.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2004.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2204-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2204-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2404-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-Ubuntu2404-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Products-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Products-SLES15SP5.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap154.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap154.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Leap155.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Tumbleweed.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Saltstack-Tumbleweed.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux8.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux9-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-AlmaLinux9-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-CENTOS7-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-CENTOS7-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian10.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian11-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian11-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian12-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Debian12-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap155.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES12SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES12SP5-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP1.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP2.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP3.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP4.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLES15SP5.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro60.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu1804.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2004.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2204-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2204-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2404-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Ubuntu2404-Bundle.tf
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }


### PR DESCRIPTION
Related to: https://github.com/SUSE/spacewalk/issues/25018

Depends on: https://github.com/uyuni-project/sumaform/pull/1723

Upgrades the libvirt provider to the latest available version at the time of writing: 0.8.1