### PR TITLE
Adding staging repository to SL Micro 6.1 for BV

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -275,6 +275,7 @@ def get_version_nodes(version: str) -> dict[str, list[str]]:
 def init_custom_repositories(version: str) -> dict[str, dict[str, str]]:
     custom_repositories = {}
     custom_repositories['slmicro60_minion'] = { 'slmicro60_staging' : "http://download.suse.de/ibs/SUSE:/ALP:/Source:/Standard:/1.0:/Staging:/Z/standard/" }
+    custom_repositories['slmicro61_minion'] = { 'slmicro61_staging' : "http://download.suse.de/ibs/SUSE:/ALP:/Source:/Standard:/1.0:/Staging:/Z/standard/" }
     return custom_repositories
 
 def update_custom_repositories(custom_repositories: dict[str, dict[str, str]], node: str, mi_id: str, url: str):


### PR DESCRIPTION
Alike generated part for `slmicro60_minion` with reference to https://jira.suse.com/browse/MSQA-914
```json
  "slmicro60_minion": {
    "slmicro60_staging": "http://download.suse.de/ibs/SUSE:/ALP:/Source:/Standard:/1.0:/Staging:/Z/standard/"
  },
```

The same should be done for the newly added `slmicro61_minion`.

Output after run:
```json
...
  "slmicro61_minion": {
    "slmicro61_staging": "http://download.suse.de/ibs/SUSE:/ALP:/Source:/Standard:/1.0:/Staging:/Z/standard/"
  },
...
```

Full output here: https://github.com/SUSE/spacewalk/issues/24901#issuecomment-2612391085