### PR TITLE
Rename uyuni master podman nue modules and hostnames

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-podman
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-podman
@@ -10,7 +10,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-podman.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -145,6 +145,9 @@ module "cucumber_testsuite" {
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
       container_tag = "latest"
       helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server"
+      main_disk_size        = 50
+      repository_disk_size  = 150
+      database_disk_size    = 50
       login_timeout = 28800
     }
     proxy_containerized = {

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -107,26 +107,26 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
+  images        = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
 
-  use_avahi    = false
-  name_prefix  = "uyuni-ci-master-podman-"
-  domain       = "mgr.suse.de"
-  from_email   = "root@suse.de"
+  use_avahi     = false
+  name_prefix   = "uyuni-ci-master-podman-"
+  domain        = "mgr.suse.de"
+  from_email    = "root@suse.de"
 
-  no_auth_registry       = "registry.mgr.suse.de"
-  auth_registry          = "registry.mgr.suse.de:5000/cucutest"
-  auth_registry_username = "cucutest"
-  auth_registry_password = "cucusecret"
-  git_profiles_repo      = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
+  no_auth_registry         = "registry.mgr.suse.de"
+  auth_registry            = "registry.mgr.suse.de:5000/cucutest"
+  auth_registry_username   = "cucutest"
+  auth_registry_password   = "cucusecret"
+  git_profiles_repo        = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
-  container_server = true
-  container_proxy  = true
+  container_server         = true
+  container_proxy          = true
 
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy          = "http-proxy.mgr.suse.de:3128"
+  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
@@ -141,43 +141,37 @@ module "cucumber_testsuite" {
         mac = "aa:b2:93:01:00:21"
         memory = 16384
       }
-      runtime = "podman"
-      container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
-      container_tag = "latest"
-      helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server"
+      runtime               = "podman"
+      container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
+      container_tag         = "latest"
+      helm_chart_url        = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server"
       main_disk_size        = 50
       repository_disk_size  = 150
       database_disk_size    = 50
-      login_timeout = 28800
+      login_timeout         = 28800
     }
     proxy_containerized = {
       provider_settings = {
         mac = "aa:b2:93:01:00:22"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
-      runtime = "podman"
-      container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
-      container_tag = "latest"
+      runtime               = "podman"
+      container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
+      container_tag         = "latest"
     }
     suse_minion = {
-      image = "opensuse155o"
+      image             = "opensuse155o"
       provider_settings = {
         mac = "aa:b2:93:01:00:26"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     suse_sshminion = {
-      image = "opensuse155o"
+      image             = "opensuse155o"
       provider_settings = {
         mac = "aa:b2:93:01:00:28"
       }
-      additional_packages = [ "venv-salt-minion", "iptables" ]
-      install_salt_bundle = true
     }
     rhlike_minion = {
-      image = "rocky8o"
+      image             = "rocky8o"
       provider_settings = {
         mac = "aa:b2:93:01:00:2a"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
@@ -185,34 +179,26 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image             = "ubuntu2204o"
       provider_settings = {
         mac = "aa:b2:93:01:00:2b"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     build_host = {
-      image = "sles15sp4o"
+      image             = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:2d"
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     pxeboot_minion = {
       image = "sles15sp4o"
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     dhcp_dns = {
-      name = "dhcp-dns"
-      image = "opensuse155o"
+      name       = "dhcp-dns"
+      image      = "opensuse155o"
       hypervisor = {
         host        = "suma-01.mgr.suse.de"
         user        = "root"
@@ -220,15 +206,12 @@ module "cucumber_testsuite" {
       }
     }
     kvm_host = {
-      image = "opensuse155o"
+      image             = "opensuse155o"
       provider_settings = {
         mac = "aa:b2:93:01:00:2e"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
-
   provider_settings = {
     pool               = "ssd"
     network_name       = null

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -110,7 +110,7 @@ module "cucumber_testsuite" {
   images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
 
   use_avahi    = false
-  name_prefix  = "uyuni-master-podman-"
+  name_prefix  = "uyuni-ci-master-podman-"
   domain       = "mgr.suse.de"
   from_email   = "root@suse.de"
 
@@ -157,27 +157,24 @@ module "cucumber_testsuite" {
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
       container_tag = "latest"
     }
-    suse-minion = {
+    suse_minion = {
       image = "opensuse155o"
-      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:26"
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "opensuse155o"
-      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:28"
       }
       additional_packages = [ "venv-salt-minion", "iptables" ]
       install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "rocky8o"
-      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:93:01:00:2a"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
@@ -188,18 +185,16 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    debian-minion = {
+    deblike_minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:93:01:00:2b"
       }
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
-      name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:00:2d"
         memory = 2048
@@ -207,12 +202,12 @@ module "cucumber_testsuite" {
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    pxeboot-minion = {
+    pxeboot_minion = {
       image = "sles15sp4o"
       additional_packages = [ "venv-salt-minion" ]
       install_salt_bundle = true
     }
-    dhcp-dns = {
+    dhcp_dns = {
       name = "dhcp-dns"
       image = "opensuse155o"
       hypervisor = {
@@ -221,10 +216,8 @@ module "cucumber_testsuite" {
         private_key = file("~/.ssh/id_rsa")
       }
     }
-    kvm-host = {
+    kvm_host = {
       image = "opensuse155o"
-      name = "min-kvm"
-
       provider_settings = {
         mac = "aa:b2:93:01:00:2e"
       }


### PR DESCRIPTION
## What does this PR do?

 - Rename Uyuni Master components:
    - Updates the names of Uyuni Master Podman NUE modules and hostnames to comply with the new standardized minion naming conventions, ensuring consistency across our infrastructure.

  -  Remove _venv-salt_ references:
      - Eliminates all _venv-salt references_ since it is now enabled by default in the updated `cucumber testsuite module`, simplifying configuration and reducing redundancy.

## Depends on https://github.com/uyuni-project/sumaform/pull/1662 but can be merge before. Using this changes in a temporary branch.