### PR TITLE
Increase memory of CI controller from 2 GB to 4 GB

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-NUE.tf
@@ -135,7 +135,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:01:10"
         vcpu = 4
-        memory = 2048
+        memory = 4096
       }
     }
     server_containerized = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -126,7 +126,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:90"
         vcpu = 4
-        memory = 2048
+        memory = 4096
       }
     }
     server = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-PRV.tf
@@ -128,7 +128,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:80"
         vcpu = 4
-        memory = 2048
+        memory = 4096
       }
     }
     server = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
@@ -135,7 +135,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:f0"
         vcpu = 4
-        memory = 2048
+        memory = 4096
       }
     }
     server_containerized = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-PRV.tf
@@ -130,7 +130,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:92:03:00:a0"
         vcpu = 4
-        memory = 2048
+        memory = 4096
       }
     }
     server_containerized = {

--- a/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-Head-NUE.tf
@@ -131,7 +131,7 @@ module "cucumber_testsuite" {
       provider_settings = {
         mac = "aa:b2:93:01:00:b0"
         vcpu = 4
-        memory = 2048
+        memory = 4096
       }
     }
     server_containerized = {


### PR DESCRIPTION
Increase memory on CI controllers from 2 GB to 4 GB, in the hope:
 * to increase performance
 * to get rid of Net::ReadTimeout issue

Justified by my findings on 2025-07-11 : 

---
OK, some new facts about the Net::ReadTimeout:

for the first time, I was able to trigger it from my command line

when it happens, the whole controller is slowed down, it can even be seen from the hypervisor:
```
127274 qemu     20  0 8150176 2,099g 28672 R 436,2 0,419 252:08.67 qemu-system-x86
```
however, the high CPU might be a consequence, and not a cause

to be noticed, 436% cpu matches our evaluation of 4 vCPUs needed -- but it might be a coincidence

it happens at time of high parallelism: 8 chromedrivers

main cpu-eating process is one of the chrome processes, and the topmost parent

I also see kswapd process eating a lot of CPU, which makes absolutely no sense, since we have no swap partition on controllers

still, i see the controller short of memory (for the first time):
```
suma-ci-head-controller:~ # free -h
              total       used       free     shared buff/cache  available
Mem:          1.9Gi      1.9Gi       53Mi      9.0Mi      120Mi       35Mi
Swap:            0B         0B         0B
```

```
MiB Mem : 1972.641 total,  56.078 free, 1936.270 used, 117.254 buff/cache
MiB Swap:   0.000 total,   0.000 free,   0.000 used.  36.371 avail Mem
```

we might also be hitting this, making the situation worse: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1518457
although i only see kswapd at 20 %
