### PR TITLE
Add cloud init disk to tainted disk list.

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -94,7 +94,7 @@ def run(params) {
                         ./terracumber-cli ${common_params} \
                             --logfile ${resultdirbuild}/sumaform.log \
                             --init \
-                            --taint '.*(domain|main_disk|data_disk|database_disk|standalone_provisioning|server_extra_nfs_mounts).*' \
+                            --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning|server_extra_nfs_mounts).*' \
                             --custom-repositories ${WORKSPACE}/custom_repositories.json \
                             --sumaform-backend ${params.sumaform_backend} \
                             --use-tf-resource-cleaner \

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -272,7 +272,7 @@ def run(params) {
                         } else {
                             env.TERRAFORM_INIT = ''
                         }
-                        sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${cucumber_ref}; export TERRAFORM=${terraform_bin}; export TERRAFORM_PLUGINS=${terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|main_disk|data_disk|database_disk|standalone_provisioning).*' --runstep provision"
+                        sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${cucumber_ref}; export TERRAFORM=${terraform_bin}; export TERRAFORM_PLUGINS=${terraform_bin_plugins}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*' --runstep provision"
                         deployed = true
   
                         // Collect and tag Flaky tests from the GitHub Board

--- a/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
@@ -36,7 +36,7 @@ def run(params) {
                 if (params.terraform_taint) {
                     switch(params.sumaform_backend) {
                         case "libvirt":
-                            env.TERRAFORM_TAINT = " --taint '.*(domain|main_disk|data_disk|database_disk|standalone_provisioning).*'";
+                            env.TERRAFORM_TAINT = " --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
                             break;
                         case "aws":
                             env.TERRAFORM_TAINT = " --taint '.*(host).*'";

--- a/jenkins_pipelines/environments/common/pipeline-reference.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference.groovy
@@ -36,7 +36,7 @@ def run(params) {
                 if (params.terraform_taint) {
                     switch(params.sumaform_backend) {
                         case "libvirt":
-                            env.TERRAFORM_TAINT = "--taint '.*(domain|main_disk|data_disk|database_disk|standalone_provisioning).*'";
+                            env.TERRAFORM_TAINT = "--taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
                             break;
                         case "aws":
                             env.TERRAFORM_TAINT = "--taint '.*(host).*'";

--- a/jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy
@@ -36,7 +36,7 @@ def run(params) {
                 if (params.terraform_taint) {
                     switch(params.sumaform_backend) {
                         case "libvirt":
-                            env.TERRAFORM_TAINT = " --taint '.*(domain|main_disk|data_disk|database_disk|standalone_provisioning).*'";
+                            env.TERRAFORM_TAINT = " --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
                             break;
                         case "aws":
                             env.TERRAFORM_TAINT = " --taint '.*(host).*'";

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -83,7 +83,7 @@ def run(params) {
                 if (params.terraform_taint) {
                     switch(params.sumaform_backend) {
                         case "libvirt":
-                            env.TERRAFORM_TAINT = " --taint '.*(domain|main_disk|data_disk|database_disk|standalone_provisioning).*'";
+                            env.TERRAFORM_TAINT = " --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
                             break;
                         case "aws":
                             env.TERRAFORM_TAINT = " --taint '.*(host).*'";


### PR DESCRIPTION
## Context
PR related to issue: https://github.com/SUSE/spacewalk/issues/27668
It seems the current taint setup is not cleaning properly all disks (cloud init disks). This could explain the deployment instability on CI

## What does this PR ?

Add cloud init disks to the tainting disk list.