### PR TITLE
Revert to 0.6.3 for tests on PRs

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.8.1"
+      version = "0.6.3"
     }
   }
 }


### PR DESCRIPTION
So not to hit tests on PRs
