### PR TITLE
Remainder of renamings

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -537,7 +537,7 @@ module "salt_migration_minion" {
   }
 
   server_configuration = {
-    hostname = "suma-continuous-bv-50-proxy.mgr.suse.de"
+    hostname = "suma-continuous-bv-proxy.mgr.suse.de"
   }
   auto_connect_to_master  = true
   use_os_released_updates = false


### PR DESCRIPTION
Seen in the DNS queries:

```
2025-05-09T06:14:00.905210+02:00 dhcp named[29159]: timed out resolving 
'suma-continuous-bv-50-proxy.mgr.suse.de.prg2.suse.org/A/IN': 10.144.53.53#53
```

The name of the proxy was incorrect.
