### PR TITLE
Beta client tools are not ready yet

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -144,7 +144,7 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile"
       container_tag = "latest"
-      beta_enabled = true
+      beta_enabled = false
     }
     proxy_containerized = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -147,7 +147,7 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile"
       container_tag = "latest"
-      beta_enabled = true
+      beta_enabled = false
     }
     proxy_containerized = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -138,7 +138,7 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/test/ion/containerfile"
       container_tag = "latest"
-      beta_enabled = true
+      beta_enabled = false
     }
     proxy_containerized = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -179,7 +179,7 @@ module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
   name               = "server"
-  beta_enabled       = var.PRODUCT_VERSION == "head" ? true : false
+  beta_enabled       = false
   provider_settings = {
     mac                = "aa:b2:93:01:02:81"
     memory             = 40960


### PR DESCRIPTION
Disable client tools that are not enabled yet in HEAD.

See https://github.com/uyuni-project/uyuni/pull/9743 : avoid starting to synchronize the "Manager beta client tools" that appear in the product tree, but are in fact the beta client tools for 5.0.

## IMPORTANT NOTE:

In fact, this setting does not seem to work. We had:
```
terracumber_config/tf_files/SUSEManager-Head-NUE.tf:      beta_enabled = true
```

but on the controller:
```
suma-ci-head-controller:~ # env | grep BETA
BETA_ENABLED=False
```

There is probably some bug in sumaform and/or terracumber, that should be fixed before we enable the beta client tools...

