### PR TITLE
Changing the container repository path for mgrpxy

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -218,8 +218,7 @@ module "proxy_containerized" {
     memory             = 4096
   }
   runtime                   = "podman"
-  // The proxy is not appending this path via product code, we need to do it in our infra
-  container_repository = "${var.CONTAINER_REPOSITORY}/suse/manager/5.0/x86_64"
+  container_repository = "${var.CONTAINER_REPOSITORY}"
   container_tag             = "latest"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -377,8 +377,7 @@ module "proxy_containerized" {
     password = "admin"
   }
   runtime                   = "podman"
-  // The proxy is not appending this path via product code, we need to do it in our infra
-  container_repository = "${var.CONTAINER_REPOSITORY}/suse/manager/5.0/x86_64"
+  container_repository = "${var.CONTAINER_REPOSITORY}"
   container_tag             = "latest"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"


### PR DESCRIPTION
Card https://github.com/SUSE/spacewalk/issues/25577

With the new mgrpxy version ( > 0.1.21 ), we don't need the /suse/manager/5.0/x86_64 anymore for proxy_containerized.
