### PR TITLE
Remove unuse parameters for uyuni and 5.0 BV pipelines

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -212,11 +212,6 @@ module "proxy_containerized" {
     mac                = "aa:b2:92:42:00:52"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-server.mgr.suse.de"
-    username = "admin"
-    password = "admin"
-  }
   runtime = "podman"
   container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile"
   auto_configure            = false
@@ -231,9 +226,6 @@ module "sles12sp5_minion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:61"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -250,9 +242,6 @@ module "sles15sp2_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -268,9 +257,6 @@ module "sles15sp3_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -286,9 +272,6 @@ module "sles15sp4_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -304,9 +287,6 @@ module "sles15sp5_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -322,9 +302,6 @@ module "sles15sp6_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -338,9 +315,6 @@ module "alma8_minion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:69"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -356,9 +330,6 @@ module "alma9_minion" {
     mac                = "aa:b2:92:42:00:72"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -372,9 +343,6 @@ module "centos7_minion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:67"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -390,9 +358,6 @@ module "liberty9_minion" {
     mac                = "aa:b2:92:42:00:75"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -406,9 +371,6 @@ module "oracle9_minion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:73"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -424,9 +386,6 @@ module "rocky8_minion" {
     mac                = "aa:b2:92:42:00:68"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -440,9 +399,6 @@ module "rocky9_minion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:71"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -458,9 +414,6 @@ module "ubuntu2004_minion" {
     mac                = "aa:b2:92:42:00:6a"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -475,9 +428,6 @@ module "ubuntu2204_minion" {
     mac                = "aa:b2:92:42:00:6b"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -491,9 +441,6 @@ module "ubuntu2404_minion" {
   provider_settings = {
     mac                = "aa:b2:92:42:00:6d"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -510,9 +457,6 @@ module "debian11_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -528,9 +472,6 @@ module "debian12_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -551,9 +492,6 @@ module "opensuse155arm_minion" {
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -573,9 +511,6 @@ module "opensuse156arm_minion" {
     memory             = 2048
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -631,15 +566,11 @@ module "slemicro51_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
 }
 
@@ -653,15 +584,11 @@ module "slemicro52_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
 }
 
@@ -675,15 +602,11 @@ module "slemicro53_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
 }
 
@@ -697,15 +620,11 @@ module "slemicro54_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
 }
 
@@ -719,15 +638,11 @@ module "slemicro55_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
 }
 
@@ -741,16 +656,11 @@ module "slmicro60_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
   install_salt_bundle = false
 }
 
@@ -1148,14 +1058,8 @@ module "sles12sp5_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  
 
 }
 
@@ -1184,13 +1088,8 @@ module "sles15sp4_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
 
 }
 
