### PR TITLE
SUMA 4.3 - REFENV - rename module names and remove configurations to use cucumber testsuite default values

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-NUE
@@ -10,7 +10,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
             string(name: 'cucumber_ref', defaultValue: 'Manager-4.3', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-infra-reference-PRV
@@ -8,7 +8,7 @@ node('sumaform-cucumber-provo') {
         parameters([
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -109,7 +109,7 @@ module "cucumber_testsuite" {
   images = ["centos7o", "opensuse155o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
-  name_prefix  = "suma-ref43-"
+  name_prefix  = "suma-ref-43-"
   domain       = "mgr.suse.de"
   from_email   = "root@suse.de"
 
@@ -145,34 +145,25 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-minion = {
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:a6"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:a8"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion", "iptables" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "centos7o"
-      name = "min-centos7"
       provider_settings = {
         mac = "aa:b2:93:01:00:a9"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
@@ -180,40 +171,30 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
+    deblike_minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:93:01:00:ab"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:ad"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    kvm-host = {
+    kvm_host = {
       image = "sles15sp4o"
-      name = "min-kvm"
       provider_settings = {
         mac = "aa:b2:93:01:00:ae"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
@@ -94,7 +94,7 @@ module "base" {
   images            = ["centos7o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
   mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
-  product_version         = "4.3-nightly"
+  product_version   = "4.3-nightly"
 
   provider_settings = {
     pool         = "ssd"

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-PRV.tf
@@ -88,12 +88,13 @@ module "base" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  name_prefix       = "suma-ref43-"
+  name_prefix       = "suma-ref-43-"
   use_avahi         = false
   domain            = "mgr.prv.suse.net"
   images            = ["centos7o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu2204o"]
   mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
+  product_version         = "4.3-nightly"
 
   provider_settings = {
     pool         = "ssd"
@@ -104,9 +105,8 @@ module "base" {
 
 module "server" {
   source                  = "./modules/server"
+  name                    = "server"
   base_configuration      = module.base.configuration
-  product_version         = "4.3-nightly"
-  name                    = "srv"
   monitored               = true
   use_os_released_updates = true
   disable_download_tokens = false
@@ -119,82 +119,67 @@ module "server" {
   }
 }
 
-module "suse-client" {
-  source             = "./modules/client"
-  base_configuration = module.base.configuration
-  product_version    = "4.3-nightly"
-  name               = "cli-sles15"
-  image              = "sles15sp4o"
-
+module "suse_client" {
+  source                  = "./modules/client"
+  base_configuration      = module.base.configuration
+  image                   = "sles15sp4o"
+  name                    = "suse-client"
   server_configuration    = module.server.configuration
   use_os_released_updates = true
 
   provider_settings = {
     mac = "aa:b2:92:03:00:96"
   }
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
-module "suse-minion" {
-  source             = "./modules/minion"
-  base_configuration = module.base.configuration
-  product_version    = "4.3-nightly"
-  name               = "min-sles15"
-  image              = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
-
+module "suse_minion" {
+  source                  = "./modules/minion"
+  base_configuration      = module.base.configuration
+  image                   = "sles15sp3o" // left with SP3 since we update it to SP4 in the testsuite
+  name                    = "suse-minion"
   server_configuration    = module.server.configuration
   use_os_released_updates = true
 
   provider_settings = {
     mac = "aa:b2:92:03:00:98"
   }
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
-module "redhat-minion" {
-  source             = "./modules/minion"
-  base_configuration = module.base.configuration
-  product_version    = "4.3-nightly"
-  name               = "min-centos7"
-  image              = "centos7o"
+module "rhlike_minion" {
+  source                = "./modules/minion"
+  base_configuration    = module.base.configuration
+  image                 = "centos7o"
+  name                  = "rhlike-minion"
 
   server_configuration   = module.server.configuration
   auto_connect_to_master = false
 
   provider_settings = {
-    mac = "aa:b2:92:03:00:99"
+    mac = "aa:b2:92:03:00:9a"
     // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
     // Also, openscap cannot run with less than 1.25 GB of RAM
     memory = 2048
     vcpu = 2
   }
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
-module "debian-minion" {
-  source               = "./modules/minion"
-  base_configuration   = module.base.configuration
-  product_version      = "4.3-nightly"
-  name                 = "min-ubuntu2204"
-  image                = "ubuntu2204o"
-  server_configuration = module.server.configuration
+module "deblike_minion" {
+  source                = "./modules/minion"
+  base_configuration    = module.base.configuration
+  image                 = "ubuntu2204o"
+  name                  = "deblike-minion"
+  server_configuration  = module.server.configuration
 
   provider_settings = {
     mac = "aa:b2:92:03:00:9b"
   }
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
-module "build-host" {
+module "build_host" {
   source                  = "./modules/build_host"
   base_configuration      = module.base.configuration
-  product_version         = "4.3-nightly"
-  name                    = "min-build"
   image                   = "sles15sp4o"
+  name                    = "build-host"
   server_configuration    = module.server.configuration
 
   provider_settings = {
@@ -208,21 +193,16 @@ module "build-host" {
         devel_pool_repo = "http://minima-mirror-ci-bv.mgr.prv.suse.net/SUSE/Products/SLE-Module-Development-Tools/15-SP4/x86_64/product/",
         devel_updates_repo = "http://minima-mirror-ci-bv.mgr.prv.suse.net/SUSE/Updates/SLE-Module-Development-Tools/15-SP4/x86_64/update/"
   }
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
-module "kvm-minion" {
+module "kvm_host" {
   source               = "./modules/virthost"
   base_configuration   = module.base.configuration
-  product_version      = "head"
-  name                 = "min-kvm"
   image                = "sles15sp4o"
+  name                 = "kvm-host"
   server_configuration = module.server.configuration
 
   provider_settings = {
     mac = "aa:b2:92:03:00:9e"
   }
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }


### PR DESCRIPTION
## What does this PR do?

 - Modules components changes:
   - rename module names using `_` to separate words and make sure module names are compatible with cucumber testsuite module.
    - remove name parameter to use default cucumber testsuite names. This will automatically use the new hostnames

  -  Remove _venv-salt_ references:
      - Eliminates all _venv-salt references_ since it is now enabled by default in the updated `cucumber testsuite module`, simplifying configuration and reducing redundancy.

Related to: https://github.com/SUSE/spacewalk/issues/25062
Specific sub-task linked into this PR thread history
Depends on: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/988
**Depends on https://github.com/uyuni-project/sumaform/pull/1662 but can be merge before. Using this changes in a temporary branch.**