### PR TITLE
Temporary skip rubocop tests for Ruby 3.3

### DIFF
--- a/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
@@ -5,6 +5,11 @@ rubocop_file="testsuite/.rubocop.yml"
 if [[ -f "$rubocop_file" ]]; then
   # Extract the Ruby version from the file
   ruby_version=$(grep "TargetRubyVersion:" "$rubocop_file" | awk '{print $2}')
+  # Temporary skip the check for Ruby 3.3
+  if [[ "$ruby_version" == "3.3" ]]; then
+    echo "Skipping Rubocop for Ruby 3.3, until sumadockers support it."
+    exit 0
+  fi
   if [[ -n "$ruby_version" ]]; then
     rubocop.ruby"$ruby_version" -v
     cd testsuite


### PR DESCRIPTION
We must adapt sumadockers to support both Rubocop versions coming from different Ruby versions.
Before we have this done, let's skip the Rubocop check for Ruby 3.3

For more context follow this thread https://suse.slack.com/archives/C02EWMAB7QV/p1728486959198399