### PR TITLE
Run Rubocop from a container

### DIFF
--- a/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
@@ -5,15 +5,9 @@ rubocop_file="testsuite/.rubocop.yml"
 if [[ -f "$rubocop_file" ]]; then
   # Extract the Ruby version from the file
   ruby_version=$(grep "TargetRubyVersion:" "$rubocop_file" | awk '{print $2}')
-  # Temporary skip the check for Ruby 3.3
-  if [[ "$ruby_version" == "3.3" ]]; then
-    echo "Skipping Rubocop for Ruby 3.3, until sumadockers support it."
-    exit 0
-  fi
   if [[ -n "$ruby_version" ]]; then
-    rubocop.ruby"$ruby_version" -v
     cd testsuite
-    rubocop.ruby"$ruby_version" features/*
+    docker run --rm --volume "$PWD:/app" docker.io/srbarrios/rubocop:ruby-$ruby_version
   else
     echo "No TargetRubyVersion found in $rubocop_file."
   fi

--- a/jenkins_pipelines/uyuni_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/uyuni_prs/tests_files/rubocop.sh
@@ -1,6 +1,16 @@
 #! /bin/bash
 
 echo "running rubocop on step files"
-rubocop.ruby2.5 -v
-cd testsuite
-rubocop.ruby2.5 features/*
+rubocop_file="testsuite/.rubocop.yml"
+if [[ -f "$rubocop_file" ]]; then
+  # Extract the Ruby version from the file
+  ruby_version=$(grep "TargetRubyVersion:" "$rubocop_file" | awk '{print $2}')
+  if [[ -n "$ruby_version" ]]; then
+    cd testsuite
+    docker run --rm --volume "$PWD:/app" docker.io/srbarrios/rubocop:ruby-$ruby_version
+  else
+    echo "No TargetRubyVersion found in $rubocop_file."
+  fi
+else
+  echo "File $rubocop_file does not exist."
+fi


### PR DESCRIPTION
We can't install two Rubocop versions through zypper, as they require different Ruby versions and that cause conflicts.
So instead, we will be using these rubocop containers from DockerHub.