@@ -1236,9 +1135,6 @@ module "monitoring_server" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -390,9 +390,6 @@ module "sles12sp5_minion" {
     mac                = "aa:b2:92:05:00:11"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -411,9 +408,6 @@ module "sles15sp2_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -432,9 +426,6 @@ module "sles15sp3_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -453,9 +444,6 @@ module "sles15sp4_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -474,9 +462,6 @@ module "sles15sp5_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -495,9 +480,6 @@ module "sles15sp6_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -514,9 +496,6 @@ module "alma8_minion" {
   provider_settings = {
     mac                = "aa:b2:92:05:00:19"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -535,9 +514,6 @@ module "alma9_minion" {
     mac                = "aa:b2:92:05:00:22"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -554,9 +530,6 @@ module "centos7_minion" {
   provider_settings = {
     mac                = "aa:b2:92:05:00:17"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -575,9 +548,6 @@ module "liberty9_minion" {
     mac                = "aa:b2:92:05:00:25"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -594,9 +564,6 @@ module "oracle9_minion" {
   provider_settings = {
     mac                = "aa:b2:92:05:00:23"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -615,9 +582,6 @@ module "rocky8_minion" {
     mac                = "aa:b2:92:05:00:18"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -634,9 +598,6 @@ module "rocky9_minion" {
   provider_settings = {
     mac                = "aa:b2:92:05:00:21"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -655,9 +616,6 @@ module "ubuntu2004_minion" {
     mac                = "aa:b2:92:05:00:1a"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -675,9 +633,6 @@ module "ubuntu2204_minion" {
     mac                = "aa:b2:92:05:00:1b"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -694,9 +649,6 @@ module "ubuntu2404_minion" {
   provider_settings = {
     mac                = "aa:b2:92:05:00:1d"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -716,9 +668,6 @@ module "debian11_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -737,9 +686,6 @@ module "debian12_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -760,9 +706,6 @@ module "opensuse155arm_minion" {
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -782,9 +725,6 @@ module "opensuse156arm_minion" {
     memory             = 2048
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -843,16 +783,12 @@ module "slemicro51_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro52_minion" {
@@ -868,16 +804,12 @@ module "slemicro52_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro53_minion" {
@@ -893,16 +825,12 @@ module "slemicro53_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro54_minion" {
@@ -918,16 +846,12 @@ module "slemicro54_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slemicro55_minion" {
@@ -943,16 +867,12 @@ module "slemicro55_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
+  install_salt_bundle = false
 }
 
 module "slmicro60_minion" {
@@ -968,16 +888,11 @@ module "slmicro60_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
   install_salt_bundle = false
 }
 
@@ -1460,10 +1375,6 @@ module "sles12sp5_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
@@ -1499,10 +1410,6 @@ module "sles15sp4_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
@@ -1555,9 +1462,6 @@ module "monitoring_server" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "suma-bv-50-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -240,9 +240,7 @@ module "sles12sp5_minion" {
     mac                = "aa:b2:93:02:01:b1"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
+
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -258,9 +256,6 @@ module "sles15sp2_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -276,9 +271,6 @@ module "sles15sp3_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -294,9 +286,6 @@ module "sles15sp4_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -312,9 +301,6 @@ module "sles15sp5_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -330,9 +316,6 @@ module "sles15sp6_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -347,15 +330,9 @@ module "alma8_minion" {
     mac                = "aa:b2:93:02:01:b9"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_minion" {
@@ -367,15 +344,9 @@ module "alma9_minion" {
     mac                = "aa:b2:93:02:01:c2"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_minion" {
@@ -387,15 +358,9 @@ module "centos7_minion" {
     mac                = "aa:b2:93:02:01:b7"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "liberty9_minion" {
@@ -407,15 +372,9 @@ module "liberty9_minion" {
     mac                = "aa:b2:93:02:01:c5"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_minion" {
@@ -427,15 +386,9 @@ module "oracle9_minion" {
     mac                = "aa:b2:93:02:01:c3"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_minion" {
@@ -448,15 +401,9 @@ module "rocky8_minion" {
 
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_minion" {
@@ -468,15 +415,9 @@ module "rocky9_minion" {
     mac                = "aa:b2:93:02:01:c1"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_minion" {
@@ -488,16 +429,10 @@ module "ubuntu2004_minion" {
     mac                = "aa:b2:93:02:01:ba"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_minion" {
@@ -508,9 +443,6 @@ module "ubuntu2204_minion" {
   provider_settings = {
     mac                = "aa:b2:93:02:01:bb"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -525,9 +457,6 @@ module "ubuntu2404_minion" {
   provider_settings = {
     mac                = "aa:b2:93:02:01:bd"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -544,9 +473,6 @@ module "debian11_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -562,15 +488,9 @@ module "debian12_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_minion" {
@@ -587,9 +507,6 @@ module "opensuse155arm_minion" {
     memory             = 2048
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -610,9 +527,6 @@ module "opensuse156arm_minion" {
     memory             = 2048
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -666,9 +580,6 @@ module "slemicro51_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -687,9 +598,6 @@ module "slemicro52_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -708,9 +616,6 @@ module "slemicro53_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -729,9 +634,6 @@ module "slemicro54_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -750,9 +652,6 @@ module "slemicro55_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -771,9 +670,6 @@ module "slmicro60_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -874,8 +770,6 @@ module "alma8_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_sshminion" {
@@ -889,9 +783,6 @@ module "alma9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_sshminion" {
@@ -905,9 +796,6 @@ module "centos7_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "liberty9_sshminion" {
@@ -921,9 +809,6 @@ module "liberty9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_sshminion" {
@@ -937,9 +822,6 @@ module "oracle9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_sshminion" {
@@ -953,9 +835,6 @@ module "rocky8_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_sshminion" {
@@ -969,9 +848,6 @@ module "rocky9_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_sshminion" {
@@ -986,9 +862,6 @@ module "ubuntu2004_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_sshminion" {
@@ -1041,9 +914,6 @@ module "debian12_sshminion" {
   }
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_sshminion" {
@@ -1196,9 +1066,6 @@ module "sles12sp5_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -1230,9 +1097,6 @@ module "sles15sp4_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -1263,9 +1127,6 @@ module "monitoring_server" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.suse.de"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -216,11 +216,6 @@ module "proxy_containerized" {
     mac                = "aa:b2:93:02:01:a2"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-server.mgr.suse.de"
-    username = "admin"
-    password = "admin"
-  }
 
   runtime = "podman"
   container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
@@ -1066,7 +1061,6 @@ module "sles12sp5_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
@@ -1097,7 +1091,6 @@ module "sles15sp4_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -365,21 +365,16 @@ module "proxy_containerized" {
   source             = "./modules/proxy_containerized"
   base_configuration = module.base_retail.configuration
   name               = "proxy"
-  provider_settings = {
+  provider_settings  = {
     mac                = "aa:b2:93:04:05:6e"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-server.mgr.prv.suse.net"
-    username = "admin"
-    password = "admin"
-  }
 
-  runtime = "podman"
-  container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
-  container_tag = "latest"
-  auto_configure            = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  runtime               = "podman"
+  container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+  container_tag         = "latest"
+  auto_configure        = false
+  ssh_key_path          = "./salt/controller/id_rsa.pub"
 }
 
 // No traditional clients in Uyuni

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -396,9 +396,6 @@ module "sles12sp5_minion" {
     mac                = "aa:b2:93:04:05:7d"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -417,9 +414,6 @@ module "sles15sp2_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -438,9 +432,6 @@ module "sles15sp3_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -459,9 +450,6 @@ module "sles15sp4_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -480,9 +468,6 @@ module "sles15sp5_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -501,9 +486,6 @@ module "sles15sp6_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -521,15 +503,10 @@ module "alma8_minion" {
     mac                = "aa:b2:93:04:05:85"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_minion" {
@@ -544,15 +521,10 @@ module "alma9_minion" {
     mac                = "aa:b2:93:04:05:8e"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_minion" {
@@ -567,15 +539,10 @@ module "centos7_minion" {
     mac                = "aa:b2:93:04:05:83"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "liberty9_minion" {
@@ -590,15 +557,11 @@ module "liberty9_minion" {
     mac                = "aa:b2:93:04:05:91"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
+
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_minion" {
@@ -613,15 +576,10 @@ module "oracle9_minion" {
     mac                = "aa:b2:93:04:05:8f"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_minion" {
@@ -636,15 +594,11 @@ module "rocky8_minion" {
     mac                = "aa:b2:93:04:05:84"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
+
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_minion" {
@@ -659,15 +613,10 @@ module "rocky9_minion" {
     mac                = "aa:b2:93:04:05:8d"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_minion" {
@@ -682,16 +631,10 @@ module "ubuntu2004_minion" {
     mac                = "aa:b2:93:04:05:86"
     memory             = 4096
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_minion" {
@@ -705,9 +648,6 @@ module "ubuntu2204_minion" {
   provider_settings = {
     mac                = "aa:b2:93:04:05:87"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -725,9 +665,6 @@ module "ubuntu2404_minion" {
   provider_settings = {
     mac                = "aa:b2:93:04:05:89"
     memory             = 4096
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -747,9 +684,6 @@ module "debian11_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -768,15 +702,10 @@ module "debian12_minion" {
     memory             = 4096
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_minion" {
@@ -793,9 +722,6 @@ module "opensuse155arm_minion" {
     memory             = 2048
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -816,9 +742,6 @@ module "opensuse156arm_minion" {
     memory             = 2048
     vcpu               = 2
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -876,9 +799,6 @@ module "slemicro51_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -900,9 +820,6 @@ module "slemicro52_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -924,9 +841,6 @@ module "slemicro53_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -948,9 +862,6 @@ module "slemicro54_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -972,9 +883,6 @@ module "slemicro55_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -996,9 +904,6 @@ module "slmicro60_minion" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -1120,8 +1025,6 @@ module "alma8_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "alma9_sshminion" {
@@ -1139,8 +1042,6 @@ module "alma9_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "centos7_sshminion" {
@@ -1158,8 +1059,6 @@ module "centos7_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "liberty9_sshminion" {
@@ -1177,8 +1076,6 @@ module "liberty9_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "oracle9_sshminion" {
@@ -1196,8 +1093,6 @@ module "oracle9_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky8_sshminion" {
@@ -1215,8 +1110,6 @@ module "rocky8_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "rocky9_sshminion" {
@@ -1234,8 +1127,6 @@ module "rocky9_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2004_sshminion" {
@@ -1253,9 +1144,6 @@ module "ubuntu2004_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "ubuntu2204_sshminion" {
@@ -1321,8 +1209,6 @@ module "debian12_sshminion" {
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
 module "opensuse155arm_sshminion" {
@@ -1496,9 +1382,6 @@ module "sles12sp5_buildhost" {
     memory             = 2048
     vcpu               = 2
   }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -1534,9 +1417,6 @@ module "sles15sp4_buildhost" {
     mac                = "aa:b2:93:04:05:71"
     memory             = 2048
     vcpu               = 2
-  }
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
@@ -1574,9 +1454,6 @@ module "monitoring_server" {
     memory             = 2048
   }
 
-  server_configuration = {
-    hostname = "uyuni-bv-master-proxy.mgr.prv.suse.net"
-  }
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"


### PR DESCRIPTION
## What does this PR ? 

Remove all parameters not use during deployment. Either it's not used during the salt states ( example server_configuration without auto connect to master ) or default value is true ( venv-salt-bundle install ).

The idea is to simplify our BV description and later create a common template.

Depends on: https://github.com/uyuni-project/sumaform/pull/1736.
I didn't impact 4.3 for stability.