### PR TITLE
QoL: BV: Rename run with <version_OS> - <triggered options>

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -304,7 +304,7 @@ def run(params) {
                 // Call the minion testing.
                 try {
                     stage('Clients paygo stages') {
-                        clientTestingStages(capybara_timeout, default_timeout, 'paygo')
+                        clientTestingStages(params, capybara_timeout, default_timeout, 'paygo')
                     }
 
                 } catch (Exception ex) {
@@ -382,7 +382,7 @@ def run(params) {
                 // Call the minion testing.
                 try {
                     stage('Clients stages') {
-                        clientTestingStages(capybara_timeout, default_timeout)
+                        clientTestingStages(params, capybara_timeout, default_timeout)
                     }
 
                 } catch (Exception ex) {
@@ -523,13 +523,13 @@ def run(params) {
 
 // Develop a function that outlines the various stages of a minion.
 // These stages will be executed concurrently.
-def clientTestingStages(capybara_timeout, default_timeout, minion_type = 'default') {
+def clientTestingStages(params, capybara_timeout, default_timeout, minion_type = 'default') {
 
     // Implement a hash map to store the various stages of nodes.
     def tests = [:]
 
     // Load JSON matching non MU repositories data (non_MU_channels_tasks_file variable declared at the pipeline description level)
-    def json_matching_non_MU_data = readJSON(file: non_MU_channels_tasks_file)
+    def json_matching_non_MU_data = readJSON(file: params.non_MU_channels_tasks_file)
     //Get minion list from terraform state list command
     def nodesHandler = getNodesHandler(minion_type)
     def mu_sync_status = nodesHandler.MUSyncStatus

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -46,15 +46,16 @@ def run(params) {
                 }
             }
 
+            stage('Name run') {
+                currentBuild.displayName = nameDisplay(params)
+            }
+
             stage('Deploy') {
                 // Restore Terraform states from artifacts
                 if (params.use_previous_terraform_state) {
                     copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
                 }
 
-                stage('Name run') {
-                    currentBuild.displayName = nameDisplay(params)
-                }
                 if (params.must_deploy) {
                     // Clone sumaform
                     sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
@@ -108,10 +109,10 @@ def run(params) {
                 }
             }
 
-            stage('Sanity check') {
-                def nodesHandler = getNodesHandler()
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable}; cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:build_validation_sanity_check'"
-            }
+//            stage('Sanity check') {
+//                def nodesHandler = getNodesHandler()
+//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable}; cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:build_validation_sanity_check'"
+//            }
 
             stage('Run core features') {
                 if (params.must_run_core && (deployed || !params.must_deploy)) {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -664,22 +664,42 @@ def nameDisplay(params) {
     if (params.must_run_core) buildLabel << 'core'
     if (params.must_sync) buildLabel << 'reposync'
 
-    buildLabel << buildComponentLabel("proxy", params, ['must_add_MU_repositories': 'AddMU', 'must_add_keys': 'ActKeys', 'must_create_bootstrap_repos': 'CrBoot', 'must_boot_node': 'Boot'], params.enable_proxy_stages)
-    buildLabel << buildComponentLabel("monitoring", params, ['must_add_MU_repositories': 'AddMU', 'must_add_keys': 'ActKeys', 'must_create_bootstrap_repos': 'CrBoot', 'must_boot_node': 'Boot'], params.enable_monitoring_stages)
+    buildLabel << buildComponentLabel("proxy", params, [
+            'must_add_MU_repositories'     : 'AddMU',
+            'must_add_keys'                : 'ActKeys',
+            'must_create_bootstrap_repos'  : 'CrBoot',
+            'must_boot_node'               : 'Boot'
+    ], params.enable_proxy_stages)
+
+    buildLabel << buildComponentLabel("monitoring", params, [
+            'must_add_MU_repositories'     : 'AddMU',
+            'must_add_keys'                : 'ActKeys',
+            'must_create_bootstrap_repos'  : 'CrBoot',
+            'must_boot_node'               : 'Boot'
+    ], params.enable_monitoring_stages)
+
     buildLabel << buildComponentLabel("client", params, [
-            'must_add_MU_repositories': 'AddMU',
-            'must_add_non_MU_repositories': 'AddNonMU',
-            'must_add_keys': 'ActKeys',
-            'must_create_bootstrap_repos': 'CrBoot',
-            'must_boot_node': 'Boot',
-            'must_run_tests': 'Smoke'
+            'must_add_MU_repositories'     : 'AddMU',
+            'must_add_non_MU_repositories' : 'AddNonMU',
+            'must_add_keys'                : 'ActKeys',
+            'must_create_bootstrap_repos'  : 'CrBoot',
+            'must_boot_node'               : 'Boot',
+            'must_run_tests'               : 'Smoke'
     ], params.enable_client_stages)
 
     if (params.must_run_products_and_salt_migration_tests) buildLabel << 'migration'
     if (params.must_prepare_retail) buildLabel << 'retail'
 
+    // Manually filter null/empty items to avoid findAll()
+    def filteredLabel = []
+    for (item in buildLabel) {
+        if (item) {
+            filteredLabel << item
+        }
+    }
+
     def baseOs = params.base_os ?: ''
-    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${buildLabel.findAll().join(' ')}"
+    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
 
     if (fullLabel.length() > 160) {
         return "#${env.BUILD_NUMBER} - ${params.product_version}${baseOs ? "_${baseOs}" : ""}"
@@ -691,8 +711,10 @@ def buildComponentLabel(component, params, conditionsMap, isEnabled) {
     if (!isEnabled) return null
 
     def options = []
-    conditionsMap.each { key, label ->
-        if (params.get(key)) options << label
+    for (entry in conditionsMap) {
+        if (params.get(entry.key)) {
+            options << entry.value
+        }
     }
     return options ? "${component}[${options.join(' ')}]" : null
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -699,10 +699,10 @@ def nameDisplay(params) {
     }
 
     def baseOs = params.base_os ?: ''
-    def fullLabel = "${product_version_display}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
+    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
 
     if (fullLabel.length() > 160) {
-        return "#${env.BUILD_NUMBER} - ${product_version_display}${baseOs ? "_${baseOs}" : ""}"
+        return "#${env.BUILD_NUMBER} - ${params.product_version}${baseOs ? "_${baseOs}" : ""}"
     }
     return fullLabel
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -699,10 +699,10 @@ def nameDisplay(params) {
     }
 
     def baseOs = params.base_os ?: ''
-    def fullLabel = "${params.product_version_display}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
+    def fullLabel = "${product_version_display}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
 
     if (fullLabel.length() > 160) {
-        return "#${env.BUILD_NUMBER} - ${params.product_version_display}${baseOs ? "_${baseOs}" : ""}"
+        return "#${env.BUILD_NUMBER} - ${product_version_display}${baseOs ? "_${baseOs}" : ""}"
     }
     return fullLabel
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -277,7 +277,7 @@ def run(params) {
                 // Call the minion testing.
                 try {
                     stage('Clients stages') {
-                        clientTestingStages()
+                        clientTestingStages(params)
                     }
                 } catch (Exception ex) {
                     println('ERROR: one or more clients have failed')
@@ -413,13 +413,13 @@ def run(params) {
 
 // Develop a function that outlines the various stages of a minion.
 // These stages will be executed concurrently.
-def clientTestingStages() {
+def clientTestingStages(params) {
 
     // Implement a hash map to store the various stages of nodes.
     def tests = [:]
 
     // Load JSON matching non MU repositories data (non_MU_channels_tasks_file variable declared at the pipeline description level)
-    def json_matching_non_MU_data = readJSON(file: non_MU_channels_tasks_file)
+    def json_matching_non_MU_data = readJSON(file: params.non_MU_channels_tasks_file)
 
     //Get minion list from terraform state list command
     def nodesHandler = getNodesHandler()

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -699,10 +699,10 @@ def nameDisplay(params) {
     }
 
     def baseOs = params.base_os ?: ''
-    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
+    def fullLabel = "${params.product_version_display}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
 
     if (fullLabel.length() > 160) {
-        return "#${env.BUILD_NUMBER} - ${params.product_version}${baseOs ? "_${baseOs}" : ""}"
+        return "#${env.BUILD_NUMBER} - ${params.product_version_display}${baseOs ? "_${baseOs}" : ""}"
     }
     return fullLabel
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -699,12 +699,10 @@ def nameDisplay(params) {
     }
 
     def baseOs = params.base_os ?: ''
-//    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
-    def fullLabel = "${params.product_version}_${baseOs} - ${filteredLabel.join(' ')}"
+    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
 
     if (fullLabel.length() > 160) {
-//        return "#${env.BUILD_NUMBER} - ${params.product_version}${baseOs ? "_${baseOs}" : ""}"
-        return "#${env.BUILD_NUMBER} - ${params.product_version}_${baseOs}"
+        return "#${env.BUILD_NUMBER} - ${params.product_version}${baseOs ? "_${baseOs}" : ""}"
     }
     return fullLabel
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -109,10 +109,10 @@ def run(params) {
                 }
             }
 
-//            stage('Sanity check') {
-//                def nodesHandler = getNodesHandler()
-//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable}; cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:build_validation_sanity_check'"
-//            }
+            stage('Sanity check') {
+                def nodesHandler = getNodesHandler()
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable}; cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:build_validation_sanity_check'"
+            }
 
             stage('Run core features') {
                 if (params.must_run_core && (deployed || !params.must_deploy)) {
@@ -355,58 +355,58 @@ def run(params) {
                 archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
             }
 
-//            stage('Get results') {
-//                def result_error = 0
-//                if (deployed || !params.must_deploy) {
-//                    try {
-//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
-//                    } catch(Exception ex) {
-//                        println("ERROR: rake cucumber:build_validation_finishing failed")
-//                        result_error = 1
-//                    }
-//                    try {
-//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
-//                    } catch(Exception ex) {
-//                        println("ERROR: rake utils:generate_test_report failed")
-//                        result_error = 1
-//                    }
-//                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
-//                    publishHTML( target: [
-//                            allowMissing: true,
-//                            alwaysLinkToLastBuild: false,
-//                            keepAll: true,
-//                            reportDir: "${resultdirbuild}/cucumber_report/",
-//                            reportFiles: 'cucumber_report.html',
-//                            reportName: "Build Validation report"]
-//                    )
-////                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
-//                }
-//                // Send email
-//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
-//                // Clean up old results
-//                sh "./clean-old-results -r ${resultdir}"
-//                // Fail pipeline if client stages failed
-//                if (client_stage_result_fail) {
-//                    error("Client stage failed")
-//                }
-//                // Fail pipeline if monitoring stages failed
-//                if (monitoring_stage_result_fail) {
-//                    error("Monitoring stage failed")
-//                }
-//                // Fail pipeline if products or Salt migration stages failed
-//                if (products_and_salt_migration_stage_result_fail) {
-//                    error("Product or Salt migration stage failed")
-//                }
-//                // Fail pipeline if retail stages failed
-//                if (retail_stage_result_fail) {
-//                    error("Retail stage failed")
-//                }
-//                // Fail pipeline if containerization stage failed
-//                if (containerization_stage_result_fail) {
-//                    error("Containerization stage failed")
-//                }
-//                sh "exit ${result_error}"
-//            }
+            stage('Get results') {
+                def result_error = 0
+                if (deployed || !params.must_deploy) {
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake cucumber:build_validation_finishing failed")
+                        result_error = 1
+                    }
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+                    } catch(Exception ex) {
+                        println("ERROR: rake utils:generate_test_report failed")
+                        result_error = 1
+                    }
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+                    publishHTML( target: [
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: false,
+                            keepAll: true,
+                            reportDir: "${resultdirbuild}/cucumber_report/",
+                            reportFiles: 'cucumber_report.html',
+                            reportName: "Build Validation report"]
+                    )
+//                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+                }
+                // Send email
+                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                // Clean up old results
+                sh "./clean-old-results -r ${resultdir}"
+                // Fail pipeline if client stages failed
+                if (client_stage_result_fail) {
+                    error("Client stage failed")
+                }
+                // Fail pipeline if monitoring stages failed
+                if (monitoring_stage_result_fail) {
+                    error("Monitoring stage failed")
+                }
+                // Fail pipeline if products or Salt migration stages failed
+                if (products_and_salt_migration_stage_result_fail) {
+                    error("Product or Salt migration stage failed")
+                }
+                // Fail pipeline if retail stages failed
+                if (retail_stage_result_fail) {
+                    error("Retail stage failed")
+                }
+                // Fail pipeline if containerization stage failed
+                if (containerization_stage_result_fail) {
+                    error("Containerization stage failed")
+                }
+                sh "exit ${result_error}"
+            }
         }
     }
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -355,58 +355,58 @@ def run(params) {
                 archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
             }
 
-            stage('Get results') {
-                def result_error = 0
-                if (deployed || !params.must_deploy) {
-                    try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
-                    } catch(Exception ex) {
-                        println("ERROR: rake cucumber:build_validation_finishing failed")
-                        result_error = 1
-                    }
-                    try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
-                    } catch(Exception ex) {
-                        println("ERROR: rake utils:generate_test_report failed")
-                        result_error = 1
-                    }
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
-                    publishHTML( target: [
-                            allowMissing: true,
-                            alwaysLinkToLastBuild: false,
-                            keepAll: true,
-                            reportDir: "${resultdirbuild}/cucumber_report/",
-                            reportFiles: 'cucumber_report.html',
-                            reportName: "Build Validation report"]
-                    )
-//                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
-                }
-                // Send email
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
-                // Clean up old results
-                sh "./clean-old-results -r ${resultdir}"
-                // Fail pipeline if client stages failed
-                if (client_stage_result_fail) {
-                    error("Client stage failed")
-                }
-                // Fail pipeline if monitoring stages failed
-                if (monitoring_stage_result_fail) {
-                    error("Monitoring stage failed")
-                }
-                // Fail pipeline if products or Salt migration stages failed
-                if (products_and_salt_migration_stage_result_fail) {
-                    error("Product or Salt migration stage failed")
-                }
-                // Fail pipeline if retail stages failed
-                if (retail_stage_result_fail) {
-                    error("Retail stage failed")
-                }
-                // Fail pipeline if containerization stage failed
-                if (containerization_stage_result_fail) {
-                    error("Containerization stage failed")
-                }
-                sh "exit ${result_error}"
-            }
+//            stage('Get results') {
+//                def result_error = 0
+//                if (deployed || !params.must_deploy) {
+//                    try {
+//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
+//                    } catch(Exception ex) {
+//                        println("ERROR: rake cucumber:build_validation_finishing failed")
+//                        result_error = 1
+//                    }
+//                    try {
+//                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
+//                    } catch(Exception ex) {
+//                        println("ERROR: rake utils:generate_test_report failed")
+//                        result_error = 1
+//                    }
+//                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
+//                    publishHTML( target: [
+//                            allowMissing: true,
+//                            alwaysLinkToLastBuild: false,
+//                            keepAll: true,
+//                            reportDir: "${resultdirbuild}/cucumber_report/",
+//                            reportFiles: 'cucumber_report.html',
+//                            reportName: "Build Validation report"]
+//                    )
+////                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+//                }
+//                // Send email
+//                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+//                // Clean up old results
+//                sh "./clean-old-results -r ${resultdir}"
+//                // Fail pipeline if client stages failed
+//                if (client_stage_result_fail) {
+//                    error("Client stage failed")
+//                }
+//                // Fail pipeline if monitoring stages failed
+//                if (monitoring_stage_result_fail) {
+//                    error("Monitoring stage failed")
+//                }
+//                // Fail pipeline if products or Salt migration stages failed
+//                if (products_and_salt_migration_stage_result_fail) {
+//                    error("Product or Salt migration stage failed")
+//                }
+//                // Fail pipeline if retail stages failed
+//                if (retail_stage_result_fail) {
+//                    error("Retail stage failed")
+//                }
+//                // Fail pipeline if containerization stage failed
+//                if (containerization_stage_result_fail) {
+//                    error("Containerization stage failed")
+//                }
+//                sh "exit ${result_error}"
+//            }
         }
     }
 }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -47,7 +47,7 @@ def run(params) {
             }
 
             stage('Name run') {
-                currentBuild.displayName = nameDisplay(params)
+                currentBuild.description = nameDisplay(params)
             }
 
             stage('Deploy') {

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -699,10 +699,12 @@ def nameDisplay(params) {
     }
 
     def baseOs = params.base_os ?: ''
-    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
+//    def fullLabel = "${params.product_version}${baseOs ? "_${baseOs}" : ""} - ${filteredLabel.join(' ')}"
+    def fullLabel = "${params.product_version}_${baseOs} - ${filteredLabel.join(' ')}"
 
     if (fullLabel.length() > 160) {
-        return "#${env.BUILD_NUMBER} - ${params.product_version}${baseOs ? "_${baseOs}" : ""}"
+//        return "#${env.BUILD_NUMBER} - ${params.product_version}${baseOs ? "_${baseOs}" : ""}"
+        return "#${env.BUILD_NUMBER} - ${params.product_version}_${baseOs}"
     }
     return fullLabel
 }

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-AWS
@@ -72,7 +72,10 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "4.3-released"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -64,7 +64,10 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "4.3-released"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE
@@ -69,5 +69,5 @@ node('sumaform-cucumber') {
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -64,7 +64,10 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "4.3-released"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-build-validation-PRV
@@ -69,5 +69,5 @@ node('sumaform-cucumber-provo') {
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-AWS
@@ -64,7 +64,10 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "5.0-released"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -71,5 +71,5 @@ node('sumaform-cucumber') {
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-NUE
@@ -66,7 +66,10 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "5.0-released"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-build-validation-PRV
@@ -66,7 +66,10 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "5.0-released"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-5.1-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-5.1-qe-build-validation-NUE
@@ -67,7 +67,10 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "5.1-released"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -70,7 +70,8 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
+    params.product_version_display = params.product_version
     non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
-    def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
+    params.pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -70,6 +70,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
+    params.product_version_display =  params.product_version
     non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -37,7 +37,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'product_version', defaultValue: '5.1-nightly', description: 'Server product version'),
-            choice(name: 'base_os', choices: ['slmicro61o', 'sles15sp7o'], description: 'Server and Proxy base OS'),
+//            choice(name: 'base_os', choices: ['slmicro61o', 'sles15sp7o'], description: 'Server and Proxy base OS'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,
@@ -70,8 +70,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-//    product_version_display = params.product_version
     non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
-    params.pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
+    def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -37,7 +37,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'product_version', defaultValue: '5.1-nightly', description: 'Server product version'),
-//            choice(name: 'base_os', choices: ['slmicro61o', 'sles15sp7o'], description: 'Server and Proxy base OS'),
+            choice(name: 'base_os', choices: ['slmicro61o', 'sles15sp7o'], description: 'Server and Proxy base OS'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -70,7 +70,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    product_version_display = params.product_version
+//    product_version_display = params.product_version
     non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     params.pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -70,9 +70,9 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    def mutableParams = params.toMap()
+    def mutableParams = [:] + params
     mutableParams.product_version_display = mutableParams.product_version
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -70,8 +70,9 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    params.product_version_display =  params.product_version
+    def mutableParams = params.toMap()
+    mutableParams.product_version_display = mutableParams.product_version
     non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -70,7 +70,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    params.product_version_display = params.product_version
+    product_version_display = params.product_version
     non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     params.pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -37,7 +37,7 @@ node('sumaform-cucumber') {
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
             string(name: 'product_version', defaultValue: '5.1-nightly', description: 'Server product version'),
-            choice(name: 'base_os', choices: ['slmicro61o', 'sles15sp7o'], description: 'Server and Proxy base OS'),
+//            choice(name: 'base_os', choices: ['slmicro61o', 'sles15sp7o'], description: 'Server and Proxy base OS'),
             extendedChoice(name: 'minions_to_run',  multiSelectDelimiter: ', ', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 15,
                     value: minionList,
                     defaultValue: minionList,

--- a/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
+++ b/jenkins_pipelines/environments/manager-qe-continuous-build-validation-NUE
@@ -73,6 +73,7 @@ node('sumaform-cucumber') {
     def mutableParams = [:] + params
     mutableParams.product_version_display = mutableParams.product_version
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -73,5 +73,5 @@ node('sumaform-cucumber') {
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-NUE
@@ -68,7 +68,10 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "uyuni-master"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -68,7 +68,10 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    def mutableParams = [:] + params
+    mutableParams.product_version_display = "uyuni-master"
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
+++ b/jenkins_pipelines/environments/uyuni-master-qe-build-validation-PRV
@@ -73,5 +73,5 @@ node('sumaform-cucumber-provo') {
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
-    pipeline.run(params)
+    pipeline.run(mutableParams)
 }


### PR DESCRIPTION
## Context

During my BV testing, I will split my tests into separate runs (deploy -> reposync -> proxy -> etc).
Having only the build number make it complicated to manage so I started to rename the jobs.

## What does this PR?

Automatically update the  run name for BV run.

The name will be as follow:

<product_version>(_<base_os>|'') - <enabled stages>
If the names is too long because we run all the stages, it will just display: <BUILD_NUMBER>-<product_version>
I was thinking to also add a field that could be edited by us when running the test to specify for example the release version (5.0.14).

![image](https://github.com/user-attachments/assets/e753c2f4-1939-4741-8353-aaa222cb6bc4)

I also took the opportunity to fix how we handle the parameter `non_MU_channels_tasks_file` to make it easier to find.


## Note
Some groovy functions are blocked by jenkins so we need to use basic function.


