### PR TITLE
Update all squad pipeline module names and hostnames

### DIFF
--- a/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Hexagon-acceptance-tests
@@ -11,7 +11,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Ion-acceptance-tests
@@ -10,7 +10,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'drop-unused-register_push_client-5.0', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Naica-acceptance-tests
@@ -10,7 +10,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -11,7 +11,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'test-orion-setup', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -147,80 +147,60 @@ module "cucumber_testsuite" {
       container_tag = "latest"
     }
 
-    suse-minion = {
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:56"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-suse"
       provider_settings = {
         mac = "aa:b2:93:01:00:58"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion", "iptables" ]
-      install_salt_bundle = true
+      additional_packages = [ "iptables" ]
     }
-    redhat-minion = {
+    rhlike-minion = {
       image = "rocky8o"
-      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:93:01:00:5a"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
         // Still researching, but it will do it for now
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
+    deblike_minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:93:01:00:5b"
         vcpu = 2
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:5d"
         vcpu = 4
         memory = 8192
       }
-      name = "min-build"
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    pxeboot-minion = {
+    pxeboot_minion = {
       image = "sles15sp4o"
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
       provider_settings = {
         vcpu = 2
         memory = 2048
       }
     }
-    kvm-host = {
+    kvm_host = {
       image = "sles15sp4o"
-      name = "min-kvm"
-      
       provider_settings = {
         mac = "aa:b2:93:01:00:5e"
         vcpu = 4
         memory = 8192
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
   

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -162,7 +162,7 @@ module "cucumber_testsuite" {
       }
       additional_packages = [ "iptables" ]
     }
-    rhlike-minion = {
+    rhlike_minion = {
       image = "rocky8o"
       provider_settings = {
         mac = "aa:b2:93:01:00:5a"

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -176,24 +176,24 @@ module "cucumber_testsuite" {
         mac = "aa:b2:93:01:00:49"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
         // Also, openscap cannot run with less than 1.25 GB of RAM
-        memory = 2048
         vcpu = 2
+        memory = 2048
       }
     }
     deblike_minion = {
       image = "ubuntu2204o"
       provider_settings = {
-        mac = "aa:b2:93:01:00:50"
-        memory = 2048
+        mac = "aa:b2:93:01:00:4b"
         vcpu = 2
+        memory = 2048
       }
     }
     build_host = {
       image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:4d"
-        memory = 2048
         vcpu = 2
+        memory = 2048
       }
     }
     pxeboot_minion = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -143,43 +143,47 @@ module "cucumber_testsuite" {
     proxy_containerized = {
       provider_settings = {
         mac = "aa:b2:93:01:00:42"
-      }
         vcpu = 2
         memory = 2048
+      }
     }
-    suse-minion = {
+    slemicro_minion = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:44"
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:46"
-      }
         vcpu = 2
         memory = 2048
+      }
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:48"
-      }
         vcpu = 2
         memory = 2048
+      }
     }
     rhlike_minion = {
       image = "rocky8o"
-      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:93:01:00:49"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
         // Also, openscap cannot run with less than 1.25 GB of RAM
-        vcpu = 2
         memory = 2048
+        vcpu = 2
       }
     }
     deblike_minion = {
       image = "ubuntu2204o"
       provider_settings = {
-        //mac = "aa:b2:93:01:00:50"
+        mac = "aa:b2:93:01:00:50"
         memory = 2048
         vcpu = 2
       }
@@ -188,16 +192,15 @@ module "cucumber_testsuite" {
       image = "sles15sp4o"
       provider_settings = {
         mac = "aa:b2:93:01:00:4d"
-        vcpu = 2
         memory = 2048
+        vcpu = 2
       }
     }
     pxeboot_minion = {
       image = "sles15sp4o"
     }
-    kvm-host = {
+    kvm_host = {
       image = "sles15sp4o"
-      name = "min-kvm"
       provider_settings = {
         mac = "aa:b2:93:01:00:4e"
       }

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -142,38 +142,27 @@ module "cucumber_testsuite" {
       additional_repos = {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Naica/openSUSE_Leap_15.3/"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     */
-    suse-client = {
+    suse_client = {
       image = "sles15sp4o"
-      name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:64"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-minion = {
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:66"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:68"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "centos7o"
       provider_settings = {
         mac = "aa:b2:93:01:00:69"
@@ -182,27 +171,19 @@ module "cucumber_testsuite" {
         memory = 2048
         vcpu = 2
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
-      name = "min-ubuntu2204"
+    deblike_minion = {
       image = "ubuntu2204o"
       provider_settings = {
         mac = "aa:b2:93:01:00:6b"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
-      name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:00:6d"
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
   provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -153,8 +153,6 @@ module "cucumber_testsuite" {
         memory = 2048
       }
       main_disk_size = 200
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/test/orion/containerfile"
       container_tag = "latest"
@@ -162,30 +160,25 @@ module "cucumber_testsuite" {
         Test_repo = "http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST:/Orion/SLE_15_SP5/"
       }
     }
-    suse-minion = {
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:76"
         vcpu = 2
         memory = 2048
       }
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:78"
         vcpu = 2
         memory = 2048
       }
       additional_packages = [ "iptables" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "rocky8o"
-      name = "min-rocky8"
       provider_settings = {
         mac = "aa:b2:93:01:00:79"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
@@ -193,40 +186,33 @@ module "cucumber_testsuite" {
         vcpu = 2
         memory = 2048
       }
-      install_salt_bundle = true
     }
-    debian-minion = {
+    deblike_minion = {
       image = "ubuntu2204o"
-      name = "min-ubuntu2204"
       provider_settings = {
         mac = "aa:b2:93:01:00:7b"
         vcpu = 2
         memory = 2048
       }
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
-      name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:00:7d"
         vcpu = 2
         memory = 2048
       }
-      install_salt_bundle = true
     }
-    pxeboot-minion = {
+    pxeboot_minion = {
       image = "sles15sp4o"
     }
-    kvm-host = {
+    kvm_host = {
       image = "sles15sp4o"
-      name = "min-kvm"
       provider_settings = {
         mac = "aa:b2:93:01:00:7c"
         vcpu = 4
         memory = 4096
       }
-      install_salt_bundle = true
     }
   }
 

--- a/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
@@ -134,38 +134,27 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:32"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
     */
-    suse-client = {
+    suse_client = {
       image = "sles15sp4o"
-      name = "cli-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:34"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-minion = {
+    suse_minion = {
       image = "sles15sp4o"
-      name = "min-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:36"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "sles15sp4o"
-      name = "minssh-sles15"
       provider_settings = {
         mac = "aa:b2:93:01:00:38"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "centos7o"
       provider_settings = {
         mac = "aa:b2:93:01:00:39"
@@ -174,27 +163,19 @@ module "cucumber_testsuite" {
         memory = 2048
         vcpu = 2
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
-      name = "min-ubuntu2204"
+    deblike_minion = {
       image = "ubuntu2204o"
       provider_settings = {
         mac = "aa:b2:93:01:00:3b"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
-      name = "min-build"
       provider_settings = {
         mac = "aa:b2:93:01:00:3d"
         memory = 2048
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
   }
   provider_settings = {


### PR DESCRIPTION
## What does this PR do?

 - Modules components changes:
   - rename module names using `_` to separate words and make sure module names are compatible with cucumber testsuite module.
    - remove name parameter to use default cucumber testsuite names. This will automatically use the new hostnames

  -  Remove _venv-salt_ references:
      - Eliminates all _venv-salt references_ since it is now enabled by default in the updated `cucumber testsuite module`, simplifying configuration and reducing redundancy.

Related to: https://github.com/SUSE/spacewalk/issues/25062
Specific sub-task linked into this PR thread history
Depends on: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/990
**Depends on https://github.com/uyuni-project/sumaform/pull/1662 but can be merge before. Using this changes in a temporary branch.**