### PR TITLE
Verify previous Terraform state can be reused

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -28,7 +28,7 @@ def run(params) {
         }
         try {
             stage('Clone terracumber, susemanager-ci and sumaform') {
-                // Create a directory for  to place the directory with the build results (if it does not exist)
+                // Create a directory in which to place the build results (if it does not exist)
                 sh "mkdir -p ${resultdir}"
                 git url: params.terracumber_gitrepo, branch: params.terracumber_ref
                 dir("susemanager-ci") {
@@ -37,9 +37,50 @@ def run(params) {
                 // Clone sumaform
                 sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
 
-                // Restore Terraform states from artifacts
+                // Attempt to restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
-                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
+                    def terraformDir = "${env.WORKSPACE}/sumaform/terraform"
+                    def terraformTmpDir = "${terraformDir}/temp/"
+                    def filters = 'results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*'
+                    def terraformStatePath = "results/sumaform/terraform.tfstate"
+                    def previousBuild = currentBuild.previousBuild
+                    def found = false
+
+                    // Loop through previous builds until we find one for which a terraform state was stored
+                    while (previousBuild != null) {
+                        found = fileExists("${WORKSPACE}/${previousBuild.getArtifactsDir()}/${terraformStatePath}")
+                        if (found){
+                            echo "Found previous Terraform state in build ${previousBuild.number}."
+
+                            // Copy just the necessary files (state and Terraform config) from the previous build to a temporary directory
+                            sh "mkdir -p ${terraformTmpDir}"
+                            copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"), filter: "${filters}" , target: "${terraformDir}"
+                            // Copy the Terraform configuration files (like main.tf, variables.tf, etc) from the current workspace to the temp dir
+                            sh "cp ${terraformDir}/*.tf ${terraformTmpDir}"
+
+                            // Validate the restored Terraform state
+                            dir(terraformTmpDir) {
+                                sh "terraform init"
+                                def planOutput = sh(script: "terraform plan -refresh=true", returnStatus: true)
+
+                                if (planOutput == 0) {
+                                    echo "Terraform state from build ${previousBuild.number} is valid."
+                                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"
+                                    break
+                                } else {
+                                    echo "Terraform state from build ${previousBuild.number} is invalid. Searching for another build."
+                                    foundState = false
+                                }
+                            }
+                        }
+                        previousBuild = previousBuild.previousBuild
+                    }
+                    // Clean up the temp directory 
+                    sh "rm -rf ${terraformTmpDir}"
+
+                    if (!found) {
+                        echo "No previous Terraform state to restore. Starting from scratch."
+                    }
                 }
             }
 

--- a/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
@@ -20,9 +20,50 @@ def run(params) {
                 // Clone sumaform
                 sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
 
-                // Restore Terraform states from artifacts
+                // Attempt to restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
-                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
+                    def terraformDir = "${env.WORKSPACE}/sumaform/terraform"
+                    def terraformTmpDir = "${terraformDir}/temp/"
+                    def filters = 'results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*'
+                    def terraformStatePath = "results/sumaform/terraform.tfstate"
+                    def previousBuild = currentBuild.previousBuild
+                    def found = false
+
+                    // Loop through previous builds until we find one for which a terraform state was stored
+                    while (previousBuild != null) {
+                        found = fileExists("${WORKSPACE}/${previousBuild.getArtifactsDir()}/${terraformStatePath}")
+                        if (found){
+                            echo "Found previous Terraform state in build ${previousBuild.number}."
+
+                            // Copy just the necessary files (state and Terraform config) from the previous build to a temporary directory
+                            sh "mkdir -p ${terraformTmpDir}"
+                            copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"), filter: "${filters}" , target: "${terraformDir}"
+                            // Copy the Terraform configuration files (like main.tf, variables.tf, etc) from the current workspace to the temp dir
+                            sh "cp ${terraformDir}/*.tf ${terraformTmpDir}"
+
+                            // Validate the restored Terraform state
+                            dir(terraformTmpDir) {
+                                sh "terraform init"
+                                def planOutput = sh(script: "terraform plan -refresh=true", returnStatus: true)
+
+                                if (planOutput == 0) {
+                                    echo "Terraform state from build ${previousBuild.number} is valid."
+                                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"
+                                    break
+                                } else {
+                                    echo "Terraform state from build ${previousBuild.number} is invalid. Searching for another build."
+                                    foundState = false
+                                }
+                            }
+                        }
+                        previousBuild = previousBuild.previousBuild
+                    }
+                    // Clean up the temp directory 
+                    sh "rm -rf ${terraformTmpDir}"
+
+                    if (!found) {
+                        echo "No previous Terraform state to restore. Starting from scratch."
+                    }
                 }
             }
             stage('Deploy') {

--- a/jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy
@@ -20,9 +20,51 @@ def run(params) {
                 }
                 // Clone sumaform
                 sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
-                // Restore Terraform states from artifacts
+                
+                // Attempt to restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
-                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
+                    def terraformDir = "${env.WORKSPACE}/sumaform/terraform"
+                    def terraformTmpDir = "${terraformDir}/temp/"
+                    def filters = 'results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*'
+                    def terraformStatePath = "results/sumaform/terraform.tfstate"
+                    def previousBuild = currentBuild.previousBuild
+                    def found = false
+
+                    // Loop through previous builds until we find one for which a terraform state was stored
+                    while (previousBuild != null) {
+                        found = fileExists("${WORKSPACE}/${previousBuild.getArtifactsDir()}/${terraformStatePath}")
+                        if (found){
+                            echo "Found previous Terraform state in build ${previousBuild.number}."
+
+                            // Copy just the necessary files (state and Terraform config) from the previous build to a temporary directory
+                            sh "mkdir -p ${terraformTmpDir}"
+                            copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"), filter: "${filters}" , target: "${terraformDir}"
+                            // Copy the Terraform configuration files (like main.tf, variables.tf, etc) from the current workspace to the temp dir
+                            sh "cp ${terraformDir}/*.tf ${terraformTmpDir}"
+
+                            // Validate the restored Terraform state
+                            dir(terraformTmpDir) {
+                                sh "terraform init"
+                                def planOutput = sh(script: "terraform plan -refresh=true", returnStatus: true)
+
+                                if (planOutput == 0) {
+                                    echo "Terraform state from build ${previousBuild.number} is valid."
+                                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"
+                                    break
+                                } else {
+                                    echo "Terraform state from build ${previousBuild.number} is invalid. Searching for another build."
+                                    foundState = false
+                                }
+                            }
+                        }
+                        previousBuild = previousBuild.previousBuild
+                    }
+                    // Clean up the temp directory 
+                    sh "rm -rf ${terraformTmpDir}"
+
+                    if (!found) {
+                        echo "No previous Terraform state to restore. Starting from scratch."
+                    }
                 }
             }
             stage('Deploy') {

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -62,9 +62,50 @@ def run(params) {
                 // Clone sumaform
                 sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
             
-                // Restore Terraform states from artifacts
+                // Attempt to restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
-                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
+                    def terraformDir = "${env.WORKSPACE}/sumaform/terraform"
+                    def terraformTmpDir = "${terraformDir}/temp/"
+                    def filters = 'results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*'
+                    def terraformStatePath = "results/sumaform/terraform.tfstate"
+                    def previousBuild = currentBuild.previousBuild
+                    def found = false
+
+                    // Loop through previous builds until we find one for which a terraform state was stored
+                    while (previousBuild != null) {
+                        found = fileExists("${WORKSPACE}/${previousBuild.getArtifactsDir()}/${terraformStatePath}")
+                        if (found){
+                            echo "Found previous Terraform state in build ${previousBuild.number}."
+
+                            // Copy just the necessary files (state and Terraform config) from the previous build to a temporary directory
+                            sh "mkdir -p ${terraformTmpDir}"
+                            copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"), filter: "${filters}" , target: "${terraformDir}"
+                            // Copy the Terraform configuration files (like main.tf, variables.tf, etc) from the current workspace to the temp dir
+                            sh "cp ${terraformDir}/*.tf ${terraformTmpDir}"
+
+                            // Validate the restored Terraform state
+                            dir(terraformTmpDir) {
+                                sh "terraform init"
+                                def planOutput = sh(script: "terraform plan -refresh=true", returnStatus: true)
+
+                                if (planOutput == 0) {
+                                    echo "Terraform state from build ${previousBuild.number} is valid."
+                                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"
+                                    break
+                                } else {
+                                    echo "Terraform state from build ${previousBuild.number} is invalid. Searching for another build."
+                                    foundState = false
+                                }
+                            }
+                        }
+                        previousBuild = previousBuild.previousBuild
+                    }
+                    // Clean up the temp directory 
+                    sh "rm -rf ${terraformTmpDir}"
+
+                    if (!found) {
+                        echo "No previous Terraform state to restore. Starting from scratch."
+                    }
                 }
 
                 // run minima sync on mirror

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -51,9 +51,50 @@ node('sumaform-cucumber-provo') {
                 // Clone sumaform
                 sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
 
-                // Restore Terraform states from artifacts
+                // Attempt to restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
-                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
+                    def terraformDir = "${env.WORKSPACE}/sumaform/terraform"
+                    def terraformTmpDir = "${terraformDir}/temp/"
+                    def filters = 'results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*'
+                    def terraformStatePath = "results/sumaform/terraform.tfstate"
+                    def previousBuild = currentBuild.previousBuild
+                    def found = false
+
+                    // Loop through previous builds until we find one for which a terraform state was stored
+                    while (previousBuild != null) {
+                        found = fileExists("${WORKSPACE}/${previousBuild.getArtifactsDir()}/${terraformStatePath}")
+                        if (found){
+                            echo "Found previous Terraform state in build ${previousBuild.number}."
+
+                            // Copy just the necessary files (state and Terraform config) from the previous build to a temporary directory
+                            sh "mkdir -p ${terraformTmpDir}"
+                            copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"), filter: "${filters}" , target: "${terraformDir}"
+                            // Copy the Terraform configuration files (like main.tf, variables.tf, etc) from the current workspace to the temp dir
+                            sh "cp ${terraformDir}/*.tf ${terraformTmpDir}"
+
+                            // Validate the restored Terraform state
+                            dir(terraformTmpDir) {
+                                sh "terraform init"
+                                def planOutput = sh(script: "terraform plan -refresh=true", returnStatus: true)
+
+                                if (planOutput == 0) {
+                                    echo "Terraform state from build ${previousBuild.number} is valid."
+                                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${previousBuild.number}"
+                                    break
+                                } else {
+                                    echo "Terraform state from build ${previousBuild.number} is invalid. Searching for another build."
+                                    foundState = false
+                                }
+                            }
+                        }
+                        previousBuild = previousBuild.previousBuild
+                    }
+                    // Clean up the temp directory 
+                    sh "rm -rf ${terraformTmpDir}"
+
+                    if (!found) {
+                        echo "No previous Terraform state to restore. Starting from scratch."
+                    }
                 }
             }
 


### PR DESCRIPTION
Related https://github.com/SUSE/spacewalk/issues/25242

Introduces additional checks when "use_previous_terraform_state"is checked,  with the aim to validate a previous Terraform state is indeed present and can be safely reused.