### PR TITLE
Commenting server_http_proxy except in Head

### DIFF
--- a/terracumber_config/tf_files/PR-testing-template.tf
+++ b/terracumber_config/tf_files/PR-testing-template.tf
@@ -43,7 +43,7 @@ module "cucumber_testsuite" {
   container_server = true
   container_proxy  = true
 
-  server_http_proxy = "http-proxy.${var.DOMAIN}:3128"
+  # server_http_proxy = "http-proxy.${var.DOMAIN}:3128"
   custom_download_endpoint = "ftp://${var.DOWNLOAD_ENDPOINT}:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
 
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -119,7 +119,7 @@ module "cucumber_testsuite" {
 
   mirror                   = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images        = true
-  server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
+  # server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.prv.suse.net:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -119,7 +119,7 @@ module "cucumber_testsuite" {
   auth_registry_password = "cucusecret"
   git_profiles_repo      = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
@@ -126,7 +126,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images        = true
 
-  server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
+  # server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.prv.suse.net:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-5.0-Test-Vega-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-Test-Vega-NUE.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   host_settings = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   container_server = true
   container_proxy  = true
 
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-PRV.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   container_server = true
   container_proxy  = true
 
-  server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
+  # server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.prv.suse.net:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-refenv-NUE.tf
@@ -123,7 +123,7 @@ module "cucumber_testsuite" {
   container_proxy  = true
   beta_enabled = false
 
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hexagon-NUE.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   host_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Hub.tf
@@ -192,7 +192,7 @@ module "controller" {
   branch       = var.CUCUMBER_BRANCH
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
-  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   
   server_configuration = module.prh1.configuration
 

--- a/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Ion-NUE.tf
@@ -115,7 +115,7 @@ module "cucumber_testsuite" {
   auth_registry_password = "cucusecret"
   git_profiles_repo      = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_nue"
 
-  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   container_server = true

--- a/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Naica-NUE.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   host_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Orion-NUE.tf
@@ -120,7 +120,7 @@ module "cucumber_testsuite" {
   container_proxy  = true
   beta_enabled = false
 
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   host_settings = {

--- a/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Test-Vega-NUE.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   host_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-K3S.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-K3S.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/Uyuni-Master-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-NUE.tf
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
 
   mirror                    = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images         = true
-  server_http_proxy         = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy         = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint  = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
 
   mirror                   = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images        = true
-  server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
+  # server_http_proxy        = "http-proxy.mgr.prv.suse.net:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.prv.suse.net:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -126,7 +126,7 @@ module "cucumber_testsuite" {
   mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images        = true
 
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   container_server = true
   container_proxy  = true
 
-  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage.tf
@@ -136,7 +136,7 @@ module "cucumber_testsuite" {
   auth_registry_password = "cucusecret"
   git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"
 
-  server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
+  # server_http_proxy = "http-proxy.mgr.prv.suse.net:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.prv.suse.net:445"
 
   host_settings = {


### PR DESCRIPTION
In order to mitigate our infrastructure issue, we want to stop using the HTTP Proxy in most of our test suites. We will keep it only on Head.


Related Slack thread: https://suse.slack.com/archives/C02EWMAB7QV/p1749637044417959