### PR TITLE
Remove auto connection to host variable from build host

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -1319,7 +1319,6 @@ module "sles12sp5_buildhost" {
   server_configuration = {
     hostname = "suma-bv-43-proxy.mgr.suse.de"
   }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
@@ -1352,7 +1351,6 @@ module "sles15sp4_buildhost" {
   server_configuration = {
     hostname = "suma-bv-43-proxy.mgr.suse.de"
   }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1648,7 +1648,6 @@ module "sle12sp5_buildhost" {
   server_configuration = {
     hostname = "suma-bv-43-proxy.mgr.prv.suse.net"
   }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }
@@ -1687,7 +1686,6 @@ module "sle15sp4_buildhost" {
   server_configuration = {
     hostname = "suma-bv-43-proxy.mgr.prv.suse.net"
   }
-  auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
 }


### PR DESCRIPTION
## What does this PR ? 

In prevision of this sumaform PR: https://github.com/uyuni-project/sumaform/pull/1736 remove the `auto_connect_to_master` variable from build host to avoid error.

Impact before PR => `auto_connect_to_master` will be set to true by default but it will change **nothing** during salt. state
After PR => variable `auto_connect_to_master` doesn't exist anymore for build_host.