### PR TITLE
Move some testsuites to the new servers

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
@@ -106,7 +106,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-07.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-10.mgr.suse.de/system"
 }
 
 provider "libvirt" {
@@ -1080,7 +1080,7 @@ module "dhcp_dns" {
     module.sles15sp4_terminal.configuration
   ]
   hypervisor = {
-    host        = "suma-07.mgr.suse.de"
+    host        = "suma-10.mgr.suse.de"
     user        = "root"
     private_key = file("~/.ssh/id_ed25519")
   }

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLE-update-NUE.tf
@@ -85,7 +85,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-08.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-11.mgr.suse.de/system"
 }
 
 module "base" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLE-update-NUE.tf
@@ -98,7 +98,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-08.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-11.mgr.suse.de/system"
 }
 
 module "base" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-alternative-base-OS-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-alternative-base-OS-NUE.tf
@@ -98,7 +98,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-08.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-11.mgr.suse.de/system"
 }
 
 module "base" {

--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -111,7 +111,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-06.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-11.mgr.suse.de/system"
 }
 
 provider "libvirt" {
@@ -1083,7 +1083,7 @@ module "dhcp_dns" {
     module.sles15sp4_terminal.configuration
   ]
   hypervisor = {
-    host        = "suma-06.mgr.suse.de"
+    host        = "suma-11.mgr.suse.de"
     user        = "root"
     private_key = file("~/.ssh/id_ed25519")
   }


### PR DESCRIPTION
Move some test suites to `suma-10` and `suma-11`:
```
suma-05    42
suma-06    60
   suma-bv-50          51
   suma-continuous-bv   9 --> suma-11
suma-07   103
   mlm-bv-51           49 --> suma-10
   suma-bv-43          54
suma-08    53
   suma-pr             39
   suma-su              8 --> suma-11
   suma-alt             4 --> suma-11
   minima-mirror        1
   kafka                1
```