### PR TITLE
Update sumaform version only when deploying.

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -34,13 +34,17 @@ def run(params) {
             env.common_params = "${env.common_params} --parallelism ${params.terraform_parallelism}"
         }
         try {
-            stage('Clone terracumber, susemanager-ci and sumaform') {
+            stage('Clone terracumber, susemanager-ci') {
                 // Create a directory for  to place the directory with the build results (if it does not exist)
                 sh "mkdir -p ${resultdir}"
                 git url: params.terracumber_gitrepo, branch: params.terracumber_ref
                 dir("susemanager-ci") {
                     checkout scm
                 }
+            }
+
+            stage('Deploy') {
+
                 // Clone sumaform
                 sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
 
@@ -48,9 +52,7 @@ def run(params) {
                 if (params.use_previous_terraform_state) {
                     copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
                 }
-            }
 
-            stage('Deploy') {
                 if (params.must_deploy) {
                     // Generate custom_repositories.json file in the workspace from the value passed by parameter
                     if (params.custom_repositories?.trim()) {


### PR DESCRIPTION
## What does this PR do?

This PR ensures that `sumaform` is only updated during the deployment phase, rather than on every pipeline run.

### Why is this needed?

Currently, `sumaform` is updated regardless of whether a deployment is happening. This behavior is unnecessary and potentially harmful:

- It introduces the risk of breaking the BV cleaning pipeline if a new `sumaform` version is incompatible with the existing deployment.
- It undermines the stability of persistent environments by unintentionally modifying the `sumaform` workspace.

### What changes?

With this update, `sumaform` will only be updated when a deployment is actually triggered. This keeps the `sumaform` version and workspace consistent and compatible with the existing deployment when environments are reused.
