### PR TITLE
SUMA 5.0 - REFENV - rename module names and remove configurations to use cucumber testsuite default values

### DIFF
--- a/jenkins_pipelines/environments/manager-5.0-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-infra-reference-NUE
@@ -10,7 +10,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'Manager-5.0', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/jenkins_pipelines/environments/manager-5.0-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-infra-reference-PRV
@@ -10,7 +10,7 @@ node('sumaform-cucumber-provo') {
             string(name: 'cucumber_ref', defaultValue: 'Manager-5.0', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
@@ -109,7 +109,7 @@ module "cucumber_testsuite" {
   images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slemicro55o"]
 
   use_avahi    = false
-  name_prefix  = "suma-ref50-"
+  name_prefix  = "suma-ref-50-"
   domain       = "mgr.suse.de"
   from_email   = "root@suse.de"
 
@@ -155,37 +155,28 @@ module "cucumber_testsuite" {
         memory = 2048
       }
       main_disk_size = 200
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile"
       container_tag = "latest"
     }
-    suse-minion = {
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:93:01:01:06"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:93:01:01:08"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion", "iptables" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "rocky8o"
-      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:93:01:01:09"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
@@ -193,41 +184,30 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
+    deblike_minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:93:01:01:0b"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
-      name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:01:0d"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    kvm-host = {
+    kvm_host = {
       image = "sles15sp4o"
-      name = "min-kvm"
       provider_settings = {
         mac = "aa:b2:93:01:01:0e"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
@@ -109,7 +109,7 @@ module "cucumber_testsuite" {
   images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slemicro55o"]
 
   use_avahi    = false
-  name_prefix  = "suma-ref50-"
+  name_prefix  = "suma-ref-50-"
   domain       = "mgr.prv.suse.net"
   from_email   = "root@suse.de"
 
@@ -155,37 +155,28 @@ module "cucumber_testsuite" {
         memory = 2048
       }
       main_disk_size = 200
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/5.0/containerfile"
       container_tag = "latest"
     }
-    suse-minion = {
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:92:03:00:b6"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:92:03:00:b8"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion", "iptables" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "rocky8o"
-      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:92:03:00:b9"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
@@ -193,41 +184,30 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
+    deblike_minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:92:03:00:bb"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
-      name = "min-build"
       provider_settings = {
         mac = "aa:b2:92:03:00:bd"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    kvm-host = {
+    kvm_host = {
       image = "sles15sp4o"
-      name = "min-kvm"
       provider_settings = {
         mac = "aa:b2:92:03:00:be"
         vcpu = 4
         memory = 4096
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

 - Modules components changes:
   - rename module names using `_` to separate words and make sure module names are compatible with cucumber testsuite module.
    - remove name parameter to use default cucumber testsuite names. This will automatically use the new hostnames

  -  Remove _venv-salt_ references:
      - Eliminates all _venv-salt references_ since it is now enabled by default in the updated `cucumber testsuite module`, simplifying configuration and reducing redundancy.

Related to: https://github.com/SUSE/spacewalk/issues/25062
Specific sub-task linked into this PR thread history
Depends on: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/988
**Depends on https://github.com/uyuni-project/sumaform/pull/1662 but can be merge before. Using this changes in a temporary branch.**