### PR TITLE
Cleaning bv pipeline - use sumaform from targeted project

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -53,8 +53,6 @@ def run(params) {
                 dir("susemanager-ci") {
                     checkout scm
                 }
-//                // Clone sumaform
-//                sh "set +x; source /home/jenkins/.credentials set -x; ${WORKSPACE}/terracumber-cli ${commonParams} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
             }
 
             stage('Confirm Environment Cleanup') {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -12,7 +12,7 @@ def run(params) {
         String hypervisorUrl = null
         GString targetedTfFile = "${WORKSPACE}/../${params.targeted_project}/results/sumaform/main.tf"
         GString targetedTfStateFile = "${WORKSPACE}/../${params.targeted_project}/results/sumaform/terraform.tfstate"
-        GString targetedTerraformDirPath = "${WORKSPACE}/../${params.targeted_project}/results/sumaform/"
+        GString targetedSumaformDirPath = "${WORKSPACE}/../${params.targeted_project}/results/sumaform/"
         GString localSumaformDirPath = "${resultdir}/sumaform/"
         GString localTfStateFile = "${localSumaformDirPath}terraform.tfstate"
         GString logFile = "${resultdirbuild}/sumaform.log"
@@ -74,7 +74,7 @@ def run(params) {
                 // Copy tfstate and terraform directory to the result directory
                 sh """
                     rm -rf ${localSumaformDirPath} 
-                    cp -r ${targetedTerraformDirPath} ${localSumaformDirPath}
+                    cp -r ${targetedSumaformDirPath} ${localSumaformDirPath}
                     rm ${localSumaformDirPath}main.tf
                 """
             }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -53,10 +53,8 @@ def run(params) {
                 dir("susemanager-ci") {
                     checkout scm
                 }
-
-                // Clone sumaform
-                sh "set +x; source /home/jenkins/.credentials set -x; ${WORKSPACE}/terracumber-cli ${commonParams} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
-
+//                // Clone sumaform
+//                sh "set +x; source /home/jenkins/.credentials set -x; ${WORKSPACE}/terracumber-cli ${commonParams} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
             }
 
             stage('Confirm Environment Cleanup') {
@@ -77,9 +75,9 @@ def run(params) {
             stage("Copy terraform files from ${params.targeted_project}"){
                 // Copy tfstate and terraform directory to the result directory
                 sh """
-                    cp ${targetedTfStateFile} ${localTfStateFile}
-                    cp -r ${targetedTerraformDirPath}.terraform ${localSumaformDirPath}
-                    cp ${targetedTfFile} ${localSumaformDirPath}
+                    rm -rf ${localSumaformDirPath} 
+                    cp -r ${targetedTerraformDirPath} ${localSumaformDirPath}
+                    rm ${localSumaformDirPath}main.tf
                 """
             }
 


### PR DESCRIPTION
## Description

During 5.0.4 client tools testing on 4.3, I attempted to use the cleanup pipeline to clean only the clients and test the 5.0.4 client tools.
However, the newer version of sumaform (from Git) was incompatible with the older sumaform deployment used in 4.3 BV results/sumaform. As a result, the controller was redeployed but became incompatible with the server and minions.

This issue is expected to occur occasionally, as we sometimes retain deployments for extended periods while sumaform continues to evolve.

To prevent this in the future, the cleanup pipeline will no longer clone sumaform from Git. Instead, it will use the version provided by the targeted project.
If a more recent sumaform version is needed, we’ll either need to update it at the project level or redeploy the environment accordingly.