### PR TITLE
Proxy additional repos placeholder on BV 5.0

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -222,6 +222,9 @@ module "proxy_containerized" {
   container_tag             = "latest"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"
+
+  //proxy_additional_repos
+
 }
 
 module "sles12sp5_minion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -381,6 +381,9 @@ module "proxy_containerized" {
   container_tag             = "latest"
   auto_configure            = false
   ssh_key_path              = "./salt/controller/id_rsa.pub"
+
+  //proxy_additional_repos
+
 }
 
 module "sles12sp5_minion" {


### PR DESCRIPTION
https://github.com/SUSE/spacewalk/issues/25575#issuecomment-2429292573

Regarding Proxy host deployment, if we just add the additional repositories in the main.tf, through Terracumber and the placeholder (all already implemented), then the mgrpxy version it's just the updated version from the MI.

Example main.tf:
```
provider "libvirt" {
  uri = "qemu:///system"
}
terraform {
  required_version = "1.0.10"
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
      version = "0.6.3"
    }
  }
}


module "base" {
  source = "./sumaform/modules/base"

  cc_username = var.SCC_USER
  cc_password = var.SCC_PASSWORD
  name_prefix = "oscar-"
  use_avahi   = false
  domain      = "mgr.suse.de"
  images = ["slemicro55o"]
  testsuite          = true

  provider_settings = {
    network_name = null
    pool = "obarrios_disks"
    bridge = "br0"
    additional_network = "192.168.3.0/24"
  }
}


module "server_containerized" {
  source             = "./sumaform/modules/server_containerized"
  base_configuration = module.base.configuration
  product_version    = "5.0-released"
  name               = "srv"
  image              = "slemicro55o"
  provider_settings = {
    mac                = "aa:b2:93:01:01:5d"
    memory             = 16384
    vcpu               = 4
    data_pool          = "ssd"
  }
  runtime = "podman"
  container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile"
  server_username = "admin"
  server_password = "admin"
  container_tag         = "latest"

  server_mounted_mirror          = "minima-mirror-ci-bv.mgr.suse.de"
  java_debugging                 = false
  auto_accept                    = false
  disable_firewall               = false
  allow_postgres_connections     = false
  skip_changelog_import          = false
  mgr_sync_autologin             = false
  create_sample_channel          = false
  create_sample_activation_key   = false
  create_sample_bootstrap_script = false
  publish_private_ssl_key        = false
  use_os_released_updates        = true
  disable_download_tokens        = false
  large_deployment               = true
  ssh_key_path                   = "./salt/controller/id_rsa.pub"
  from_email                     = "root@suse.de"

  additional_repos = {
    "35946" = "http://download.suse.de/ibs/SUSE:/Maintenance:/35946/SUSE_Updates_SUSE-Manager-Server_5.0_x86_64/"
    "35957" = "http://download.suse.de/ibs/SUSE:/Maintenance:/35957/SUSE_Updates_SUSE-Manager-Server_5.0_x86_64/"
  }
}

module "proxy_containerized" {
  source             = "./sumaform/modules/proxy_containerized"
  base_configuration = module.base.configuration
  name               = "proxy"
  product_version    = "5.0-released"
  image              = "slemicro55o"
  provider_settings = {
    mac                = "aa:b2:93:01:01:5e"
    memory             = 4096
  }
  runtime                   = "podman"
  container_repository = "registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile"
  container_tag             = "latest"
  auto_configure            = false
  ssh_key_path              = "./salt/controller/id_rsa.pub"

  additional_repos = {
    "35599" = "http://download.suse.de/ibs/SUSE:/Maintenance:/35599/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/"
    "35895" = "http://download.suse.de/ibs/SUSE:/Maintenance:/35895/SUSE_Updates_SLE-Micro_5.5_x86_64/"
    "35943" = "http://download.suse.de/ibs/SUSE:/Maintenance:/35943/SUSE_Updates_SLE-Manager-Tools-For-Micro_5_x86_64/"
    "35946" =  "http://download.suse.de/ibs/SUSE:/Maintenance:/35946/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"
    "35946-1" = "http://download.suse.de/ibs/SUSE:/Maintenance:/35946/SUSE_Updates_SUSE-Manager-Retail-Branch-Server_5.0_x86_64/"
  }

}
```


```
oscar-proxy:/var/log # snapper list
Failed to set locale. Fix your system.
 # | Type   | Pre # | Date                     | User | Used Space | Cleanup | Description           | Userdata
---+--------+-------+--------------------------+------+------------+---------+-----------------------+---------
0  | single |       |                          | root |            |         | current               |         
1  | single |       | Mon Oct 21 17:03:56 2024 | root | 560.00 KiB |         | first root filesystem |         
2  | single |       | Tue Oct 22 13:08:27 2024 | root | 404.00 KiB |         | Snapshot Update of #1 |         
3  | single |       | Tue Oct 22 13:08:31 2024 | root | 400.00 KiB |         | Snapshot Update of #2 |         
4  | single |       | Tue Oct 22 13:08:41 2024 | root | 560.00 KiB |         | Snapshot Update of #3 |         
5* | single |       | Tue Oct 22 13:08:50 2024 | root | 177.61 MiB |         | Snapshot Update of #4 |         
oscar-proxy:/var/log # zypper lr
Repository priorities are without effect. All enabled repositories share the same priority.

#  | Alias             | Name              | Enabled | GPG Check | Refresh
---+-------------------+-------------------+---------+-----------+--------
 1 | 35599_repo        | 35599_repo        | No      | ----      | ----
 2 | 35895_repo        | 35895_repo        | No      | ----      | ----
 3 | 35943_repo        | 35943_repo        | No      | ----      | ----
 4 | 35946-1_repo      | 35946-1_repo      | No      | ----      | ----
 5 | 35946_repo        | 35946_repo        | No      | ----      | ----
 6 | ca_suse           | ca_suse           | No      | ----      | ----
 7 | micro_pool_repo   | micro_pool_repo   | No      | ----      | ----
 8 | micro_update_repo | micro_update_repo | No      | ----      | ----
 9 | os_pool_repo      | os_pool_repo      | No      | ----      | ----
10 | tools_pool_repo   | tools_pool_repo   | Yes     | (r ) Yes  | Yes
11 | tools_update_repo | tools_update_repo | Yes     | (r ) Yes  | Yes
oscar-proxy:/var/log # zypper info mgrpxy
Loading repository data...
Reading installed packages...


Information for package mgrpxy:
-------------------------------
Repository     : @System
Name           : mgrpxy
Version        : 0.1.23-150500.3.6.2
Arch           : x86_64
Vendor         : SUSE LLC <https://www.suse.com/>
Support Level  : unknown
Installed Size : 7.0 MiB
Installed      : Yes
Status         : up-to-date
Source package : uyuni-tools-0.1.23-150500.3.6.2.src
Upstream URL   : https://github.com/uyuni-project/uyuni-tools
Summary        : Command line tool to install and update Uyuni proxy
Description    : 
    mgrpxy is a convenient tool to install and update Uyuni proxy components as containers
    running either on Podman or a Kubernetes cluster.

oscar-proxy:/var/log # mgrpxy status
3:23PM INF Welcome to mgrpxy
3:23PM INF Executing command: status
Error: no installed proxy detected
```

So, IMHO, I would go with this s**imple one-liner** fix for now.

> Add the place holder in the main.tf to pass the MI repos through Terracumber


Until we implement Solution 2:

> - Deploy a regular minion module with SLE Micro 5.5 instead of using proxy_container module
> - Onboard that VM as a SLE Micro 5.5 + Proxy 5.0 extension + custom channels (mgr-tools coming from submissions)
> - We need to fix https://github.com/SUSE/spacewalk/issues/25574
> - Install mgrpxy package
> - Missing scenario in the current proxy.feature
> - Setup proxy container through mgrpxy


@SUSE/suse-manager-qe make this sense for you?