### PR TITLE
Increase number of runs kept for 5.1 BV

### DIFF
--- a/jenkins_pipelines/environments/manager-5.1-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.1-qe-build-validation-NUE
@@ -21,7 +21,7 @@ node('sumaform-cucumber') {
             'sles15sp5s390_minion, sles15sp5s390_sshminion, ' +
             'slemicro51_minion, slemicro52_minion, slemicro53_minion, slemicro54_minion, slemicro55_minion, slmicro60_minion, slmicro61_minion'
     properties([
-        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
+        buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '5')),
         disableConcurrentBuilds(),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),


### PR DESCRIPTION
## Context

With the possibility to enable/disable stages, we often need more than 5 runs to execute a full BV.

## What does this PR ?

Increase the number of run we keep to more easily look at the history.