### PR TITLE
Switch to Ubuntu 24.04 in CI/refenv 5.0/head/uyuni

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ image for testing Pull Requests built with the open build service. This needs to
 
 | Version       | Minion      | SSH minion  | Client      | RH-like  | Deb-like     | Virthost    | Buildhost   | Terminal    | Controller | Server         | Proxy          |
 | ------------- | ----------- | ----------- | ----------- | -------- | ------------ | ----------- | ----------- | ----------- | ---------- | -------------- | -------------- |
-|  PR test      | Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap 15.5      | Leap 15.5      |
-|  Uyuni        | Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 22.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap Micro 5.5 | Leap Micro 5.5 |
-|  HEAD         | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SL Micro 6.1   | SL Micro 6.1   |
-|  5.0          | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLE Micro 5.5  | SLE Micro 5.5  |
+|  PR test      | Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 24.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap 15.5      | Leap 15.5      |
+|  Uyuni        | Leap 15.5   | Leap 15.5   | -           | Rocky 8  | Ubuntu 24.04 | Leap 15.5   | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | Leap Micro 5.5 | Leap Micro 5.5 |
+|  HEAD         | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 24.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SL Micro 6.1   | SL Micro 6.1   |
+|  5.0          | SLES 15 SP4 | SLES 15 SP4 | -           | Rocky 8  | Ubuntu 24.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLE Micro 5.5  | SLE Micro 5.5  |
 |  4.3          | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Rocky 8  | Ubuntu 22.04 | SLES 15 SP4 | SLES 15 SP4 | SLES 15 SP4 | Leap 15.5  | SLES 15 SP4    | SLES 15 SP4    |

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slmicro61o"]
+  images = ["rocky8o", "opensuse155o", "ubuntu2404o", "sles15sp4o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "suma-ci-head-"
@@ -184,7 +184,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:bb"
         vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slmicro61o"]
+  images = ["rocky8o", "opensuse155o", "ubuntu2404o", "sles15sp4o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "suma-ref-head-"
@@ -187,7 +187,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:cb"
         vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slemicro55o"]
+  images = ["rocky8o", "opensuse155o", "ubuntu2404o", "sles15sp4o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-hexagon-"
@@ -172,7 +172,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:5b"
         vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slemicro55o"]
+  images = ["rocky8o", "opensuse155o", "ubuntu2404o", "sles15sp4o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-ion-"
@@ -181,7 +181,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:4b"
         vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slemicro55o"]
+  images = ["rocky8o", "opensuse155o", "ubuntu2404o", "sles15sp4o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-naica-"
@@ -184,7 +184,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:6b"
       }

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -103,7 +103,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2204o", "slmicro61o"]
+  images = ["rocky8o", "opensuse155o", "sles15sp4o", "ubuntu2404o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-orion-"
@@ -187,7 +187,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:7b"
         vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "ubuntu2204o", "sles15sp4o", "slemicro55o"]
+  images = ["rocky8o", "opensuse155o", "ubuntu2404o", "sles15sp4o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-test-vega-"
@@ -184,7 +184,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:3b"
       }

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8", "opensuse155o", "sles15sp4o", "ubuntu2204"]
+  images = ["rocky8", "opensuse155o", "sles15sp4o", "ubuntu2404"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"
@@ -200,7 +200,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204"
+      image = "ubuntu2404"
       provider_settings = {
         instance_type = "t3a.medium"
         private_ip = "172.16.3.11"

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
+  images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2404o", "sles15sp4o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-ci-master-k3s-"
@@ -187,7 +187,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:1b"
       }

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -107,7 +107,7 @@ module "cucumber_testsuite" {
   cc_username   = var.SCC_USER
   cc_password   = var.SCC_PASSWORD
 
-  images        = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
+  images        = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2404o", "sles15sp4o"]
 
   use_avahi     = false
   name_prefix   = "uyuni-ci-master-"
@@ -189,7 +189,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image             = "ubuntu2204o"
+      image             = "ubuntu2404o"
       provider_settings = {
         mac     = "aa:b2:93:01:00:db"
         vcpu    = 2

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username  = var.SCC_USER
   cc_password  = var.SCC_PASSWORD
 
-  images       = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
+  images       = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2404o", "sles15sp4o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-ci-master-"
@@ -182,7 +182,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:92:03:00:db"
         vcpu = 2

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -107,7 +107,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images        = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
+  images        = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2404o", "sles15sp4o"]
 
   use_avahi     = false
   name_prefix   = "uyuni-ci-master-podman-"
@@ -181,7 +181,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image             = "ubuntu2204o"
+      image             = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:2b"
       }

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
+  images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2404o", "sles15sp4o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-ref-master-"
@@ -185,7 +185,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:93:01:00:eb"
         vcpu = 2

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2204o", "sles15sp4o"]
+  images = ["rocky8o", "opensuse155o", "leapmicro55o", "ubuntu2404o", "sles15sp4o"]
 
   use_avahi    = false
   name_prefix  = "suma-codecov-"
@@ -192,7 +192,7 @@ module "cucumber_testsuite" {
       }
     }
     deblike_minion = {
-      image = "ubuntu2204o"
+      image = "ubuntu2404o"
       provider_settings = {
         mac = "aa:b2:92:04:00:f7"
         memory = 4096


### PR DESCRIPTION
Switch to Ubuntu 24.04 in CI/refenv 5.0/head/uyuni

Note: 5.0 done separately in 5.0 because of considerations on merging order: #1545