### PR TITLE
Replace RSA SSH keys with ed_25519 ones

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-AWS
@@ -25,7 +25,7 @@ node('sumaform-cucumber') {
             extendedChoice(name: 'functional_scopes',  multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30, value: '@scope_smdba,@scope_spacecmd,@scope_spacewalk_utils,@scope_visualization,@scope_notification_message,@scope_virtual_host_manager,@scope_subscription_matching,@scope_formulas,@scope_sp_migration,@scope_cve_audit,@scope_onboarding,@scope_content_lifecycle_management,@scope_res,@scope_recurring_actions,@scope_maintenance_windows,@scope_building_container_images,@scope_kubernetes_integration,@scope_openscap,@scope_deblike,@scope_action_chains,@scope_salt_ssh,@scope_tomcat,@scope_changing_software_channels,@scope_monitoring,@scope_salt,@scope_cobbler,@scope_sumatoolbox,@scope_virtualization,@scope_hub,@scope_retail,@scope_configuration_channels,@scope_content_staging,@scope_proxy,@scope_traditional_client,@scope_api,@scope_power_management,@scope_retracted_patches,@scope_ansible,@scope_reportdb,@scope_containerized_proxy', description: 'Choose the functional scopes that you want to test'),
             string(name: 'bastion_hostname', defaultValue: 'ec2-3-68-127-29.eu-central-1.compute.amazonaws.com', description: 'Hostname of the bastion to use as jumphost'),
             string(name: 'bastion_username', defaultValue: 'jumper', description: 'Username on the bastion host'),
-            string(name: 'bastion_ssh_key_file', defaultValue: '/home/jenkins/.ssh/id_rsa', description: 'SSH Key to authenticate at the bastion host')
+            string(name: 'bastion_ssh_key_file', defaultValue: '/home/jenkins/.ssh/testing-suma.pem', description: 'SSH Key to authenticate at the bastion host')
         ])
     ])
 

--- a/jenkins_pipelines/scripts/test_environment_cleaner/test_environment_cleaner_program/TestEnvironmentCleaner.py
+++ b/jenkins_pipelines/scripts/test_environment_cleaner/test_environment_cleaner_program/TestEnvironmentCleaner.py
@@ -70,7 +70,7 @@ def main():
     # Server commands part
     elif args.mode in ["update_terminal_mac_addresses"]:
         ssh_controller_session = SSHClientManager(url=args.controller_url, password= "linux")
-        ssh_hypervisor_session = SSHClientManager(url=args.hypervisor_url,ssh_key_path="/home/jenkins/.ssh/id_rsa")
+        ssh_hypervisor_session = SSHClientManager(url=args.hypervisor_url,ssh_key_path="/home/jenkins/.ssh/id_25519")
         virsh_output = ssh_hypervisor_session.run_command(f"virsh list | grep terminal | grep {''.join(product_version.split('.')[:2])} | awk '{{print $2}}'")
         terminal_names = virsh_output.strip().split("\n") if virsh_output.strip() else []
         logger.debug(f"Terminal list: {terminal_names}")

--- a/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
@@ -212,7 +212,7 @@ module "server_containerized" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
   provision                      = true
 
