### PR TITLE
Increase AWS instance size for PAYGO servers

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-5.0-build-validation-paygo-AWS.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-build-validation-paygo-AWS.tf
@@ -208,7 +208,7 @@ module "server" {
   install_salt_bundle            = false
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   provider_settings = {
-    instance_type = var.ARCHITECTURE == "x86_64" ? "m6a.xlarge" : "m6g.xlarge"
+    instance_type = var.ARCHITECTURE == "x86_64" ? "m6a.2xlarge" : "m6g.2xlarge"
   }
 
   //server_additional_repos


### PR DESCRIPTION
4 vCPU and 16 GB of RAM tends to feel quite slow when syncing multiple repositories and/or big ones.

Switching to the recommended 8 vCPU and 32GB instance.