### PR TITLE
Add possibility to choose product version/base OS  Continuous BV

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -27,6 +27,9 @@ def run(params) {
         def server_container_repository = params.server_container_repository ?: null
         def proxy_container_repository = params.proxy_container_repository ?: null
         def server_container_image = params.server_container_image ?: ''
+        // Parameters used for continuous pipeline
+        def product_version = params.product_version ?: ''
+        def base_os = params.base_os ?: ''
 
         env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform"
 
@@ -79,6 +82,8 @@ def run(params) {
                         export TF_VAR_SERVER_CONTAINER_IMAGE=${server_container_image}
                         export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}
                         export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}
+                        export TF_VAR_PRODUCT_VERSION=${product_version}
+                        export TF_VAR_BASE_OS=${base_os}
                         export TERRAFORM=${params.terraform_bin}
                         export TERRAFORM_PLUGINS=${params.terraform_bin_plugins}
                     

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -37,6 +37,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'product_version', defaultValue: '5.1-nightly', description: 'Server product version'),
+            choice(name: 'base_os', choices: ['slmicro61o', 'sles15sp7o'], description: 'Server and Proxy base OS'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,

--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -30,6 +30,11 @@ variable "PRODUCT_VERSION" {
   default = "5.1-nightly"
 }
 
+variable "BASE_OS" {
+  type = string
+  default = "slmicro61o"
+}
+
 variable "MAIL_SUBJECT" {
   type = string
   default = "Results Continuous Build Validation $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
@@ -188,6 +193,7 @@ module "server_containerized" {
   source             = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
   name               = "server"
+  image              = var.BASE_OS
   beta_enabled       = false
   provider_settings = {
     mac                = "aa:b2:93:01:02:81"
@@ -228,6 +234,7 @@ module "proxy_containerized" {
   source             = "./modules/proxy_containerized"
   base_configuration = module.base_core.configuration
   name               = "proxy"
+  image              = var.BASE_OS
   provider_settings = {
     mac                = "aa:b2:93:01:02:82"
     memory             = 4096


### PR DESCRIPTION
## What does this PR ?

This PR introduces Jenkins parameters that allow you to select the product version and base OS for both the proxy and the server.
With these changes, you can now deploy 5.1 or Head on top of either SLE Micro 6.1 or SLES 15 SP7.
To use this functionality, you need to specify the following four parameters:
 - Product version for the Uyuni client tools
 - Base OS (default: slmicro6.1)
 - server_container_repository: Container registry for the server (differs between 5.1 and Head)
 - proxy_container_repository: Container registry for the proxy (differs between 5.1 and Head)

This enhancement makes it easier to switch between product versions without needing additional pull requests.