### PR TITLE
Add proxy to PR testing

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -296,6 +296,13 @@ def run(params) {
                     }
                 }
             }
+            stage('Core - Proxy') {
+                ws(environment_workspace){
+                    if(must_test) {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${namespace}:proxy'"
+                    }
+                }
+            }
             stage('Core - Initialize clients') {
                 ws(environment_workspace){
                     if(must_test) {


### PR DESCRIPTION
## What does this PR ? 

Proxy is required for the init client step but not declare in the PR pipeline.
Add  init proxy to PR pipeline script.