### PR TITLE
Beta disabled in Head

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
 
   container_server = true
   container_proxy  = true
-  beta_enabled = true
+  beta_enabled = false
 
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
 
   container_server = true
   container_proxy  = true
-  beta_enabled = true
+  beta_enabled = false
 
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -118,7 +118,7 @@ module "cucumber_testsuite" {
 
   container_server = true
   container_proxy  = true
-  beta_enabled = true
+  beta_enabled = false
 
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"

--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -188,7 +188,7 @@ module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
   name               = "server"
-  beta_enabled       = true
+  beta_enabled       = false
   provider_settings = {
     mac                = "aa:b2:93:01:02:81"
     memory             = 40960
@@ -1141,7 +1141,7 @@ module "controller" {
     vcpu               = 8
   }
   swap_file_size = null
-  beta_enabled = true
+  beta_enabled = false
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER


### PR DESCRIPTION
This pull request updates the Terraform configuration files to disable the `beta_enabled` flag across multiple modules. 