### PR TITLE
Temporary incr. of main disk until we implement a partition for /var/lib/containers/storage/overlay

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -183,7 +183,7 @@ module "server_containerized" {
   }
   runtime = "podman"
   container_repository  = var.CONTAINER_REPOSITORY
-  main_disk_size        = 40
+  main_disk_size        = 100
   repository_disk_size  = 3072
   database_disk_size    = 150
   container_tag         = "latest"

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -335,7 +335,7 @@ module "server_containerized" {
 
   runtime               = "podman"
   container_repository  = var.CONTAINER_REPOSITORY
-  main_disk_size        = 40
+  main_disk_size        = 100
   repository_disk_size  = 3072
   database_disk_size    = 150
 

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -183,7 +183,7 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.suse.de"
-  main_disk_size        = 40
+  main_disk_size        = 100
   repository_disk_size  = 3072
   database_disk_size    = 150
 

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -334,7 +334,7 @@ module "server_containerized" {
   }
 
   server_mounted_mirror = "minima-mirror-ci-bv.mgr.prv.suse.net"
-  main_disk_size        = 40
+  main_disk_size        = 100
   repository_disk_size  = 3072
   database_disk_size    = 150
 


### PR DESCRIPTION
In our server containerized, we don't have a separated partition for the new overlay, located in `/var/lib/containers/storage/overlay`, that's causing a full disk issue in `/var`.

For now, I'm fixing it by increasing the main disk size, which automatically will give more space to `/var` partition. [But ideally we should implement a new partition for the overlay through sumaform.](https://github.com/SUSE/spacewalk/issues/25719)