### PR TITLE
Workaround s390 clients delete

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -142,6 +142,8 @@ def run(params) {
                 // WORKAROUND: Remove s390 clients manually until https://github.com/SUSE/spacewalk/issues/26502 is fixed.
                 sh """
                     set +x
+                    source ~/.credentials
+                    export TF_VAR_CONTAINER_REPOSITORY='unused'
                     cd ${localSumaformDirPath}
                     sh ${remove_s390_bash} main.tf
                     terraform refresh

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -148,26 +148,26 @@ def run(params) {
                     sh ${remove_s390_bash} main.tf
                     terraform refresh
                 """
-//                // Execute Terracumber CLI to deploy the environment without clients
-//                sh """
-//                    ${environmentVars}
-//                    set +x
-//                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${logFile} --init --sumaform-backend ${sumaform_backend} --use-tf-resource-cleaner --init --runstep provision ${tfResourcesToDeleteArg}
-//                """
+                // Execute Terracumber CLI to deploy the environment without clients
+                sh """
+                    ${environmentVars}
+                    set +x
+                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${logFile} --init --sumaform-backend ${sumaform_backend} --use-tf-resource-cleaner --init --runstep provision ${tfResourcesToDeleteArg}
+                """
             }
 
-//            stage('Redeploy the environment with new client VMs') {
-//                // Run Terracumber to deploy the environment
-//                sh """
-//                    ${environmentVars}
-//                    set +x
-//                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/sumaform.log --init --sumaform-backend ${sumaform_backend} --runstep provision
-//                """
-//            }
+            stage('Redeploy the environment with new client VMs') {
+                // Run Terracumber to deploy the environment
+                sh """
+                    ${environmentVars}
+                    set +x
+                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/sumaform.log --init --sumaform-backend ${sumaform_backend} --runstep provision
+                """
+            }
 
