### PR TITLE
uyuni-master-dev-acceptance-tests-code-coverage: Core Proxy stage is missing

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -104,6 +104,9 @@ node('sumaform-cucumber-provo') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:core'"
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reposync'"
             }
+            stage('Core - Proxy') {
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:proxy'"
+            }
             stage('Core - Initialize clients') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:init_clients'"
             }


### PR DESCRIPTION
## Description

Clients fail because they cannot be bootstrapped against proxy, due to non-existant proxy setup:
```
18:13:31  Scenario: Bootstrap a SLES minion                                # features/init_clients/sle_minion.feature:13
18:13:31  This scenario ran at: 2025-02-25 18:12:13 +0100
18:13:31  When I follow the left menu "Systems > Bootstrapping"          # 
...
18:13:31  Node: suma-codecov-proxy, OS Version: 5.5, Family: opensuse-leap-micro
18:13:31  And I select the hostname of "proxy" from "proxies" if present # features/step_definitions/navigation_steps.rb:461
18:13:31        Unable to find xpath "//*[contains(@class, 'data-testid-proxies-child__control')]" (Capybara::ElementNotFound)
18:13:31        ./features/step_definitions/navigation_steps.rb:171:in `/^I select "([^"]*)" from "([^"]*)"$/'
18:13:31        ./features/step_definitions/navigation_steps.rb:470:in `/^I select the hostname of "([^"]*)" from "([^"]*)"((?: if present)?)$/'
18:13:31        features/init_clients/sle_minion.feature:21:in `I select the hostname of "proxy" from "proxies" if present'
```

This PR makes stage passing up until secondary.