### PR TITLE
[salt-shaker] Fix slmicro 6.x salt-test flavor

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro60
@@ -17,7 +17,7 @@ node('salt-shaker-tests') {
             cron('H 0 * * *')],
         ),
         parameters([
-            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt or '),
+            choice(name: 'salt_flavor', choices: ['python311'], description: 'Run testsuite for classic Salt or '),
             booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
             booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
             booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro61
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-slmicro61
@@ -17,7 +17,7 @@ node('salt-shaker-tests') {
             cron('H 0 * * *')],
         ),
         parameters([
-            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt or '),
+            choice(name: 'salt_flavor', choices: ['python311'], description: 'Run testsuite for classic Salt or '),
             booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
             booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
             booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro60
@@ -17,7 +17,7 @@ node('salt-shaker-tests') {
             cron('H 0 * * *')],
         ),
         parameters([
-            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt or '),
+            choice(name: 'salt_flavor', choices: ['python311'], description: 'Run testsuite for classic Salt or '),
             booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
             booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
             booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro61
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-slmicro61
@@ -17,7 +17,7 @@ node('salt-shaker-tests') {
             cron('H 0 * * *')],
         ),
         parameters([
-            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Run testsuite for classic Salt or '),
+            choice(name: 'salt_flavor', choices: ['python311'], description: 'Run testsuite for classic Salt or '),
             booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
             booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
             booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),


### PR DESCRIPTION
SLM 6.0 and 6.1 use `python311-salt-testsuite` - the flavor needs to be set to `python311`.