### PR TITLE
[salt-shaker] Add SLM 6.1 tests

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux8-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-almalinux9-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-centos7-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-centos7-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian12-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-debian12-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-leap155-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles12sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles12sp5-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp2-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp3-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp4-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp5-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
@@ -36,7 +36,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60-bundle
@@ -36,7 +36,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro61
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro61
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+node('salt-shaker-tests') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([
+            URLTrigger(
+                cronTabSpec: '* * * * *',
+                triggerLabel: "salt-shaker-tests",
+                labelRestriction: true,
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next/SLMicro61/repodata/repomd.xml',
+                    contentTypes: [MD5Sum()]
+                )]
+            ),
+            cron('H 0 * * *')],
+        ),
+        parameters([
+            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt or '),
+            booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
+            booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
+            booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),
+            string(name: 'testsuite_dir', defaultValue: '/opt/salt-testsuite-classic/', description: 'Optional: Run testsuite from this directory'),
+            string(name: 'wait_after_deploy', defaultValue: '120', description: 'Optional: Seconds to wait after deployment is done (usually to allow transactional systems to reboot)'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'skip_list_url', defaultValue: 'https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/main/skipped_tests.toml', description: 'URL to the skiplist.toml file to run Salt shaker'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro61.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terraform_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for terraform'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 3, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
+        pipeline.run(params)
+    }
+}

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro61-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro61-bundle
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+node('salt-shaker-tests') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([
+            URLTrigger(
+                cronTabSpec: '* * * * *',
+                triggerLabel: "salt-shaker-tests",
+                labelRestriction: true,
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/testsuite/SLMicro61/repodata/repomd.xml',
+                    contentTypes: [MD5Sum()]
+                )]aa:b2:93:01:01:b8
+            ),
+            cron('H 0 * * *')],
+        ),
+        parameters([
+            choice(name: 'salt_flavor', choices: ['bundle'], description: 'Run testsuite for classic Salt or Salt Bundle'),
+            booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
+            booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
+            booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),
+            string(name: 'testsuite_dir', defaultValue: '/opt/salt-testsuite-bundle/', description: 'Optional: Run testsuite from this directory'),
+            string(name: 'wait_after_deploy', defaultValue: '120', description: 'Optional: Seconds to wait after deployment is done (usually to allow transactional systems to reboot)'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'skip_list_url', defaultValue: 'https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/main/skipped_tests.toml', description: 'URL to the skiplist.toml file to run Salt shaker'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro61-Bundle.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terraform_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for terraform'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 3, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
+        pipeline.run(params)
+    }
+}

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu1804-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2004-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2204-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2404-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-ubuntu2404-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-sles15sp5
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux8-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-almalinux9-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-centos7-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-centos7-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian12-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-debian12-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-leap155-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles12sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles12sp5-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp2-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp3-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp4-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp5-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp6
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp6
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp6-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp6-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
@@ -36,7 +36,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60-bundle
@@ -36,7 +36,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro61
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro61
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+node('salt-shaker-tests') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([
+            URLTrigger(
+                cronTabSpec: '* * * * *',
+                triggerLabel: "salt-shaker-tests",
+                labelRestriction: true,
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/SLMicro61/repodata/repomd.xml',
+                    contentTypes: [MD5Sum()]
+                )]
+            ),
+            cron('H 0 * * *')],
+        ),
+        parameters([
+            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt or '),
+            booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
+            booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
+            booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),
+            string(name: 'testsuite_dir', defaultValue: '/opt/salt-testsuite-classic/', description: 'Optional: Run testsuite from this directory'),
+            string(name: 'wait_after_deploy', defaultValue: '120', description: 'Optional: Seconds to wait after deployment is done (usually to allow transactional systems to reboot)'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'skip_list_url', defaultValue: 'https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/main/skipped_tests.toml', description: 'URL to the skiplist.toml file to run Salt shaker'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro61.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terraform_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for terraform'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 3, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
+        pipeline.run(params)
+    }
+}

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro61-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro61-bundle
@@ -1,0 +1,50 @@
+#!/usr/bin/env groovy
+
+node('salt-shaker-tests') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '4', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([
+            URLTrigger(
+                cronTabSpec: '* * * * *',
+                triggerLabel: "salt-shaker-tests",
+                labelRestriction: true,
+                entries: [URLTriggerEntry(
+                    url: 'https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/testing:/testsuite/SLMicro61/repodata/repomd.xml',
+                    contentTypes: [MD5Sum()]
+                )]
+            ),
+            cron('H 0 * * *')],
+        ),
+        parameters([
+            choice(name: 'salt_flavor', choices: ['bundle'], description: 'Run testsuite for classic Salt or Salt Bundle'),
+            booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
+            booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
+            booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),
+            string(name: 'testsuite_dir', defaultValue: '/opt/salt-testsuite-bundle/', description: 'Optional: Run testsuite from this directory'),
+            string(name: 'wait_after_deploy', defaultValue: '120', description: 'Optional: Seconds to wait after deployment is done (usually to allow transactional systems to reboot)'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'skip_list_url', defaultValue: 'https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/main/skipped_tests.toml', description: 'URL to the skiplist.toml file to run Salt shaker'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro61-Bundle.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'terraform_bin', choices: ['/usr/bin/terraform'], description: 'Terraform binary path'),
+            choice(name: 'terraform_bin_plugins', choices: ['/usr/bin'], description: 'Terraform plugins path'),
+            string(name: 'terraform_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for terraform'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 3, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy"
+        pipeline.run(params)
+    }
+}

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu1804-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2004-bundle
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2204-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2404-bundle
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-ubuntu2404-bundle
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap154
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap154
@@ -23,7 +23,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap155
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-leap155
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-tumbleweed
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-saltstack-tumbleweed
@@ -34,7 +34,7 @@ node('salt-shaker-tests') {
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
-            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
         ])
     ])
 

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro61-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro61-Bundle.tf
@@ -1,0 +1,118 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-next-slmicro61-bundle"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "echo EXECUTE SALT TESTS HERE"
+}
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Salt Shaker - products:next - SLMicro6.1 Salt Bundle $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Salt Shaker - products:next - SLMicro6.1 Salt Bundle: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "salt-shaker@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.1"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-04.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br1"
+  }
+
+  images = [ "slmicro61o" ]
+}
+
+module "salt-shaker-products-next" {
+  source             = "./modules/salt_testenv"
+  base_configuration = module.base.configuration
+
+  name               = "salt-shaker-products-next-slmicro61-bundle"
+  image              = "slmicro61o"
+  salt_obs_flavor    = "saltstack:products:next"
+  provider_settings  = {
+    mac = "aa:b2:93:01:01:b9"
+  }
+}
+
+output "configuration" {
+  value = module.salt-shaker-products-next.configuration
+}

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro61.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Next-SLMicro61.tf
@@ -1,0 +1,118 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-next-slmicro61"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "echo EXECUTE SALT TESTS HERE"
+}
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Salt Shaker - products:next - SLMicro6.1 $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Salt Shaker - products:next - SLMicro6.1: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "salt-shaker@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.1"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-04.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br1"
+  }
+
+  images = [ "slmicro61o" ]
+}
+
+module "salt-shaker-products-next" {
+  source             = "./modules/salt_testenv"
+  base_configuration = module.base.configuration
+
+  name               = "salt-shaker-products-next-slmicro61"
+  image              = "slmicro61o"
+  salt_obs_flavor    = "saltstack:products:next"
+  provider_settings  = {
+    mac = "aa:b2:93:01:01:b8"
+  }
+}
+
+output "configuration" {
+  value = module.salt-shaker-products-next.configuration
+}

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro61-Bundle.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro61-Bundle.tf
@@ -1,0 +1,118 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-testing-slmicro61-bundle"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "echo EXECUTE SALT TESTS HERE"
+}
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Salt Shaker - products:testing - SLMicro6.0 Salt Bundle $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Salt Shaker - products:testing - SLMicro6.0 Salt Bundle: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "salt-shaker@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.1"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-03.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br1"
+  }
+
+  images = [ "slmicro61o" ]
+}
+
+module "salt-shaker-products-testing" {
+  source             = "./modules/salt_testenv"
+  base_configuration = module.base.configuration
+
+  name               = "salt-shaker-products-testing-slmicro61-bundle"
+  image              = "slmicro61o"
+  salt_obs_flavor    = "saltstack:products:testing"
+  provider_settings  = {
+    mac = "aa:b2:93:01:01:d6"
+  }
+}
+
+output "configuration" {
+  value = module.salt-shaker-products-testing.configuration
+}

