### PR TITLE
Increase number of vCPUs on CI's controllers

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -125,7 +125,7 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:93:01:00:90"
-        vcpu = 2
+        vcpu = 4
         memory = 2048
       }
     }

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -127,7 +127,7 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:92:03:00:80"
-        vcpu = 2
+        vcpu = 4
         memory = 2048
       }
     }

--- a/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
@@ -134,7 +134,7 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:93:01:00:f0"
-        vcpu = 2
+        vcpu = 4
         memory = 2048
       }
     }

--- a/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
@@ -129,7 +129,7 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:92:03:00:a0"
-        vcpu = 2
+        vcpu = 4
         memory = 2048
       }
     }

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:93:01:00:b0"
-        vcpu = 2
+        vcpu = 4
         memory = 2048
       }
     }

--- a/terracumber_config/tf_files/Uyuni-Master-PRV.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-PRV.tf
@@ -125,7 +125,7 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:92:03:00:d0"
-        vcpu = 2
+        vcpu = 4
         memory = 2048
       }
     }

--- a/terracumber_config/tf_files/Uyuni-Master-podman.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman.tf
@@ -134,6 +134,8 @@ module "cucumber_testsuite" {
     controller = {
       provider_settings = {
         mac = "aa:b2:93:01:00:20"
+        vcpu = 4
+        memory = 2048
       }
     }
     server_containerized = {


### PR DESCRIPTION
Increase number of vCPUs on CI's controllers for two reasons:
 * hope to increase performance
 * hope to avoid Net::ReadTimeout issue

Supported by Maxime's tests and Eric's measurements.