### PR TITLE
Add suport multihost json generator

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -19,7 +19,7 @@ def parse_cli_args() -> argparse.Namespace:
     )
     parser.add_argument("-v", "--version", dest="version",
                         help="Version of SUMA you want to run this script for, the options are 43 for 4.3, 50 for 5.0, and 51 for 5.1",
-                        choices=["43", "50", "51"], default="43", action='store')
+                        choices=["43", "50", "51-micro","51-sles"], default="43", action='store')
     parser.add_argument("-i", "--mi_ids", required=False, dest="mi_ids", help="Space separated list of MI IDs", nargs='*', action='store')
     parser.add_argument("-f", "--file", required=False, dest="file", help="Path to a file containing MI IDs separated by newline character", action='store')
     parser.add_argument("-e", "--no_embargo", dest="embargo_check", help="Reject MIs under embargo",  action='store_true')
@@ -71,16 +71,9 @@ def get_version_nodes(version: str):
         raise ValueError(f"No nodes for version {version} - supported versions: {supported_versions}")
     return version_nodes
 
-def init_custom_repositories(version: str, static_repos: dict[str, list[str]] = None) -> dict[str, dict[str, str]]:
-    custom_repositories: dict[str, dict[str, str]] = {}
-    if version == "51" and static_repos:
-        for node, urls in static_repos.items():
-            custom_repositories[node] = {f"static_{i}": url for i, url in enumerate(urls)}
-    return custom_repositories
-
 def init_custom_repositories(version: str, static_repos: dict[str, dict[str, str]] = None) -> dict[str, dict[str, str]]:
     custom_repositories: dict[str, dict[str, str]] = {}
-    if version == "51" and static_repos:
+    if version.startswith("51") and static_repos:
         for node, named_urls in static_repos.items():
             custom_repositories[node] = {
                 name: f"{IBS_MAINTENANCE_URL_PREFIX}{url}" if not url.startswith("http") else url

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/__init__.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/__init__.py
@@ -2,10 +2,12 @@ from .v43_nodes import get_v43_nodes_sorted
 from .v50_nodes import get_v50_nodes_sorted
 from .v51_nodes import get_v51_static_and_client_tools
 
-static_51, dynamic_51 = get_v51_static_and_client_tools()
+static_51_micro, dynamic_51_micro = get_v51_static_and_client_tools("micro")
+static_51_sles, dynamic_51_sles = get_v51_static_and_client_tools("sles")
 
 nodes_by_version: dict[str, dict[str, dict[str, list[str]]]] = {
     "43": {"dynamic": get_v43_nodes_sorted()},
     "50": {"dynamic": get_v50_nodes_sorted(get_v43_nodes_sorted())},
-    "51": {"static": static_51, "dynamic": dynamic_51},
+    "51-sles": {"static": static_51_sles, "dynamic": dynamic_51_sles},
+    "51-micro": {"static": static_51_micro, "dynamic": dynamic_51_micro}
 }

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
@@ -2,7 +2,7 @@
 from typing import Dict, Set, List
 
 # dictionary for 4.3 client tools
-v43_client_tools: dict[str, set[str]] = {
+v43_client_tools: dict[str, Dict[str, str]] = {
     "sle12sp5_client": {"/SUSE_Updates_SLE-Manager-Tools_12_x86_64/"},
     "sle12sp5_minion": {"/SUSE_Updates_SLE-Manager-Tools_12_x86_64/"},
     "sle15_client": {"/SUSE_Updates_SLE-Manager-Tools_15_x86_64/",
@@ -98,7 +98,7 @@ v43_client_tools: dict[str, set[str]] = {
 }
 
 # Dictionary for SUMA 4.3 Server and Proxy
-v43_nodes: Dict[str, Set[str]] = {
+v43_nodes: Dict[str, Dict[str, str]] = {
     "server": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3_x86_64/",
                "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/",
                "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
@@ -1,7 +1,7 @@
 from typing import Dict, Set, List
 
 # Dictionary for SUMA 5.0 Server and Proxy nodes
-v50_nodes: Dict[str, Set[str]] = {
+v50_nodes: Dict[str,Dict[str, str]] = {
     "server": {
         "/SUSE_Products_SUSE-Manager-Server_5.0_x86_64/",
         "/SUSE_Updates_SUSE-Manager-Server_5.0_x86_64/",
@@ -15,12 +15,12 @@ v50_nodes: Dict[str, Set[str]] = {
     },
 }
 
-def get_v50_nodes_sorted(v43_client_tools: Dict[str, Set[str]]) -> Dict[str, List[str]]:
+def get_v50_nodes_sorted(v43_client_tools: Dict[str,Dict[str, str]]) -> Dict[str, List[str]]:
     """
     Combine v50_nodes (server/proxy) with v43_client_tools (clients),
     returning a dictionary with sorted lists of repository paths.
     """
-    combined_nodes: Dict[str, Set[str]] = {}
+    combined_nodes: Dict[str,Dict[str, str]] = {}
 
     # Add v50_nodes entries
     for key, paths in v50_nodes.items():


### PR DESCRIPTION
## What does this PR do?
### Current Behavior

The JSON generator currently only supports generating custom repository JSON for a single host type (either slemicro55 or slmicro61) when using versions 5.1 or 5.0. This limits our ability to test or validate Uyuni tool repositories across multiple host types.

### Changes Introduced

This PR adds support for generating custom repository JSON for multiple host types (e.g., slmicro61 and sles15sp7) when using version 5.1.

 - The version argument now accepts a suffix (e.g., 51-slmicro61, 51-sles15sp7) to indicate which host variant should be used.
 - This avoids introducing a separate --host argument, which would complicate logic and break backward compatibility, especially for version 4.3, which doesn’t need host-specific repositories.

### Notes
- Only 5.1 variants are supported for now.
- Similar support for 5.0 variants will be implemented in a future change.