### PR TITLE
Remove  proxy registry path extension in 5.0 SLE updates

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
@@ -168,8 +168,7 @@ module "proxy_containerized" {
   }
 
   runtime              = "podman"
-  // The proxy is not appending this path via product code, we need to do it in our infra
-  container_repository = "${var.CONTAINER_REPOSITORY}/suse/manager/5.0/x86_64"
+  container_repository = var.CONTAINER_REPOSITORY
   container_tag        = "latest"
 
   auto_configure        = false


### PR DESCRIPTION
Path extension for Proxy should be no longer needed.