--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro61.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-SLMicro61.tf
@@ -1,0 +1,118 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-testing-slmicro61"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "echo EXECUTE SALT TESTS HERE"
+}
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "master"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Salt Shaker - products:testing - SLMicro6.1 $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Salt Shaker - products:testing - SLMicro6.1: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../../mail_templates/mail-template-salt-shaker-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "salt-shaker@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "salt-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+  default = null // Not needed for Salt tests
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.1"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-03.mgr.suse.de/system"
+}
+
+module "base" {
+  source = "./modules/base"
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+  use_avahi   = false
+  domain      = "mgr.suse.de"
+
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br1"
+  }
+
+  images = [ "slmicro61o" ]
+}
+
+module "salt-shaker-products-testing" {
+  source             = "./modules/salt_testenv"
+  base_configuration = module.base.configuration
+
+  name               = "salt-shaker-products-testing-slmicro61"
+  image              = "slmicro61o"
+  salt_obs_flavor    = "saltstack:products:testing"
+  provider_settings  = {
+    mac = "aa:b2:93:01:01:d5"
+  }
+}
+
+output "configuration" {
+  value = module.salt-shaker-products-testing.configuration
+}


### PR DESCRIPTION
In this PR, I:

- Disable using previous state on all Salt Shaker pipelines, since it can cause failures when recovering from failed provisioning
- Add SLM 6.1 pipelines for `testing`, `testing & bundle`, `next`, `next & bundle` 