### PR TITLE
Add RHEL PAYGO minion to 5.0 PAYG BV pipeline

### DIFF
--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-AWS
@@ -4,7 +4,8 @@ node('sumaform-cucumber') {
     def minionList = 'sles12sp5_minion, sles12sp5_sshminion, sles12sp5_paygo_minion, ' +
             'sles15sp4_minion, sles15sp4_sshminion, ' +
             'sles15sp5_minion, sles15sp5_sshminion, sles15sp5_paygo_minion, ' +
-            'sles15sp6_minion, sles15sp6_sshminion, sles15sp6_paygo_minion'
+            'sles15sp6_minion, sles15sp6_sshminion, sles15sp6_paygo_minion, ' +
+            'rhel9_paygo_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '5')),
         disableConcurrentBuilds(),

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-paygo-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-paygo-AWS.tf
@@ -424,6 +424,24 @@ module "sles15sp6_sshminion" {
 
 }
 
+module "rhel9_paygo_minion" {
+  source             = "./modules/minion"
+  base_configuration = module.base.configuration
+  name               = "rhel9-paygo-minion"
+  image              = "rhel9"
+  server_configuration = module.server.configuration
+  auto_connect_to_master  = false
+  use_os_released_updates = false
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  provider_settings = {
+    memory = 2048
+    vcpu = 2
+    instance_type = "t3a.medium"
+  }
+
+}
+
+
 module "controller" {
   source             = "./modules/controller"
   name               = "controller"
@@ -469,6 +487,8 @@ module "controller" {
 
   sle15sp6_minion_configuration    = module.sles15sp6_minion.configuration
   sle15sp6_sshminion_configuration = module.sles15sp6_sshminion.configuration
+
+  rhel9_minion_configuration       = module.rhel9_paygo_minion.configuration
 }
 
 output "bastion_public_name" {


### PR DESCRIPTION
Adds to the 5.0 PAYGO AWS build validation pipeline the option to deploy a RHEL 9.X PAYGO minion.