### PR TITLE
Use salt bundle 61

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
@@ -630,9 +630,6 @@ module "slmicro60_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-
-// WORKAROUND: Does not work in sumaform, yet
-  install_salt_bundle = false
 }
 
 module "slmicro61_minion" {
@@ -648,9 +645,6 @@ module "slmicro61_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-
-// WORKAROUND: Does not work in sumaform, yet
-  install_salt_bundle = false
 }
 
 module "sles12sp5_sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -843,7 +843,6 @@ module "slmicro61_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-  install_salt_bundle = false
 }
 
 module "sles12sp5_sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-NUE.tf
@@ -824,7 +824,6 @@ module "slmicro60_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-  install_salt_bundle = false
 }
 
 module "slmicro61_minion" {

--- a/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-build-validation-PRV.tf
@@ -1068,7 +1068,6 @@ module "slmicro60_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-  install_salt_bundle = false
 }
 
 module "slmicro61_minion" {
@@ -1090,7 +1089,6 @@ module "slmicro61_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-  install_salt_bundle = false
 }
 
 module "sle12sp5_sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf
@@ -628,9 +628,6 @@ module "slmicro60_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-
-// WORKAROUND: Does not work in sumaform, yet
-  install_salt_bundle = false
 }
 
 module "slmicro61_minion" {
@@ -646,9 +643,6 @@ module "slmicro61_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-
-// WORKAROUND: Does not work in sumaform, yet
-  install_salt_bundle = false
 }
 
 module "sles12sp5_sshminion" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-PRV.tf
@@ -853,9 +853,6 @@ module "slmicro60_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-
-// WORKAROUND: Does not work in sumaform, yet
-  install_salt_bundle = false
 }
 
 module "slmicro61_minion" {
@@ -874,9 +871,6 @@ module "slmicro61_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-
-// WORKAROUND: Does not work in sumaform, yet
-  install_salt_bundle = false
 }
 
 module "sles12sp5_sshminion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -643,9 +643,6 @@ module "slmicro60_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = false
 }
 
 module "slmicro61_minion" {
@@ -661,9 +658,6 @@ module "slmicro61_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = false
 }
 
 module "sles12sp5_sshminion" {

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -866,9 +866,6 @@ module "slmicro60_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = false
 }
 
 module "slmicro61_minion" {
@@ -887,9 +884,6 @@ module "slmicro61_minion" {
   auto_connect_to_master  = false
   use_os_released_updates = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
-// WORKAROUND: Does not work in sumaform, yet
-//  additional_packages = [ "venv-salt-minion" ]
-  install_salt_bundle = false
 }
 
 module "sles12sp5_sshminion" {


### PR DESCRIPTION
## Description

salt bundle is now available for slmicro 6.0 and slmicro 6.1.
Using classic salt seems to be broken for slmicro 6.1.

Update all the BV pipelines to use salt bundle for those two minions by removing the salt_bundle value (default true).