### PR TITLE
Switch Uyuni and Head to large_deployment

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -145,6 +145,7 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile"
       container_tag = "latest"
+      large_deployment      = true
     }
     proxy_containerized = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -145,7 +145,6 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile"
       container_tag = "latest"
-      large_deployment      = true
     }
     proxy_containerized = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -149,6 +149,7 @@ module "cucumber_testsuite" {
       repository_disk_size  = 150
       database_disk_size    = 50
       login_timeout         = 28800
+      large_deployment      = true
     }
     proxy_containerized = {
       provider_settings = {


### PR DESCRIPTION
Switch Uyuni and Head to large_deployment to see if that solves the issue with the session crashes. This should at least increase taskomatic threads etc.

If this does work then we will switch the rest of the CI maybe