### PR TITLE
Make parameter mutable to pass to pipeline

### DIFF
--- a/jenkins_pipelines/environments/manager-4.3-qe-sle-update-NUE
+++ b/jenkins_pipelines/environments/manager-4.3-qe-sle-update-NUE
@@ -44,7 +44,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-4.3-qe-sle-update-PRV
+++ b/jenkins_pipelines/environments/manager-4.3-qe-sle-update-PRV
@@ -44,7 +44,7 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-5.0-qe-sle-update-NUE
+++ b/jenkins_pipelines/environments/manager-5.0-qe-sle-update-NUE
@@ -47,7 +47,7 @@ node('sumaform-cucumber') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }

--- a/jenkins_pipelines/environments/manager-5.0-qe-sle-update-PRV
+++ b/jenkins_pipelines/environments/manager-5.0-qe-sle-update-PRV
@@ -47,7 +47,7 @@ node('sumaform-cucumber-provo') {
     stage('Checkout pipeline') {
         checkout scm
     }
-    non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(params)
 }


### PR DESCRIPTION
We use loadEnvironment so we need mutableParams to populate params otherwise they are empty. See https://github.com/SUSE/susemanager-ci/blob/master/jenkins_pipelines/environments/manager-4.3-qe-build-validation-NUE#L69 for example. I suspect the SLE pipelines were leftovers.