-//            stage('Sanity check') {
-//                sh "${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:build_validation_sanity_check'"
-//            }
+            stage('Sanity check') {
+                sh "${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:build_validation_sanity_check'"
+            }
 
         }
         finally {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -2,6 +2,7 @@ def run(params) {
     timestamps {
         // Define paths and environment variables for reusability
         GString TestEnvironmentCleanerProgram = "${WORKSPACE}/susemanager-ci/jenkins_pipelines/scripts/test_environment_cleaner/test_environment_cleaner_program/TestEnvironmentCleaner.py"
+        GString remove_s390_bash = "${WORKSPACE}/susemanager-ci/jenkins_pipelines/scripts/test_environment_cleaner/delete_s390_clients.sh"
         GString resultdir = "${WORKSPACE}/results"
         GString resultdirbuild = "${resultdir}/${BUILD_NUMBER}"
         GString exports = "export BUILD_NUMBER=${BUILD_NUMBER}; export BUILD_VALIDATION=true; "
@@ -138,7 +139,13 @@ def run(params) {
             stage('Delete client VMs') {
                 // Join the resources into a comma-separated string if there are any to delete
                 String tfResourcesToDeleteArg = params.tfResourcesToDelete ? '' : "--tf-resources-delete-all"
-
+                // WORKAROUND: Remove s390 clients manually until https://github.com/SUSE/spacewalk/issues/26502 is fixed.
+                sh """
+                    set +x
+                    cd ${localSumaformDirPath}
+                    sh ${remove_s390_bash} main.tf
+                    terraform refresh
+                """
                 // Execute Terracumber CLI to deploy the environment without clients
                 sh """
                     ${environmentVars}
@@ -148,7 +155,6 @@ def run(params) {
             }
 
             stage('Redeploy the environment with new client VMs') {
-
                 // Run Terracumber to deploy the environment
                 sh """
                     ${environmentVars}

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -141,9 +141,9 @@ def run(params) {
                 String tfResourcesToDeleteArg = params.tfResourcesToDelete ? '' : "--tf-resources-delete-all"
                 // WORKAROUND: Remove s390 clients manually until https://github.com/SUSE/spacewalk/issues/26502 is fixed.
                 sh """
-                    set +x
                     source ~/.credentials
                     export TF_VAR_CONTAINER_REPOSITORY='unused'
+                    set +x
                     cd ${localSumaformDirPath}
                     sh ${remove_s390_bash} main.tf
                     terraform refresh

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -148,26 +148,26 @@ def run(params) {
                     sh ${remove_s390_bash} main.tf
                     terraform refresh
                 """
-                // Execute Terracumber CLI to deploy the environment without clients
-                sh """
-                    ${environmentVars}
-                    set +x
-                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${logFile} --init --sumaform-backend ${sumaform_backend} --use-tf-resource-cleaner --init --runstep provision ${tfResourcesToDeleteArg}
-                """
+//                // Execute Terracumber CLI to deploy the environment without clients
+//                sh """
+//                    ${environmentVars}
+//                    set +x
+//                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${logFile} --init --sumaform-backend ${sumaform_backend} --use-tf-resource-cleaner --init --runstep provision ${tfResourcesToDeleteArg}
+//                """
             }
 
-            stage('Redeploy the environment with new client VMs') {
-                // Run Terracumber to deploy the environment
-                sh """
-                    ${environmentVars}
-                    set +x
-                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/sumaform.log --init --sumaform-backend ${sumaform_backend} --runstep provision
-                """
-            }
+//            stage('Redeploy the environment with new client VMs') {
+//                // Run Terracumber to deploy the environment
+//                sh """
+//                    ${environmentVars}
+//                    set +x
+//                    ${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/sumaform.log --init --sumaform-backend ${sumaform_backend} --runstep provision
+//                """
+//            }
 
-            stage('Sanity check') {
-                sh "${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:build_validation_sanity_check'"
-            }
+//            stage('Sanity check') {
+//                sh "${WORKSPACE}/terracumber-cli ${commonParams} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:build_validation_sanity_check'"
+//            }
 
         }
         finally {

--- a/jenkins_pipelines/scripts/test_environment_cleaner/delete_s390_clients.sh
+++ b/jenkins_pipelines/scripts/test_environment_cleaner/delete_s390_clients.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+##### Manually delete the s390 using delete_s390_guest command #####
+# Check if the main.tf file is provided as an argument
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <path_to_main.tf>"
+  exit 1
+fi
+
+# Get the main.tf file from the argument
+MAIN_TF_FILE=$1
+
+# Check if the file exists
+if [ ! -f "$MAIN_TF_FILE" ]; then
+  echo "Error: File $MAIN_TF_FILE does not exist."
+  exit 1
+fi
+
+# Extract user IDs from the main.tf file
+USERIDS=$(grep -A 1 "userid" "$MAIN_TF_FILE" | awk -F'"' '/userid/ {print $2}')
+
+# Iterate through each userid and delete the s390 clients
+for USERID in $USERIDS; do
+  echo "Deleting client with userid: $USERID"
+  delete_s390_guest "$USERID"
+
+done
+
+
+##### Remove s390 clients from the terraform state file #####
+
+# Check if the Terraform state file exists in the current directory
+if [ ! -f "terraform.tfstate" ]; then
+  echo "Error: No terraform.tfstate file found in the current directory."
+  exit 1
+fi
+
+# Get all Terraform state items containing "s390"
+MODULES=$(terraform state list | grep "s390")
+
+# Check if any modules containing "s390" were found
+if [ -z "$MODULES" ]; then
+  echo "No modules containing 's390' found in the Terraform state."
+  exit 0
+fi
+
+for MODULE in $MODULES; do
+  echo "Removing $MODULE..."
+  terraform state rm "$MODULE"
+  if [ $? -ne 0 ]; then
+    echo "Error: Failed to remove $MODULE."
+    exit 1
+  fi
+done
+
+echo "All modules containing 's390' have been successfully removed from the Terraform state."

--- a/jenkins_pipelines/scripts/test_environment_cleaner/delete_s390_clients.sh
+++ b/jenkins_pipelines/scripts/test_environment_cleaner/delete_s390_clients.sh
@@ -17,14 +17,12 @@ fi
 
 # Extract user IDs from the main.tf file
 USERIDS=$(grep -A 1 "userid" "$MAIN_TF_FILE" | awk -F'"' '/userid/ {print $2}')
-
+echo "Extracted userid: $USERIDS"
 # Iterate through each userid and delete the s390 clients
 for USERID in $USERIDS; do
   echo "Deleting client with userid: $USERID"
-  delete_s390_guest "$USERID"
-
+  /usr/local/bin/delete_s390_guest "$USERID"
 done
-
 
 ##### Remove s390 clients from the terraform state file #####
 


### PR DESCRIPTION
## Context

The deletion of s390 clients using terraform destroy is failing due to the issue described in [#26502.](https://github.com/SUSE/spacewalk/issues/26502) This problem is currently blocking the BV cleanup pipeline and the ability to clean up the BV environment using Terraform.

Since a long-term solution is not expected soon, this PR introduces a temporary workaround to address the issue.

## What does this PR do?
### Bash Script

 -   Introduces a new script, delete_s390_guest, to manually remove the s390 minion.
 -  Removes s390 modules from the Terraform state file (tfstate) to prevent conflicts during environment cleanup.

### Cleanup Pipeline

 -  Updates the cleanup pipeline to execute the new bash script before running Terraform commands.
 -  This ensures the environment is properly cleaned and avoids the issue when invoking terraform destroy.