### PR TITLE
Fix proxy init for reference pipeline

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
@@ -57,7 +57,7 @@ def run(params) {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reference_reposync'"
             }
             stage('Core - Proxy') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:proxy'"
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:proxy'"
             }
             stage('Core - Initialize clients') {
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:reference_init_clients'"


### PR DESCRIPTION
```bash
[2025-02-28T14:37:27.091Z] + ./terracumber-cli --outputdir /home/jenkins/workspace/manager-Head-infra-reference-NUE/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf --gitfolder /home/jenkins/workspace/manager-Head-infra-reference-NUE/results/sumaform --terraform-bin /usr/bin/terraform --logfile /home/jenkins/workspace/manager-Head-infra-reference-NUE/results/1812/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; null rake cucumber:proxy'

[2025-02-28T14:37:27.091Z] 2025-02-28 15:37:27,070 - __main__ - INFO - Running command...

[2025-02-28T14:37:27.091Z] 2025-02-28 15:37:27,070 - INFO - Running command...

[2025-02-28T14:37:27.346Z] 2025-02-28 15:37:27,091 - INFO - Connected (version 2.0, client OpenSSH_8.4)

[2025-02-28T14:37:27.346Z] 2025-02-28 15:37:27,115 - INFO - Authentication (publickey) successful!

[2025-02-28T14:37:27.346Z] bash: null: command not found

script returned exit code 1
```