### PR TITLE
UYUNI MASTER - REFENV - rename module names and remove configurations to use cucumber testsuite default values

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-infra-reference-NUE
@@ -10,7 +10,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -109,7 +109,7 @@ module "cucumber_testsuite" {
   images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
 
   use_avahi    = false
-  name_prefix  = "uyuni-refmaster-"
+  name_prefix  = "uyuni-ref-master-"
   domain       = "mgr.suse.de"
   from_email   = "root@suse.de"
 
@@ -154,37 +154,28 @@ module "cucumber_testsuite" {
         memory = 2048
       }
       main_disk_size = 200
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
       runtime = "podman"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
       container_tag = "latest"
     }
-    suse-minion = {
+    suse_minion = {
       image = "opensuse155o"
-      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:e6"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "opensuse155o"
-      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:e8"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion", "iptables" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "rocky8o"
-      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:93:01:00:e9"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
@@ -192,40 +183,30 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
+    deblike_minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:93:01:00:eb"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:ed"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    kvm-host = {
+    kvm_host = {
       image = "opensuse155o"
-      name = "min-kvm"
       provider_settings = {
         mac = "aa:b2:93:01:00:ee"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
   provider_settings = {


### PR DESCRIPTION
## What does this PR do?

 - Modules components changes:
   - rename module names using `_` to separate words and make sure module names are compatible with cucumber testsuite module.
    - remove name parameter to use default cucumber testsuite names. This will automatically use the new hostnames

  -  Remove _venv-salt_ references:
      - Eliminates all _venv-salt references_ since it is now enabled by default in the updated `cucumber testsuite module`, simplifying configuration and reducing redundancy.

Related to: https://github.com/SUSE/spacewalk/issues/25062
Specific sub-task linked into this PR thread history
Depends on: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/988
**Depends on https://github.com/uyuni-project/sumaform/pull/1662 but can be merge before. Using this changes in a temporary branch.**