### PR TITLE
Append correct path for registry in SLE and BV

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
@@ -168,8 +168,8 @@ module "proxy_containerized" {
   }
 
   runtime              = "podman"
-  // Temporary workaround to see if we pass proxy stage. Also needs to be updated on next MU
-  container_repository = var.CONTAINER_REPOSITORY
+  // The proxy is not appending this path via product code, we need to do it in our infra
+  container_repository = "${var.CONTAINER_REPOSITORY}/suse/manager/5.0/x86_64"
   container_tag        = "latest"
 
   auto_configure        = false

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-PRV.tf
@@ -168,8 +168,8 @@ module "proxy_containerized" {
   }
 
   runtime              = "podman"
-  // Temporary workaround to see if we pass proxy stage. Also needs to be updated on next MU
-  container_repository = var.CONTAINER_REPOSITORY
+  // The proxy is not appending this path via product code, we need to do it in our infra
+  container_repository = "${var.CONTAINER_REPOSITORY}/suse/manager/5.0/x86_64"
   container_tag         = "latest"
 
   auto_configure            = false

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -218,7 +218,8 @@ module "proxy_containerized" {
     memory             = 4096
   }
   runtime                   = "podman"
-  container_repository      = var.CONTAINER_REPOSITORY
+  // The proxy is not appending this path via product code, we need to do it in our infra
+  container_repository = "${var.CONTAINER_REPOSITORY}/suse/manager/5.0/x86_64"
   container_tag             = "latest"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"
@@ -1018,7 +1019,7 @@ module "sles15sp5s390_sshminion" {
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
 //
-//  
+//
 //
 //}
 
@@ -1034,7 +1035,7 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//  
+//
 //
 //}
 
@@ -1050,7 +1051,7 @@ module "sles15sp5s390_sshminion" {
 //   }
 //   use_os_released_updates = false
 //   ssh_key_path            = "./salt/controller/id_rsa.pub"
-//  
+//
 //
 //}
 

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -377,7 +377,8 @@ module "proxy_containerized" {
     password = "admin"
   }
   runtime                   = "podman"
-  container_repository      = var.CONTAINER_REPOSITORY
+  // The proxy is not appending this path via product code, we need to do it in our infra
+  container_repository = "${var.CONTAINER_REPOSITORY}/suse/manager/5.0/x86_64"
   container_tag             = "latest"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"


### PR DESCRIPTION
Append correct path for registry in SLE and BV. I don't want to change the default value in the jenkins because this is used for the server and there the rest of this path (which is part of the image name basically) is hardcoded in the product code. But not for the proxy product code. I only tested this on SLE not BV but since it's common code I think it is needed there as well. 