@@ -232,7 +232,7 @@ module "proxy_containerized" {
   container_repository      = var.PROXY_CONTAINER_REPOSITORY
   container_tag             = "latest"
   auto_configure            = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
   provision                 = true
 
   //proxy_additional_repos
@@ -250,7 +250,7 @@ module "sles12sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_minion" {
@@ -265,7 +265,7 @@ module "sles15sp3_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_minion" {
@@ -280,7 +280,7 @@ module "sles15sp4_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -295,7 +295,7 @@ module "sles15sp5_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -310,7 +310,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -324,7 +324,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_minion" {
@@ -338,7 +338,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_minion" {
@@ -352,7 +352,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "liberty9_minion" {
@@ -366,7 +366,7 @@ module "liberty9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_minion" {
@@ -380,7 +380,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_minion" {
@@ -394,7 +394,7 @@ module "rocky8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_minion" {
@@ -408,7 +408,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_minion" {
@@ -422,7 +422,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -436,7 +436,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -451,7 +451,7 @@ module "debian12_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_minion" {
@@ -471,7 +471,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_minion" {
@@ -489,7 +489,7 @@ module "sles15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
@@ -509,7 +509,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -525,7 +525,7 @@ module "slemicro51_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -543,7 +543,7 @@ module "slemicro52_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -561,7 +561,7 @@ module "slemicro53_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -579,7 +579,7 @@ module "slemicro54_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -597,7 +597,7 @@ module "slemicro55_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -615,7 +615,7 @@ module "slmicro60_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -633,7 +633,7 @@ module "slmicro61_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -650,7 +650,7 @@ module "sles12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -664,7 +664,7 @@ module "sles15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_sshminion" {
@@ -677,7 +677,7 @@ module "sles15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_sshminion" {
@@ -690,7 +690,7 @@ module "sles15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_sshminion" {
@@ -703,7 +703,7 @@ module "sles15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -716,7 +716,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_sshminion" {
@@ -729,7 +729,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_sshminion" {
@@ -742,7 +742,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 
@@ -756,7 +756,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_sshminion" {
@@ -769,7 +769,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_sshminion" {
@@ -782,7 +782,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_sshminion" {
@@ -795,7 +795,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_sshminion" {
@@ -808,7 +808,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -821,7 +821,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -834,7 +834,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_sshminion" {
@@ -853,7 +853,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_sshminion" {
@@ -871,7 +871,7 @@ module "sles15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -885,7 +885,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -899,7 +899,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -913,7 +913,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -927,7 +927,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //
@@ -944,7 +944,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -960,7 +960,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -976,7 +976,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -992,7 +992,7 @@ module "sles12sp5_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1022,7 +1022,7 @@ module "sles15sp4_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1070,7 +1070,7 @@ module "monitoring_server" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-AWS.tf
@@ -190,7 +190,7 @@ module "server" {
   publish_private_ssl_key        = false
   use_os_released_updates        = false
   disable_download_tokens        = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "m6a.xlarge"
   }
@@ -215,7 +215,7 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = false
   proxy_containerized       = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
 
@@ -232,7 +232,7 @@ module "suse_client" {
   sles_registration_code  = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -248,7 +248,7 @@ module "suse_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = true
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -263,7 +263,7 @@ module "suse_sshminion" {
   name               = "suse-minion"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = true
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   provider_settings = {
     instance_type = "t3a.medium"
@@ -286,7 +286,7 @@ module "rhlike_minion"  {
   product_version    = "4.3-released"
   server_configuration = module.server.configuration
   auto_connect_to_master = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "deblike_minion" {
@@ -297,7 +297,7 @@ module "deblike_minion" {
   product_version    = "4.3-released"
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-NUE.tf
@@ -137,7 +137,7 @@ module "server" {
   publish_private_ssl_key        = false
   use_os_released_updates        = true
   disable_download_tokens        = false
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
   accept_all_ssl_protocols       = true
 
@@ -167,7 +167,7 @@ module "proxy" {
   generate_bootstrap_script = false
   publish_private_ssl_key   = false
   use_os_released_updates   = true
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -184,7 +184,7 @@ module "sles15sp4_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-PRV.tf
@@ -137,7 +137,7 @@ module "server" {
   publish_private_ssl_key        = false
   use_os_released_updates        = true
   disable_download_tokens        = false
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
   accept_all_ssl_protocols       = true
 
@@ -166,7 +166,7 @@ module "proxy" {
   generate_bootstrap_script = false
   publish_private_ssl_key   = false
   use_os_released_updates   = true
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -185,7 +185,7 @@ module "sles15sp4_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-AWS.tf
@@ -194,7 +194,7 @@ module "server" {
   disable_download_tokens        = false
   disable_auto_bootstrap         = true
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "m6a.xlarge"
   }
@@ -220,7 +220,7 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = true
   proxy_containerized       = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "c6i.large"
   }
@@ -236,7 +236,7 @@ module "sles12sp5_client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -253,7 +253,7 @@ module "sles15sp3_client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -270,7 +270,7 @@ module "sles15sp4_client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -287,7 +287,7 @@ module "sles15sp5_client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -303,7 +303,7 @@ module "sles15sp6_client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -318,7 +318,7 @@ module "ubuntu2004_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -333,7 +333,7 @@ module "rhel9_minion" {
   image              = "rhel9"
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = true
   provider_settings = {
     instance_type = "t3a.medium"
@@ -349,7 +349,7 @@ module "rocky8_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
   provider_settings = {
@@ -367,7 +367,7 @@ module "sles12sp5_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -384,7 +384,7 @@ module "sles15sp3_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -400,7 +400,7 @@ module "sles15sp4_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -421,7 +421,7 @@ module "salt_migration_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -434,7 +434,7 @@ module "sles15sp5_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -450,7 +450,7 @@ module "sles15sp6_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -463,7 +463,7 @@ module "ubuntu2004_sshminion" {
   name               = "minssh-ubuntu2004"
   image              = "ubuntu2004"
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   provider_settings = {
     instance_type = "t3a.medium"
@@ -477,7 +477,7 @@ module "rocky8_sshminion" {
   name               = "minssh-rocky8"
   image              = "rocky8"
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -496,7 +496,7 @@ module "sles12sp5_sshminion" {
   image              = "sles12sp5"
   use_os_released_updates = false
   sles_registration_code = var.SLES_REGISTRATION_CODE
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   provider_settings = {
     instance_type = "t3a.medium"
@@ -512,7 +512,7 @@ module "sles15sp3_sshminion" {
   image              = "sles15sp3o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -526,7 +526,7 @@ module "sles15sp4_sshminion" {
   image              = "sles15sp4o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -540,7 +540,7 @@ module "sles15sp5_sshminion" {
   image              = "sles15sp5o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -554,7 +554,7 @@ module "sles15sp6_sshminion" {
   image              = "sles15sp6o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -567,7 +567,7 @@ module "ubuntu2204_sshminion" {
   name               = "minssh-ubuntu2204"
   image              = "ubuntu2204"
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -583,7 +583,7 @@ module "ubuntu2204_minion" {
   image              = "ubuntu2204"
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -195,7 +195,7 @@ module "server" {
   disable_download_tokens        = false
   disable_auto_bootstrap         = true
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
   accept_all_ssl_protocols       = true
 
@@ -224,7 +224,7 @@ module "proxy" {
   generate_bootstrap_script = false
   publish_private_ssl_key   = false
   use_os_released_updates   = true
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles12sp5_client" {
@@ -241,7 +241,7 @@ module "sles12sp5_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_client" {
@@ -258,7 +258,7 @@ module "sles15sp3_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_client" {
@@ -275,7 +275,7 @@ module "sles15sp4_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_client" {
@@ -292,7 +292,7 @@ module "sles15sp5_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_client" {
@@ -309,7 +309,7 @@ module "sles15sp6_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_client" {
@@ -326,7 +326,7 @@ module "centos7_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -346,7 +346,7 @@ module "sles12sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_minion" {
@@ -364,7 +364,7 @@ module "sles15sp3_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_minion" {
@@ -382,7 +382,7 @@ module "sles15sp4_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -400,7 +400,7 @@ module "sles15sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -418,7 +418,7 @@ module "sles15sp6_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -435,7 +435,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -455,7 +455,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -475,7 +475,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -495,7 +495,7 @@ module "liberty9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -515,7 +515,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -535,7 +535,7 @@ module "rocky8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -555,7 +555,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -575,7 +575,7 @@ module "ubuntu2004_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
   additional_packages = [ "venv-salt-minion" ]
@@ -596,7 +596,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -613,7 +613,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -631,7 +631,7 @@ module "debian12_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -657,7 +657,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_minion" {
@@ -674,7 +674,7 @@ module "sles15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
@@ -694,7 +694,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -713,7 +713,7 @@ module "slemicro51_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -735,7 +735,7 @@ module "slemicro52_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -757,7 +757,7 @@ module "slemicro53_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -779,7 +779,7 @@ module "slemicro54_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -801,7 +801,7 @@ module "slemicro55_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -823,7 +823,7 @@ module "slmicro60_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -842,7 +842,7 @@ module "slmicro61_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -857,7 +857,7 @@ module "sles12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -871,7 +871,7 @@ module "sles15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_sshminion" {
@@ -884,7 +884,7 @@ module "sles15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_sshminion" {
@@ -897,7 +897,7 @@ module "sles15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_sshminion" {
@@ -910,7 +910,7 @@ module "sles15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -923,7 +923,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -939,7 +939,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -955,7 +955,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -971,7 +971,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -987,7 +987,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1003,7 +1003,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1019,7 +1019,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1035,7 +1035,7 @@ module "ubuntu2004_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
   additional_packages = [ "venv-salt-minion" ]
@@ -1052,7 +1052,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -1065,7 +1065,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -1078,7 +1078,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1100,7 +1100,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_sshminion" {
@@ -1117,7 +1117,7 @@ module "sles15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1131,7 +1131,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1145,7 +1145,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1159,7 +1159,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1173,7 +1173,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1187,7 +1187,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1201,7 +1201,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1215,7 +1215,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 module "sles12sp5_buildhost" {
@@ -1233,7 +1233,7 @@ module "sles12sp5_buildhost" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles12sp5_terminal" {
@@ -1266,7 +1266,7 @@ module "sles15sp4_buildhost" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_terminal" {
@@ -1299,7 +1299,7 @@ module "monitoring_server" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -348,7 +348,7 @@ module "server" {
   disable_download_tokens        = false
   disable_auto_bootstrap         = true
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
   accept_all_ssl_protocols       = true
 
@@ -380,7 +380,7 @@ module "proxy" {
   generate_bootstrap_script = false
   publish_private_ssl_key   = false
   use_os_released_updates   = true
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle12sp5_client" {
@@ -400,7 +400,7 @@ module "sle12sp5_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp3_client" {
@@ -420,7 +420,7 @@ module "sle15sp3_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp4_client" {
@@ -440,7 +440,7 @@ module "sle15sp4_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp5_client" {
@@ -460,7 +460,7 @@ module "sle15sp5_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp6_client" {
@@ -480,7 +480,7 @@ module "sle15sp6_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_client" {
@@ -500,7 +500,7 @@ module "centos7_client" {
   }
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -523,7 +523,7 @@ module "sle12sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp3_minion" {
@@ -544,7 +544,7 @@ module "sle15sp3_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp4_minion" {
@@ -565,7 +565,7 @@ module "sle15sp4_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp5_minion" {
@@ -586,7 +586,7 @@ module "sle15sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp6_minion" {
@@ -607,7 +607,7 @@ module "sle15sp6_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -627,7 +627,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -650,7 +650,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -673,7 +673,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -696,7 +696,7 @@ module "liberty9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -719,7 +719,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -742,7 +742,7 @@ module "rocky8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -765,7 +765,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -788,7 +788,7 @@ module "ubuntu2004_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
   additional_packages = [ "venv-salt-minion" ]
@@ -812,7 +812,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -832,7 +832,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -853,7 +853,7 @@ module "debian12_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -879,7 +879,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp5s390_minion" {
@@ -897,7 +897,7 @@ module "sle15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 // This is an x86_64 SLES 15 SP5 minion (like sle15sp5_minion),
@@ -920,7 +920,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -942,7 +942,7 @@ module "slemicro51_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -967,7 +967,7 @@ module "slemicro52_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -992,7 +992,7 @@ module "slemicro53_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -1017,7 +1017,7 @@ module "slemicro54_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -1042,7 +1042,7 @@ module "slemicro55_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   // WORKAROUND: Does not work in sumaform, yet
   //  additional_packages = [ "venv-salt-minion" ]
@@ -1067,7 +1067,7 @@ module "slmicro60_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -1089,7 +1089,7 @@ module "slmicro61_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -1107,7 +1107,7 @@ module "sle12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -1124,7 +1124,7 @@ module "sle15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp4_sshminion" {
@@ -1140,7 +1140,7 @@ module "sle15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp5_sshminion" {
@@ -1156,7 +1156,7 @@ module "sle15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp6_sshminion" {
@@ -1172,7 +1172,7 @@ module "sle15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -1188,7 +1188,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1207,7 +1207,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1226,7 +1226,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1245,7 +1245,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1264,7 +1264,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1283,7 +1283,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1302,7 +1302,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1321,7 +1321,7 @@ module "ubuntu2004_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   # WORKAROUND https://github.com/uyuni-project/uyuni/issues/7637
   additional_packages = [ "venv-salt-minion" ]
@@ -1341,7 +1341,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -1357,7 +1357,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -1373,7 +1373,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
@@ -1395,7 +1395,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp5s390_sshminion" {
@@ -1413,7 +1413,7 @@ module "sle15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1430,7 +1430,7 @@ module "sle15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1447,7 +1447,7 @@ module "sle15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1464,7 +1464,7 @@ module "sle15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1481,7 +1481,7 @@ module "sle15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1498,7 +1498,7 @@ module "sle15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1515,7 +1515,7 @@ module "sle15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1532,7 +1532,7 @@ module "sle15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 module "sle12sp5_buildhost" {
@@ -1553,7 +1553,7 @@ module "sle12sp5_buildhost" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle12sp5_terminal" {
@@ -1592,7 +1592,7 @@ module "sle15sp4_buildhost" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sle15sp4_terminal" {
@@ -1631,7 +1631,7 @@ module "monitoring-server" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-paygo-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-paygo-AWS.tf
@@ -187,7 +187,7 @@ module "server" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   large_deployment               = true
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "m6a.xlarge"
   }
@@ -215,7 +215,7 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = true
   proxy_containerized       = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "c6i.large"
   }
@@ -234,7 +234,7 @@ module "sles12sp5_paygo_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -250,7 +250,7 @@ module "sles15sp5_paygo_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -266,7 +266,7 @@ module "sles15sp6_paygo_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -282,7 +282,7 @@ module "slesforsap15sp5_paygo_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -297,7 +297,7 @@ module "sles12sp5_client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -316,7 +316,7 @@ module "sles15sp4_client" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_register           = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -333,7 +333,7 @@ module "sles12sp5_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -351,7 +351,7 @@ module "sles15sp4_byos_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -368,7 +368,7 @@ module "sles15sp4_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -385,7 +385,7 @@ module "sles15sp5_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -402,7 +402,7 @@ module "sles15sp6_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -417,7 +417,7 @@ module "sles12sp5_sshminion" {
   image              = "sles12sp5"
   use_os_released_updates = false
   sles_registration_code = var.SLES_REGISTRATION_CODE
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   provider_settings = {
     instance_type = "t3a.medium"
@@ -433,7 +433,7 @@ module "sles15sp4_sshminion" {
   image              = "sles15sp4o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -448,7 +448,7 @@ module "sles15sp5_sshminion" {
   image              = "sles15sp5o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -463,7 +463,7 @@ module "sles15sp6_sshminion" {
   image              = "sles15sp6o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
@@ -155,7 +155,7 @@ module "server_containerized" {
   publish_private_ssl_key        = false
   use_os_released_updates        = true
   disable_download_tokens        = false
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
 
   //server_additional_repos
@@ -182,7 +182,7 @@ module "proxy_containerized" {
   container_tag        = "latest"
 
   auto_configure        = false
-  ssh_key_path          = "./salt/controller/id_rsa.pub"
+  ssh_key_path          = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -199,7 +199,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-PRV.tf
@@ -155,7 +155,7 @@ module "server_containerized" {
   publish_private_ssl_key        = false
   use_os_released_updates        = true
   disable_download_tokens        = false
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
 
   //server_additional_repos
@@ -182,7 +182,7 @@ module "proxy_containerized" {
   container_tag         = "latest"
 
   auto_configure            = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -201,7 +201,7 @@ module "sles15sp6_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 

--- a/terracumber_config/tf_files/SUSEManager-5.0-alternative-base-OS-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-alternative-base-OS-NUE.tf
@@ -155,7 +155,7 @@ module "server_containerized" {
   publish_private_ssl_key        = false
   use_os_released_updates        = true
   disable_download_tokens        = false
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
 
   //server_additional_repos
@@ -182,7 +182,7 @@ module "proxy_containerized" {
   container_tag        = "latest"
 
   auto_configure        = false
-  ssh_key_path          = "./salt/controller/id_rsa.pub"
+  ssh_key_path          = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -198,7 +198,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -212,7 +212,7 @@ module "server_containerized" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
 
   //server_additional_repos
@@ -231,7 +231,7 @@ module "proxy_containerized" {
   container_repository      = var.PROXY_CONTAINER_REPOSITORY
   container_tag             = "latest"
   auto_configure            = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 
   //proxy_additional_repos
 
@@ -248,7 +248,7 @@ module "sles12sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_minion" {
@@ -263,7 +263,7 @@ module "sles15sp3_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_minion" {
@@ -278,7 +278,7 @@ module "sles15sp4_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -293,7 +293,7 @@ module "sles15sp5_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -308,7 +308,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -322,7 +322,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_minion" {
@@ -336,7 +336,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_minion" {
@@ -350,7 +350,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "liberty9_minion" {
@@ -364,7 +364,7 @@ module "liberty9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_minion" {
@@ -378,7 +378,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_minion" {
@@ -392,7 +392,7 @@ module "rocky8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_minion" {
@@ -406,7 +406,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2004_minion" {
@@ -420,7 +420,7 @@ module "ubuntu2004_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_minion" {
@@ -434,7 +434,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -448,7 +448,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -463,7 +463,7 @@ module "debian12_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_minion" {
@@ -483,7 +483,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_minion" {
@@ -501,7 +501,7 @@ module "sles15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
@@ -521,7 +521,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -537,7 +537,7 @@ module "slemicro51_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -555,7 +555,7 @@ module "slemicro52_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -573,7 +573,7 @@ module "slemicro53_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -591,7 +591,7 @@ module "slemicro54_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -609,7 +609,7 @@ module "slemicro55_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -627,7 +627,7 @@ module "slmicro60_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -645,7 +645,7 @@ module "slmicro61_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -662,7 +662,7 @@ module "sles12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -676,7 +676,7 @@ module "sles15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_sshminion" {
@@ -689,7 +689,7 @@ module "sles15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_sshminion" {
@@ -702,7 +702,7 @@ module "sles15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_sshminion" {
@@ -715,7 +715,7 @@ module "sles15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -728,7 +728,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_sshminion" {
@@ -741,7 +741,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_sshminion" {
@@ -754,7 +754,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 
@@ -768,7 +768,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_sshminion" {
@@ -781,7 +781,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_sshminion" {
@@ -794,7 +794,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_sshminion" {
@@ -807,7 +807,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2004_sshminion" {
@@ -820,7 +820,7 @@ module "ubuntu2004_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_sshminion" {
@@ -833,7 +833,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -846,7 +846,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -859,7 +859,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_sshminion" {
@@ -878,7 +878,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_sshminion" {
@@ -896,7 +896,7 @@ module "sles15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -910,7 +910,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -924,7 +924,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -938,7 +938,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -952,7 +952,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //
@@ -969,7 +969,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -985,7 +985,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -1001,7 +1001,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -1017,7 +1017,7 @@ module "sles12sp5_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1047,7 +1047,7 @@ module "sles15sp4_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1095,7 +1095,7 @@ module "monitoring_server" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -363,7 +363,7 @@ module "server_containerized" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
 
   //server_additional_repos
@@ -390,7 +390,7 @@ module "proxy_containerized" {
   container_repository      = var.PROXY_CONTAINER_REPOSITORY
   container_tag             = "latest"
   auto_configure            = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 
   //proxy_additional_repos
 
@@ -410,7 +410,7 @@ module "sles12sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_minion" {
@@ -428,7 +428,7 @@ module "sles15sp3_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_minion" {
@@ -446,7 +446,7 @@ module "sles15sp4_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -464,7 +464,7 @@ module "sles15sp5_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -482,7 +482,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -499,7 +499,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_minion" {
@@ -516,7 +516,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_minion" {
@@ -533,7 +533,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "liberty9_minion" {
@@ -550,7 +550,7 @@ module "liberty9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_minion" {
@@ -567,7 +567,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_minion" {
@@ -584,7 +584,7 @@ module "rocky8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_minion" {
@@ -601,7 +601,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2004_minion" {
@@ -618,7 +618,7 @@ module "ubuntu2004_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_minion" {
@@ -635,7 +635,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -652,7 +652,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -670,7 +670,7 @@ module "debian12_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_minion" {
@@ -690,7 +690,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_minion" {
@@ -708,7 +708,7 @@ module "sles15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
@@ -728,7 +728,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -747,7 +747,7 @@ module "slemicro51_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -768,7 +768,7 @@ module "slemicro52_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -789,7 +789,7 @@ module "slemicro53_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -810,7 +810,7 @@ module "slemicro54_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -831,7 +831,7 @@ module "slemicro55_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -852,7 +852,7 @@ module "slmicro60_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -873,7 +873,7 @@ module "slmicro61_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -893,7 +893,7 @@ module "sles12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -910,7 +910,7 @@ module "sles15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_sshminion" {
@@ -926,7 +926,7 @@ module "sles15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_sshminion" {
@@ -942,7 +942,7 @@ module "sles15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_sshminion" {
@@ -958,7 +958,7 @@ module "sles15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -974,7 +974,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_sshminion" {
@@ -990,7 +990,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_sshminion" {
@@ -1006,7 +1006,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "liberty9_sshminion" {
@@ -1022,7 +1022,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_sshminion" {
@@ -1038,7 +1038,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_sshminion" {
@@ -1054,7 +1054,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_sshminion" {
@@ -1070,7 +1070,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2004_sshminion" {
@@ -1086,7 +1086,7 @@ module "ubuntu2004_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_sshminion" {
@@ -1102,7 +1102,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -1118,7 +1118,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -1134,7 +1134,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_sshminion" {
@@ -1153,7 +1153,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_sshminion" {
@@ -1171,7 +1171,7 @@ module "sles15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1188,7 +1188,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
@@ -1208,7 +1208,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
@@ -1228,7 +1228,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
@@ -1248,7 +1248,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
@@ -1268,7 +1268,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
@@ -1288,7 +1288,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
@@ -1308,7 +1308,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //  additional_packages = [ "venv-salt-minion" ]
 //  install_salt_bundle = true
@@ -1328,7 +1328,7 @@ module "sles12sp5_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles12sp5_terminal" {
@@ -1363,7 +1363,7 @@ module "sles15sp4_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_terminal" {
@@ -1416,7 +1416,7 @@ module "monitoring_server" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-paygo-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-paygo-AWS.tf
@@ -206,7 +206,7 @@ module "server" {
   large_deployment               = true
   provision                      = true
   install_salt_bundle            = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = var.ARCHITECTURE == "x86_64" ? "m6a.xlarge" : "m6g.xlarge"
   }
@@ -227,7 +227,7 @@ module "proxy" {
 
   auto_configure            = false
   use_os_released_updates   = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
   provider_settings         = {
     instance_type = "c6i.large"
   }
@@ -247,7 +247,7 @@ module "sles12sp5_paygo_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -264,7 +264,7 @@ module "sles15sp5_paygo_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   install_salt_bundle     = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -281,7 +281,7 @@ module "sles15sp6_paygo_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   install_salt_bundle     = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -297,7 +297,7 @@ module "slesforsap15sp5_paygo_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   additional_packages = [ "python-instance-billing-flavor-check" ]
 }
 
@@ -311,7 +311,7 @@ module "sles12sp5_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -328,7 +328,7 @@ module "sles15sp4_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -344,7 +344,7 @@ module "sles15sp5_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -360,7 +360,7 @@ module "sles15sp6_minion" {
   sles_registration_code = var.SLES_REGISTRATION_CODE
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -374,7 +374,7 @@ module "sles12sp5_sshminion" {
   image              = "sles12sp5"
   use_os_released_updates = false
   sles_registration_code = var.SLES_REGISTRATION_CODE
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   provider_settings = {
     instance_type = "t3a.medium"
@@ -389,7 +389,7 @@ module "sles15sp4_sshminion" {
   image              = "sles15sp4o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -403,7 +403,7 @@ module "sles15sp5_sshminion" {
   image              = "sles15sp5o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -417,7 +417,7 @@ module "sles15sp6_sshminion" {
   image              = "sles15sp6o"
   sles_registration_code = var.SLES_REGISTRATION_CODE
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     instance_type = "t3a.medium"
   }
@@ -432,7 +432,7 @@ module "rhel9_paygo_minion" {
   server_configuration = module.server.configuration
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
     memory = 2048
     vcpu = 2

--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -217,7 +217,7 @@ module "server_containerized" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
 
   //server_additional_repos
@@ -236,7 +236,7 @@ module "proxy_containerized" {
   container_repository      = var.PROXY_CONTAINER_REPOSITORY
   container_tag             = "latest"
   auto_configure            = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 
   //proxy_additional_repos
 
@@ -253,7 +253,7 @@ module "sles12sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_minion" {
@@ -268,7 +268,7 @@ module "sles15sp3_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_minion" {
@@ -283,7 +283,7 @@ module "sles15sp4_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -298,7 +298,7 @@ module "sles15sp5_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -313,7 +313,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -327,7 +327,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_minion" {
@@ -341,7 +341,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_minion" {
@@ -355,7 +355,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "liberty9_minion" {
@@ -369,7 +369,7 @@ module "liberty9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_minion" {
@@ -383,7 +383,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_minion" {
@@ -397,7 +397,7 @@ module "rocky8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_minion" {
@@ -411,7 +411,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_minion" {
@@ -425,7 +425,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -439,7 +439,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -454,7 +454,7 @@ module "debian12_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_minion" {
@@ -474,7 +474,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_minion" {
@@ -492,7 +492,7 @@ module "sles15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 // This is an x86_64 SLES 15 SP5 minion (like sles15sp5-minion),
@@ -512,7 +512,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -528,7 +528,7 @@ module "slemicro51_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -546,7 +546,7 @@ module "slemicro52_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -564,7 +564,7 @@ module "slemicro53_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -582,7 +582,7 @@ module "slemicro54_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -600,7 +600,7 @@ module "slemicro55_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -618,7 +618,7 @@ module "slmicro60_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -636,7 +636,7 @@ module "slmicro61_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 // WORKAROUND: Does not work in sumaform, yet
   install_salt_bundle = false
@@ -653,7 +653,7 @@ module "sles12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -667,7 +667,7 @@ module "sles15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_sshminion" {
@@ -680,7 +680,7 @@ module "sles15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_sshminion" {
@@ -693,7 +693,7 @@ module "sles15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_sshminion" {
@@ -706,7 +706,7 @@ module "sles15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -719,7 +719,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_sshminion" {
@@ -732,7 +732,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_sshminion" {
@@ -745,7 +745,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 
@@ -759,7 +759,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_sshminion" {
@@ -772,7 +772,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_sshminion" {
@@ -785,7 +785,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_sshminion" {
@@ -798,7 +798,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2204_sshminion" {
@@ -811,7 +811,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -824,7 +824,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -837,7 +837,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_sshminion" {
@@ -856,7 +856,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_sshminion" {
@@ -874,7 +874,7 @@ module "sles15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -888,7 +888,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -902,7 +902,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -916,7 +916,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -930,7 +930,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //
@@ -947,7 +947,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -963,7 +963,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -979,7 +979,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 //
 //
 //}
@@ -995,7 +995,7 @@ module "sles12sp5_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1025,7 +1025,7 @@ module "sles15sp4_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1073,7 +1073,7 @@ module "monitoring_server" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -86,12 +86,12 @@ variable "AVAILABILITY_ZONE" {
 
 variable "KEY_FILE" {
   type = string
-  default = "/home/jenkins/.ssh/id_rsa"
+  default = "/home/jenkins/.ssh/testing-suma.pem"
 }
 
 variable "KEY_NAME" {
   type = string
-  default = "internal-jenkins-worker"
+  default = "testing-suma"
 }
 
 variable "MY_IP" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -209,7 +209,7 @@ module "server_containerized" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
 
   runtime               = "podman"
@@ -234,7 +234,7 @@ module "proxy_containerized" {
   container_repository      = var.PROXY_CONTAINER_REPOSITORY
   container_tag             = "latest"
   auto_configure            = false
-  ssh_key_path              = "./salt/controller/id_rsa.pub"
+  ssh_key_path              = "./salt/controller/id_ed25519.pub"
 }
 
 // No traditional clients in Uyuni
@@ -251,7 +251,7 @@ module "sles12sp5_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_minion" {
@@ -266,7 +266,7 @@ module "sles15sp3_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_minion" {
@@ -281,7 +281,7 @@ module "sles15sp4_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -296,7 +296,7 @@ module "sles15sp5_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -311,7 +311,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -325,7 +325,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma9_minion" {
@@ -339,7 +339,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_minion" {
@@ -353,7 +353,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "liberty9_minion" {
@@ -367,7 +367,7 @@ module "liberty9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_minion" {
@@ -381,7 +381,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_minion" {
@@ -396,7 +396,7 @@ module "rocky8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_minion" {
@@ -410,7 +410,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2004_minion" {
@@ -424,7 +424,7 @@ module "ubuntu2004_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -439,7 +439,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -453,7 +453,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -468,7 +468,7 @@ module "debian12_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_minion" {
@@ -488,7 +488,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_minion" {
@@ -506,7 +506,7 @@ module "sles15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "salt_migration_minion" {
@@ -524,7 +524,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -540,7 +540,7 @@ module "slemicro51_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -558,7 +558,7 @@ module "slemicro52_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -576,7 +576,7 @@ module "slemicro53_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -594,7 +594,7 @@ module "slemicro54_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -612,7 +612,7 @@ module "slemicro55_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -630,7 +630,7 @@ module "slmicro60_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -648,7 +648,7 @@ module "slmicro61_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -665,7 +665,7 @@ module "sles12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -679,7 +679,7 @@ module "sles15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_sshminion" {
@@ -692,7 +692,7 @@ module "sles15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_sshminion" {
@@ -705,7 +705,7 @@ module "sles15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_sshminion" {
@@ -718,7 +718,7 @@ module "sles15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -731,7 +731,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -745,7 +745,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "centos7_sshminion" {
@@ -758,7 +758,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "liberty9_sshminion" {
@@ -771,7 +771,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "oracle9_sshminion" {
@@ -784,7 +784,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky8_sshminion" {
@@ -797,7 +797,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "rocky9_sshminion" {
@@ -810,7 +810,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2004_sshminion" {
@@ -823,7 +823,7 @@ module "ubuntu2004_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -837,7 +837,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -850,7 +850,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -863,7 +863,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "opensuse156arm_sshminion" {
@@ -882,7 +882,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_sshminion" {
@@ -900,7 +900,7 @@ module "sles15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -914,7 +914,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -928,7 +928,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -942,7 +942,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -956,7 +956,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -970,7 +970,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -984,7 +984,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -998,7 +998,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 module "sles12sp5_buildhost" {
@@ -1012,7 +1012,7 @@ module "sles12sp5_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles12sp5_terminal" {
@@ -1042,7 +1042,7 @@ module "sles15sp4_buildhost" {
     vcpu               = 2
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_terminal" {
@@ -1072,7 +1072,7 @@ module "monitoring_server" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -360,7 +360,7 @@ module "server_containerized" {
   use_os_released_updates        = true
   disable_download_tokens        = false
   large_deployment               = true
-  ssh_key_path                   = "./salt/controller/id_rsa.pub"
+  ssh_key_path                   = "./salt/controller/id_ed25519.pub"
   from_email                     = "root@suse.de"
   runtime               = "podman"
   container_repository  = var.SERVER_CONTAINER_REPOSITORY
@@ -387,7 +387,7 @@ module "proxy_containerized" {
   container_repository  = var.PROXY_CONTAINER_REPOSITORY
   container_tag         = "latest"
   auto_configure        = false
-  ssh_key_path          = "./salt/controller/id_rsa.pub"
+  ssh_key_path          = "./salt/controller/id_ed25519.pub"
 }
 
 // No traditional clients in Uyuni
@@ -406,7 +406,7 @@ module "sles12sp5_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp3_minion" {
@@ -424,7 +424,7 @@ module "sles15sp3_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_minion" {
@@ -442,7 +442,7 @@ module "sles15sp4_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_minion" {
@@ -460,7 +460,7 @@ module "sles15sp5_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_minion" {
@@ -478,7 +478,7 @@ module "sles15sp6_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_minion" {
@@ -495,7 +495,7 @@ module "alma8_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -513,7 +513,7 @@ module "alma9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -531,7 +531,7 @@ module "centos7_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -550,7 +550,7 @@ module "liberty9_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -568,7 +568,7 @@ module "oracle9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -587,7 +587,7 @@ module "rocky8_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -605,7 +605,7 @@ module "rocky9_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -623,7 +623,7 @@ module "ubuntu2004_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -641,7 +641,7 @@ module "ubuntu2204_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_minion" {
@@ -658,7 +658,7 @@ module "ubuntu2404_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_minion" {
@@ -676,7 +676,7 @@ module "debian12_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -697,7 +697,7 @@ module "opensuse156arm_minion" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_minion" {
@@ -715,7 +715,7 @@ module "sles15sp5s390_minion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "salt_migration_minion" {
@@ -733,7 +733,7 @@ module "salt_migration_minion" {
   }
   auto_connect_to_master  = true
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = false
 }
 
@@ -753,7 +753,7 @@ module "slemicro51_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -774,7 +774,7 @@ module "slemicro52_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -795,7 +795,7 @@ module "slemicro53_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -816,7 +816,7 @@ module "slemicro54_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -837,7 +837,7 @@ module "slemicro55_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -858,7 +858,7 @@ module "slmicro60_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -879,7 +879,7 @@ module "slmicro61_minion" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // WORKAROUND: Does not work in sumaform, yet
 //  additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = false
@@ -899,7 +899,7 @@ module "sles12sp5_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
 }
 
@@ -916,7 +916,7 @@ module "sles15sp3_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_sshminion" {
@@ -932,7 +932,7 @@ module "sles15sp4_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5_sshminion" {
@@ -948,7 +948,7 @@ module "sles15sp5_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp6_sshminion" {
@@ -964,7 +964,7 @@ module "sles15sp6_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "alma8_sshminion" {
@@ -980,7 +980,7 @@ module "alma8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -997,7 +997,7 @@ module "alma9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1014,7 +1014,7 @@ module "centos7_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1031,7 +1031,7 @@ module "liberty9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1048,7 +1048,7 @@ module "oracle9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1065,7 +1065,7 @@ module "rocky8_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1082,7 +1082,7 @@ module "rocky9_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1099,7 +1099,7 @@ module "ubuntu2004_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1116,7 +1116,7 @@ module "ubuntu2204_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "ubuntu2404_sshminion" {
@@ -1132,7 +1132,7 @@ module "ubuntu2404_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "debian12_sshminion" {
@@ -1148,7 +1148,7 @@ module "debian12_sshminion" {
     memory             = 4096
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 
 }
 
@@ -1168,7 +1168,7 @@ module "opensuse156arm_sshminion" {
     xslt               = file("../../susemanager-ci/terracumber_config/tf_files/common/tune-aarch64.xslt")
   }
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp5s390_sshminion" {
@@ -1186,7 +1186,7 @@ module "sles15sp5s390_sshminion" {
   }
 
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1203,7 +1203,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1220,7 +1220,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1237,7 +1237,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1254,7 +1254,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1271,7 +1271,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1288,7 +1288,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 //  WORKAROUND until https://bugzilla.suse.com/show_bug.cgi?id=1208045 gets fixed
@@ -1305,7 +1305,7 @@ module "sles15sp5s390_sshminion" {
 //     memory             = 2048
 //   }
 //   use_os_released_updates = false
-//   ssh_key_path            = "./salt/controller/id_rsa.pub"
+//   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 // }
 
 module "sles12sp5_buildhost" {
@@ -1323,7 +1323,7 @@ module "sles12sp5_buildhost" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles12sp5_terminal" {
@@ -1359,7 +1359,7 @@ module "sles15sp4_buildhost" {
   }
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "sles15sp4_terminal" {
@@ -1395,7 +1395,7 @@ module "monitoring_server" {
 
   auto_connect_to_master  = false
   use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
 module "controller" {

--- a/terracumber_config/tf_files/local_mirror.tf
+++ b/terracumber_config/tf_files/local_mirror.tf
@@ -78,7 +78,7 @@ variable "GIT_PASSWORD" {
 
 variable "SSH_KEY" {
   type = string
-  default = "/home/jenkins/.ssh/id_rsa.pub"
+  default = "/home/jenkins/.ssh/id_25519.pub"
 }
 
 terraform {


### PR DESCRIPTION
Follow up to https://github.com/SUSE/spacewalk/issues/26776

Somewhat related to https://github.com/SUSE/spacewalk/issues/26493

If possible, we should drop the use of old RSA keys and switch to a more secure algorithm such as ed25519.
This will also allow us to drop a few workarounds we have in place to make newer version of openSSH, shipped with some newer distros, accept RSA keys - see https://github.com/uyuni-project/sumaform/pull/1807

We already had one ed25519 AWS keypair, used on some pipelines.
I took care of adding the corresponding pub key to the bastion.