### PR TITLE
fix: Add proxy stage to reference pipelines definition

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
@@ -56,6 +56,9 @@ def run(params) {
             stage('Core - Reposync') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reference_reposync'"
             }
+            stage('Core - Proxy') {
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:proxy'"
+            }
             stage('Core - Initialize clients') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:reference_init_clients'"
             }


### PR DESCRIPTION
The new proxy stage was missing for all the reference entvironments.