### PR TITLE
Increase server volume size

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -152,7 +152,7 @@ module "cucumber_testsuite" {
       image = "opensuse156o"
       provider_settings = {
         instance_type = "m6a.xlarge"
-        volume_size = "100"
+        volume_size = "200"
         private_ip = "172.16.3.6"
         overwrite_fqdn = "uyuni-master-server.sumaci.aws"
       }

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8", "opensuse155o", "opensuse156o", "sles15sp4o", "ubuntu2404"]
+  images = ["rocky8", "opensuse156o", "sles15sp4o", "ubuntu2404"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"


### PR DESCRIPTION
See https://github.com/uyuni-project/sumaform/pull/1858  - AMIs for Leap 15.5 are no longer available. We already did the switch to 15.6 and should not need them anyway.

The attached volume for AWS CI Server needs to be increased as it is currently insufficient to sync Leap 15.6, SLES 15 SP4, Rocky8 and Ubuntu 24.04