### PR TITLE
Rename s390 guest in continuous BV to use 51 name

### DIFF
--- a/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-continuous-build-validation-NUE.tf
@@ -536,7 +536,7 @@ module "sles15sp5s390_minion" {
   image              = "s15s5-minimal-2part-xfs"
 
   provider_settings = {
-    userid             = "W50MINUE"
+    userid             = "W51MINUE"
     mac                = "02:00:00:42:00:2e"
     ssh_user           = "sles"
     vswitch            = "VSUMA"
@@ -957,7 +957,7 @@ module "sles15sp5s390_sshminion" {
   image              = "s15s5-minimal-2part-xfs"
 
   provider_settings = {
-    userid             = "W50SSNUE"
+    userid             = "W51SSNUE"
     mac                = "02:00:00:42:00:2f"
     ssh_user           = "sles"
     vswitch            = "VSUMA"


### PR DESCRIPTION
Rename s390 guest in continuous BV to use 51 name instead of 50. The MACs are correct