### PR TITLE
update aws hostname and modules

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -10,7 +10,7 @@ node('sumaform-cucumber') {
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-AWS.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
-            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            string(name: 'sumaform_ref', defaultValue: 'rename_cucumber_testsuite_module', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
             choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
             choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -194,7 +194,6 @@ module "server" {
   provider_settings = {
     instance_type = "m6a.xlarge"
   }
-  //server_additional_repos
 
 }
 
@@ -219,71 +218,58 @@ module "proxy" {
   ssh_key_path              = "./salt/controller/id_rsa.pub"
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
-  //proxy_additional_repos
 
 }
 
-module "suse-client" {
+module "suse_client" {
 
-  source             = "./modules/client"
-  base_configuration = module.base.configuration
-  name                 = "cli-sles15"
-  image                = "sles15sp4o"
-  product_version    = "4.3-released"
-  server_configuration = module.server.configuration
-  sles_registration_code = var.SLES_REGISTRATION_CODE
+  source                  = "./modules/client"
+  base_configuration      = module.base.configuration
+  image                   = "sles15sp4o"
+  product_version         = "4.3-released"
+  server_configuration    = module.server.configuration
+  sles_registration_code  = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
   }
-  //sle15sp4-client_additional_repos
 }
 
-module "suse-minion" {
+module "suse_minion" {
   source             = "./modules/minion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
-  name               = "min-sles15"
   image              = "sles15sp4o"
   server_configuration = module.server.configuration
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
   }
-  //sle15sp4-minion_additional_repos
 
 }
 
-module "suse-sshminion" {
+module "suse_sshminion" {
   source             = "./modules/sshminion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
-  name               = "minssh-sles15"
   image              = "sles15sp4o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
-  additional_packages = [ "venv-salt-minion" , "iptables"]
-  install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
   }
 
 }
 
-module "redhat-minion"  {
+module "rhlike_minion"  {
   image = "rocky8"
-  name = "min-rocky8"
   provider_settings = {
     // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
     // Also, openscap cannot run with less than 1.25 GB of RAM
@@ -297,12 +283,9 @@ module "redhat-minion"  {
   server_configuration = module.server.configuration
   auto_connect_to_master = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
 }
 
-module "debian-minion" {
-  name = "min-ubuntu2204"
+module "deblike_minion" {
   image = "ubuntu2204"
   source             = "./modules/minion"
   base_configuration = module.base.configuration
@@ -310,30 +293,10 @@ module "debian-minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
   }
 }
-//
-//module "build-host"  {
-//  image = "sles15sp4o"
-//  name = "build-host"
-//  source             = "./modules/build_host"
-//  base_configuration = module.base.configuration
-//  sles_registration_code = var.SLES_REGISTRATION_CODE
-//  product_version    = "4.3-released"
-//  server_configuration = module.server.configuration
-//  auto_connect_to_master  = false
-//  use_os_released_updates = true
-//  ssh_key_path            = "./salt/controller/id_rsa.pub"
-//  additional_packages = [ "venv-salt-minion" ]
-//  install_salt_bundle = true
-//  provider_settings = {
-//    instance_type = "t3a.large"
-//  }
-//}
 
 module "controller" {
   source             = "./modules/controller"
@@ -355,12 +318,12 @@ module "controller" {
 
   server_configuration    = module.server.configuration
   proxy_configuration     = module.proxy.configuration
-  client_configuration    = module.suse-client.configuration
-  minion_configuration    = module.suse-minion.configuration
+  client_configuration    = module.suse_client.configuration
+  minion_configuration    = module.suse_minion.configuration
 //  buildhost_configuration = module.build-host.configuration
-  sshminion_configuration = module.suse-sshminion.configuration
-  redhat_configuration    = module.redhat-minion.configuration
-  debian_configuration    = module.debian-minion.configuration
+  sshminion_configuration = module.suse_sshminion.configuration
+  redhat_configuration    = module.rhlike_minion.configuration
+  debian_configuration    = module.deblike_minion.configuration
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -227,6 +227,7 @@ module "suse_client" {
   base_configuration      = module.base.configuration
   image                   = "sles15sp4o"
   product_version         = "4.3-released"
+  name                 = "suse-client"
   server_configuration    = module.server.configuration
   sles_registration_code  = var.SLES_REGISTRATION_CODE
   auto_register           = false
@@ -242,6 +243,7 @@ module "suse_minion" {
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
   image              = "sles15sp4o"
+  name               = "suse-minion"
   server_configuration = module.server.configuration
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
@@ -258,6 +260,7 @@ module "suse_sshminion" {
   base_configuration = module.base.configuration
   product_version    = "4.3-released"
   image              = "sles15sp4o"
+  name               = "suse-minion"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -270,6 +273,7 @@ module "suse_sshminion" {
 
 module "rhlike_minion"  {
   image = "rocky8"
+  name = "rhlike-minion"
   provider_settings = {
     // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
     // Also, openscap cannot run with less than 1.25 GB of RAM
@@ -287,6 +291,7 @@ module "rhlike_minion"  {
 
 module "deblike_minion" {
   image = "ubuntu2204"
+  name = "deblike-minion"
   source             = "./modules/minion"
   base_configuration = module.base.configuration
   product_version    = "4.3-released"

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -175,7 +175,6 @@ module "cucumber_testsuite" {
     }
     suse_minion = {
       image = "opensuse155o"
-      name = "min-suse"
       provider_settings = {
         instance_type = "t3a.medium"
         private_ip = "172.16.3.8"
@@ -184,7 +183,6 @@ module "cucumber_testsuite" {
     }
     suse_sshminion = {
       image = "opensuse155o"
-      name = "minssh-suse"
       provider_settings = {
         instance_type = "t3a.medium"
         private_ip = "172.16.3.9"

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -145,7 +145,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         instance_type = "c6i.xlarge"
         private_ip = "172.16.3.5"
-        overwrite_fqdn = "uyuni-master-ctl.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-controller.sumaci.aws"
       }
     }
     server_containerized = {
@@ -154,7 +154,7 @@ module "cucumber_testsuite" {
         instance_type = "m6a.xlarge"
         volume_size = "100"
         private_ip = "172.16.3.6"
-        overwrite_fqdn = "uyuni-master-srv.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-server.sumaci.aws"
       }
       runtime = "podman"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
@@ -167,7 +167,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         instance_type = "c6i.large"
         private_ip = "172.16.3.7"
-        overwrite_fqdn = "uyuni-master-pxy.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-proxy.sumaci.aws"
       }
       runtime = "podman"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
@@ -178,7 +178,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         instance_type = "t3a.medium"
         private_ip = "172.16.3.8"
-        overwrite_fqdn = "uyuni-master-min-sles15.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-suse-minion.sumaci.aws"
       }
     }
     suse_sshminion = {
@@ -186,7 +186,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         instance_type = "t3a.medium"
         private_ip = "172.16.3.9"
-        overwrite_fqdn = "uyuni-master-minssh-sles15.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-suse-sshminion.sumaci.aws"
       }
     }
     rhlike_minion = {
@@ -196,7 +196,7 @@ module "cucumber_testsuite" {
         // use small instead of micro
         instance_type = "t3a.medium"
         private_ip = "172.16.3.10"
-        overwrite_fqdn = "uyuni-master-min-rocky8.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-rhlike-minion.sumaci.aws"
       }
     }
     deblike_minion = {
@@ -204,7 +204,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         instance_type = "t3a.medium"
         private_ip = "172.16.3.11"
-        overwrite_fqdn = "uyuni-master-min-ubuntu2204.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-deblike-minion.sumaci.aws"
       }
     }
     build_host = {
@@ -212,7 +212,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         instance_type = "t3a.large"
         private_ip = "172.16.3.12"
-        overwrite_fqdn = "uyuni-master-min-build.sumaci.aws"
+        overwrite_fqdn = "uyuni-master-build-host.sumaci.aws"
       }
     }
 // No PXE support for AWS yet

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -169,13 +169,11 @@ module "cucumber_testsuite" {
         private_ip = "172.16.3.7"
         overwrite_fqdn = "uyuni-master-pxy.sumaci.aws"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
       runtime = "podman"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers"
       container_tag = "latest"
     }
-    suse-minion = {
+    suse_minion = {
       image = "opensuse155o"
       name = "min-suse"
       provider_settings = {
@@ -183,10 +181,8 @@ module "cucumber_testsuite" {
         private_ip = "172.16.3.8"
         overwrite_fqdn = "uyuni-master-min-sles15.sumaci.aws"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    suse-sshminion = {
+    suse_sshminion = {
       image = "opensuse155o"
       name = "minssh-suse"
       provider_settings = {
@@ -194,10 +190,8 @@ module "cucumber_testsuite" {
         private_ip = "172.16.3.9"
         overwrite_fqdn = "uyuni-master-minssh-sles15.sumaci.aws"
       }
-      additional_packages = [ "venv-salt-minion", "iptables" ]
-      install_salt_bundle = true
     }
-    redhat-minion = {
+    rhlike_minion = {
       image = "rocky8"
       provider_settings = {
         // openscap cannot run with less than 1.25 GB of RAM
@@ -206,29 +200,22 @@ module "cucumber_testsuite" {
         private_ip = "172.16.3.10"
         overwrite_fqdn = "uyuni-master-min-rocky8.sumaci.aws"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    debian-minion = {
-      name = "min-ubuntu2204"
+    deblike_minion = {
       image = "ubuntu2204"
       provider_settings = {
         instance_type = "t3a.medium"
         private_ip = "172.16.3.11"
         overwrite_fqdn = "uyuni-master-min-ubuntu2204.sumaci.aws"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
-    build-host = {
+    build_host = {
       image = "sles15sp4o"
       provider_settings = {
         instance_type = "t3a.large"
         private_ip = "172.16.3.12"
         overwrite_fqdn = "uyuni-master-min-build.sumaci.aws"
       }
-      additional_packages = [ "venv-salt-minion" ]
-      install_salt_bundle = true
     }
 // No PXE support for AWS yet
 // No nested virtualization in AWS


### PR DESCRIPTION
## What does this PR
Align aws uyuni pipeline with the new module names to be compatible with the new cucumber testsuite module.
Use the new naming convention for the node deployment (route53 in AWS has been updated).
Remove useless venv-salt declaration.

Depends on https://github.com/uyuni-project/sumaform/pull/1662