### PR TITLE
Add 5.0 registry for both SLE envs

### DIFF
--- a/jenkins_pipelines/environments/manager-5.0-qe-sle-update-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-sle-update-NUE
@@ -22,7 +22,7 @@ node('sumaform-cucumber') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            string(name: 'container_repository', defaultValue: 'registry.suse.de/suse/maintenance/347951/suse_sle-15-sp6_update_products_manager50_update_containerfile', description: 'Proxy and server container registry'),
+            string(name: 'container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp6/update/products/manager50/update/containerfile', description: 'Proxy and server container registry'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/manager-5.0-qe-sle-update-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-sle-update-PRV
@@ -22,7 +22,7 @@ node('sumaform-cucumber-provo') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            string(name: 'container_repository', defaultValue: 'registry.suse.de/suse/maintenance/347951/suse_sle-15-sp6_update_products_manager50_update_containerfile', description: 'Proxy and server container registry'),
+            string(name: 'container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp6/update/products/manager50/update/containerfile', description: 'Proxy and server container registry'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),


### PR DESCRIPTION
We should be using the latest available released container from the registry for SLE, and we can overwrite it as we want with the new jenkins parameter. This registry currently works and deploys. The previous was not until the MU was ready and would not after it was released. So this with the latest tag and the server image from mgradm works now. Tested on NUE deployment