### PR TITLE
QE: Have Proxy bootstrap on its own stage

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -122,6 +122,9 @@ def run(params) {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:core'"
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:reposync'"
             }
+            stage('Core - Proxy') {
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:proxy'"
+            }
             stage('Core - Initialize clients') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake ${params.rake_namespace}:init_clients'"
             }


### PR DESCRIPTION
Card: https://github.com/SUSE/spacewalk/issues/22434

Some time ago, we have the proxy initialized in a different stage.

Having the proxy at the same stage of the rest of the clients it impedes to bootstrap the clients in parallel. 

This PR refactors it, so we have again the proxy onboarding on its own stage, before initializing the clients on CI test suites.

This PR can't be merged without the refactors in 4.3, 5.0, master branches, to have different YAML file for the proxy features.