### PR TITLE
Use correct bridge for x86 VMs

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
@@ -129,7 +129,7 @@ module "base_core" {
 
   provider_settings = {
     pool        = "ssd"
-    bridge      = "br0"
+    bridge      = "br1"
     additional_network = "192.168.51.0/24"
   }
 }


### PR DESCRIPTION
IP range 10.146.*.* is on the second network (the one with dhcp2.mgr.suse.de), so we have to use bridge `br1`.