### PR TITLE
Disable openeuler until we find a solution for the broken image

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-build-validation-NUE.tf
@@ -129,7 +129,8 @@ module "base_core" {
   name_prefix       = "mlm-bv-51-"
   use_avahi         = false
   domain            = "mgr.suse.de"
-  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "sles15sp7o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "slmicro61o", "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2204o", "ubuntu2404o", "debian12o", "opensuse155o", "opensuse156o" ]
+  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "sles15sp7o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "slmicro61o", "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2204o", "ubuntu2404o", "debian12o", "opensuse155o", "opensuse156o" ]
+                    # disabled: "openeuler2403o"
 
   mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -398,19 +399,19 @@ module "liberty9_minion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_minion" {
-  source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  name               = "openeuler2403-minion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:01:20"
-    memory             = 4096
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_minion" {
+#   source             = "./modules/minion"
+#   base_configuration = module.base_core.configuration
+#   name               = "openeuler2403-minion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:92:42:01:20"
+#     memory             = 4096
+#   }
+#   auto_connect_to_master  = false
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_minion" {
   source             = "./modules/minion"
@@ -822,18 +823,18 @@ module "liberty9_sshminion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_sshminion" {
-  source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  name               = "openeuler2403-sshminion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:92:42:01:40"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_sshminion" {
+#   source             = "./modules/sshminion"
+#   base_configuration = module.base_core.configuration
+#   name               = "openeuler2403-sshminion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:92:42:01:40"
+#     memory             = 4096
+#   }
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
@@ -1204,8 +1205,8 @@ module "controller" {
   liberty9_minion_configuration    = module.liberty9_minion.configuration
   liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
-  openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
-  openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
+  # openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
+  # openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
   oracle9_sshminion_configuration = module.oracle9_sshminion.configuration

--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -139,7 +139,8 @@ module "base_core" {
   name_prefix       = "suma-continuous-bv-"
   use_avahi         = false
   domain            = "mgr.suse.de"
-  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "sles15sp7o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "slmicro61o", "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2204o", "ubuntu2404o", "debian12o", "opensuse155o", "opensuse156o" ]
+  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "sles15sp7o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "slmicro61o", "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2204o", "ubuntu2404o", "debian12o", "opensuse155o", "opensuse156o" ]
+                    # disabled: "openeuler2403o"
 
   mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -408,19 +409,19 @@ module "liberty9_minion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_minion" {
-  source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  name               = "openeuler2403-minion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:93:01:02:a0"
-    memory             = 4096
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_minion" {
+#   source             = "./modules/minion"
+#   base_configuration = module.base_core.configuration
+#   name               = "openeuler2403-minion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:93:01:02:a0"
+#     memory             = 4096
+#   }
+#   auto_connect_to_master  = false
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_minion" {
   source             = "./modules/minion"
@@ -838,18 +839,18 @@ module "liberty9_sshminion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_sshminion" {
-  source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  name               = "openeuler2403-sshminion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:93:01:02:c0"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_sshminion" {
+#   source             = "./modules/sshminion"
+#   base_configuration = module.base_core.configuration
+#   name               = "openeuler2403-sshminion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:93:01:02:c0"
+#     memory             = 4096
+#   }
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
@@ -1220,8 +1221,8 @@ module "controller" {
   liberty9_minion_configuration    = module.liberty9_minion.configuration
   liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
-  openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
-  openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
+  # openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
+  # openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
   oracle9_sshminion_configuration = module.oracle9_sshminion.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-NUE.tf
@@ -129,7 +129,8 @@ module "base_core" {
   name_prefix       = "uyuni-bv-master-"
   use_avahi         = false
   domain            = "mgr.suse.de"
-  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "sles15sp7o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "slmicro61o", "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
+  images            = [ "sles12sp5o", "sles15sp3o", "sles15sp4o", "sles15sp5o", "sles15sp6o", "sles15sp7o", "slemicro51-ign", "slemicro52-ign", "slemicro53-ign", "slemicro54-ign", "slemicro55o", "slmicro60o", "slmicro61o", "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o", "ubuntu2004o", "ubuntu2204o", "ubuntu2404o", "debian12o", "opensuse155o", "opensuse156o", "leapmicro55o" ]
+                    # disabled: "openeuler2403o"
 
   mirror            = "minima-mirror-ci-bv.mgr.suse.de"
   use_mirror_images = true
@@ -398,19 +399,19 @@ module "liberty9_minion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_minion" {
-  source             = "./modules/minion"
-  base_configuration = module.base_core.configuration
-  name               = "openeuler2403-minion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:c0"
-    memory             = 4096
-  }
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_minion" {
+#   source             = "./modules/minion"
+#   base_configuration = module.base_core.configuration
+#   name               = "openeuler2403-minion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:93:02:01:c0"
+#     memory             = 4096
+#   }
+#   auto_connect_to_master  = false
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_minion" {
   source             = "./modules/minion"
@@ -834,18 +835,18 @@ module "liberty9_sshminion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_sshminion" {
-  source             = "./modules/sshminion"
-  base_configuration = module.base_core.configuration
-  name               = "openeuler2403-sshminion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:93:02:01:e0"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_sshminion" {
+#   source             = "./modules/sshminion"
+#   base_configuration = module.base_core.configuration
+#   name               = "openeuler2403-sshminion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:93:02:01:e0"
+#     memory             = 4096
+#   }
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_sshminion" {
   source             = "./modules/sshminion"
@@ -1200,8 +1201,8 @@ module "controller" {
   liberty9_minion_configuration    = module.liberty9_minion.configuration
   liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
-  openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
-  openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
+  # openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
+  # openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
   oracle9_sshminion_configuration = module.oracle9_sshminion.configuration

--- a/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-build-validation-PRV.tf
@@ -202,7 +202,8 @@ module "base_res" {
   name_prefix       = "uyuni-bv-master-"
   use_avahi         = false
   domain            = "mgr.prv.suse.net"
-  images            = [ "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "rocky8o", "rocky9o" ]
+  images            = [ "almalinux8o", "almalinux9o", "amazonlinux2023o", "centos7o", "libertylinux9o", "oraclelinux9o", "rocky8o", "rocky9o" ]
+                    # disabled: "openeuler2403o"
 
   mirror            = "minima-mirror-ci-bv.mgr.prv.suse.net"
   use_mirror_images = true
@@ -584,23 +585,23 @@ module "liberty9_minion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_minion" {
-  providers = {
-    libvirt = libvirt.cosmopolitan
-  }
-  source             = "./modules/minion"
-  base_configuration = module.base_res.configuration
-  name               = "openeuler2403-minion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:93:04:05:8c"
-    memory             = 4096
-  }
-
-  auto_connect_to_master  = false
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_minion" {
+#   providers = {
+#     libvirt = libvirt.cosmopolitan
+#   }
+#   source             = "./modules/minion"
+#   base_configuration = module.base_res.configuration
+#   name               = "openeuler2403-minion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:93:04:05:8c"
+#     memory             = 4096
+#   }
+#
+#   auto_connect_to_master  = false
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_minion" {
   providers = {
@@ -1100,21 +1101,21 @@ module "liberty9_sshminion" {
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
 }
 
-module "openeuler2403_sshminion" {
-  providers = {
-    libvirt = libvirt.cosmopolitan
-  }
-  source             = "./modules/sshminion"
-  base_configuration = module.base_res.configuration
-  name               = "openeuler2403-sshminion"
-  image              = "openeuler2403o"
-  provider_settings = {
-    mac                = "aa:b2:93:04:05:ac"
-    memory             = 4096
-  }
-  use_os_released_updates = false
-  ssh_key_path            = "./salt/controller/id_ed25519.pub"
-}
+# module "openeuler2403_sshminion" {
+#   providers = {
+#     libvirt = libvirt.cosmopolitan
+#   }
+#   source             = "./modules/sshminion"
+#   base_configuration = module.base_res.configuration
+#   name               = "openeuler2403-sshminion"
+#   image              = "openeuler2403o"
+#   provider_settings = {
+#     mac                = "aa:b2:93:04:05:ac"
+#     memory             = 4096
+#   }
+#   use_os_released_updates = false
+#   ssh_key_path            = "./salt/controller/id_ed25519.pub"
+# }
 
 module "oracle9_sshminion" {
   providers = {
@@ -1527,8 +1528,8 @@ module "controller" {
   liberty9_minion_configuration    = module.liberty9_minion.configuration
   liberty9_sshminion_configuration = module.liberty9_sshminion.configuration
 
-  openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
-  openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
+  # openeuler2403_minion_configuration    = module.openeuler2403_minion.configuration
+  # openeuler2403_sshminion_configuration = module.openeuler2403_sshminion.configuration
 
   oracle9_minion_configuration    = module.oracle9_minion.configuration
   oracle9_sshminion_configuration = module.oracle9_sshminion.configuration


### PR DESCRIPTION
SP1 image lacks cloud-init and is unusable.

We will probably switch to another openEuler version after 5.1. In the meantime, we disable automated tests in BV.

Not removing from infra, sumaform, pipelines, mirrors,  test suite code, etc. to let people experiment with openeuler and to make revival easier.