### PR TITLE
Do not overwrite server and proxy for 50 in json script

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -48,7 +48,7 @@ def clean_mi_ids(mi_ids: list[str]) -> set[str]:
 def create_url(mi_id: str, suffix: str) -> str:
     url = f"{IBS_MAINTENANCE_URL_PREFIX}{mi_id}{suffix}"
 
-    res: requests.Response = requests.get(url)
+    res: requests.Response = requests.get(url, timeout=6)
     return url if res.ok else ""
 
 def validate_and_store_results(expected_ids: set [str], custom_repositories: dict[str, dict[str, str]], output_file: str = JSON_OUTPUT_FILE_NAME):

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
@@ -2,7 +2,7 @@
 from typing import Dict, Set, List
 
 # dictionary for 4.3 client tools
-v43_client_tools: dict[str, Dict[str, str]] = {
+v43_client_tools: dict[str, Set[str]] = {
     "sle12sp5_client": {"/SUSE_Updates_SLE-Manager-Tools_12_x86_64/"},
     "sle12sp5_minion": {"/SUSE_Updates_SLE-Manager-Tools_12_x86_64/"},
     "sle15_client": {"/SUSE_Updates_SLE-Manager-Tools_15_x86_64/",
@@ -100,7 +100,7 @@ v43_client_tools: dict[str, Dict[str, str]] = {
 }
 
 # Dictionary for SUMA 4.3 Server and Proxy
-v43_nodes: Dict[str, Dict[str, str]] = {
+v43_nodes: Dict[str, Set[str]] = {
     "server": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3_x86_64/",
                "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/",
                "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3-LTS_x86_64/",
@@ -115,5 +115,18 @@ v43_nodes: Dict[str, Dict[str, str]] = {
 }
 
 def get_v43_nodes_sorted() -> Dict[str, List[str]]:
+    """
+    Merge v43_nodes (server/proxy) with v43_client_tools (clients),
+    returning a dictionary with sorted lists of repository paths.
+
+    Notes:
+    - v43_nodes: Dict[str, Set[str]] (server/proxy paths)
+    - v43_client_tools: Dict[str, Set[str]] (client tool paths)
+    - No need to worry about duplicates; simply merge the dictionaries.
+    - The sets are converted into sorted lists for deterministic ordering.
+
+    Returns:
+        Dict[str, List[str]]: Each node type maps to a sorted list of repository paths.
+    """
     v43_nodes.update(v43_client_tools)
     return {k: sorted(v) for k, v in v43_nodes.items()}

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
@@ -101,12 +101,14 @@ v43_client_tools: dict[str, Dict[str, str]] = {
 
 # Dictionary for SUMA 4.3 Server and Proxy
 v43_nodes: Dict[str, Dict[str, str]] = {
-    "server": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3-LTS_x86_64/",
+    "server": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3_x86_64/",
+               "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/",
                "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3-LTS_x86_64/",
                "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",
                "/SUSE_Updates_SLE-Module-Web-Scripting_15-SP4_x86_64/",
                "/SUSE_Updates_SLE-Module-Server-Applications_15-SP4_x86_64/"},
-    "proxy": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Proxy_4.3-LTS_x86_64/",
+    "proxy": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Proxy_4.3_x86_64/",
+              "/SUSE_Updates_SLE-Product-SUSE-Manager-Proxy_4.3_x86_64/",
               "/SUSE_Updates_SLE-Product-SUSE-Manager-Proxy_4.3-LTS_x86_64/",
               "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",
               "/SUSE_Updates_SLE-Module-Server-Applications_15-SP4_x86_64/"}

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
@@ -20,6 +20,19 @@ def get_v50_nodes_sorted(v43_client_tools: Dict[str, Set[str]]) -> Dict[str, Lis
     """
     Combine v50_nodes (server/proxy) with v43_client_tools (clients),
     returning a dictionary with sorted lists of repository paths.
+
+    Notes:
+    - v50_nodes: Dict[str, Set[str]] (server/proxy paths)
+    - v43_client_tools: Dict[str, Set[str]] (client tool paths)
+    - Only adds client tool entries if they are not already defined in v50_nodes
+      (server/proxy keys are preserved).
+    - The sets are converted into sorted lists for deterministic ordering.
+
+    Args:
+        v43_client_tools (Dict[str, Set[str]]): Client tool repository paths to merge.
+
+    Returns:
+        Dict[str, List[str]]: Each node type maps to a sorted list of repository paths.
     """
     combined_nodes: Dict[str, Set[str]] = {k: set(v) for k, v in v50_nodes.items()}
 

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
@@ -1,7 +1,7 @@
 from typing import Dict, Set, List
 
 # Dictionary for SUMA 5.0 Server and Proxy nodes
-v50_nodes: Dict[str,Dict[str, str]] = {
+v50_nodes: Dict[str, Set[str]] = {
     "server": {
         "/SUSE_Products_SUSE-Manager-Server_5.0_x86_64/",
         "/SUSE_Updates_SUSE-Manager-Server_5.0_x86_64/",
@@ -15,23 +15,16 @@ v50_nodes: Dict[str,Dict[str, str]] = {
     },
 }
 
-def get_v50_nodes_sorted(v43_client_tools: Dict[str,Dict[str, str]]) -> Dict[str, List[str]]:
+def get_v50_nodes_sorted(v43_client_tools: Dict[str, Set[str]]) -> Dict[str, List[str]]:
     """
     Combine v50_nodes (server/proxy) with v43_client_tools (clients),
     returning a dictionary with sorted lists of repository paths.
     """
-    combined_nodes: Dict[str,Dict[str, str]] = {}
+    combined_nodes: Dict[str, Set[str]] = {k: set(v) for k, v in v50_nodes.items()}
 
-    # Add v50_nodes entries
-    for key, paths in v50_nodes.items():
-        combined_nodes[key] = paths.copy()
-
-    # Add v43_client_tools entries (client tools)
     for key, paths in v43_client_tools.items():
-        if key in combined_nodes:
-            combined_nodes[key].update(paths)
-        else:
-            combined_nodes[key] = paths.copy()
+        # only add if not already defined in v50 (avoid overwriting server/proxy)
+        if key not in combined_nodes:
+            combined_nodes[key] = set(paths)
 
-    # Return sorted lists instead of sets
     return {key: sorted(paths) for key, paths in combined_nodes.items()}

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
@@ -37,7 +37,7 @@ def get_v50_nodes_sorted(v43_client_tools: Dict[str, Set[str]]) -> Dict[str, Lis
     combined_nodes: Dict[str, Set[str]] = {k: set(v) for k, v in v50_nodes.items()}
 
     for key, paths in v43_client_tools.items():
-        # only add if not already defined in v50 (avoid overwriting server/proxy)
+        # Only add if not already defined in v50 (avoid overwriting server/proxy)
         if key not in combined_nodes:
             combined_nodes[key] = set(paths)
 

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
@@ -5,6 +5,7 @@ v50_nodes: Dict[str, Set[str]] = {
     "server": {
         "/SUSE_Products_SUSE-Manager-Server_5.0_x86_64/",
         "/SUSE_Updates_SUSE-Manager-Server_5.0_x86_64/",
+        "/SUSE_Updates_SLE-Module-Web-Scripting_15-SP6_x86_64/",
     },
     "proxy": {
         "/SUSE_Products_SUSE-Manager-Proxy_5.0_x86_64/",

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v51_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v51_nodes.py
@@ -120,13 +120,51 @@ v51_nodes_static_client_tools_repositories: Dict[str, Dict[str, str]] = {
     }
 }
 
-v51_nodes_dynamic_client_tools_repos: Dict[str, Dict[str, str]] = {
+v51_nodes_dynamic_client_tools_repos: Dict[str, Set[str]] = {
     "debian12_minion": {"/SUSE_Updates_MultiLinuxManagerTools_Debian-12_x86_64/"},
     "ubuntu2204_minion": {"/SUSE_Updates_MultiLinuxManagerTools_Ubuntu-22.04_x86_64/"},
     "ubuntu2404_minion": {"/SUSE_Updates_MultiLinuxManagerTools_Ubuntu-24.04_x86_64/"}
 }
 
 def get_v51_static_and_client_tools(variant: str = "micro") -> (Dict[str, Dict[str, str]], Dict[str, List[str]]):
+    """
+    Generate the full set of static and dynamic client tool repositories for SUMA 5.1.
+
+    The function merges static client repositories with Uyuni server/proxy repositories,
+    prepends the IBS URL prefix, and returns both static and dynamic sets in a
+    deterministic, sorted form.
+
+    Parameters:
+        variant (str): Either "micro" or "sles", determines which Uyuni tool set to use.
+                       "micro" → v51_uyuni_tools_micro_repos
+                       "sles"  → v51_uyuni_tools_sles_repos
+
+    Returns:
+        Tuple[
+            Dict[str, Dict[str, str]],  # static_repos
+                - Maps node IDs (e.g., "alma8_minion", "server", "proxy") to
+                  repo names → full IBS URLs.
+            Dict[str, List[str]]        # dynamic_client_tools_repos
+                - Maps dynamic client nodes (e.g., "debian12_minion") to
+                  a sorted list of full IBS URLs.
+        ]
+
+    Type and structure notes:
+    1. Static repositories:
+       - Input: v51_nodes_static_client_tools_repositories (Dict[str, Dict[str, str]])
+       - Merged with Uyuni server/proxy repos for the selected variant
+       - Output: Dict[str, Dict[str, str]] with full URLs
+
+    2. Dynamic client tool repositories:
+       - Input: v51_nodes_dynamic_client_tools_repos (Dict[str, Set[str]])
+       - Output: Dict[str, List[str]] with sorted full URLs
+       - Mirrors the pattern in v43/v50: sets of paths are converted to sorted lists.
+
+    Example:
+        static_repos, dynamic_repos = get_v51_static_and_client_tools("micro")
+        static_repos["server"]["server_uyuni_tools"]
+        dynamic_repos["debian12_minion"][0]
+    """
     static_repos: Dict[str, Dict[str, str]] = {
         key: {name: f"{IBS_URL_PREFIX}{path}" for name, path in subdict.items()}
         for key, subdict in v51_nodes_static_client_tools_repositories.items()


### PR DESCRIPTION
Do not overwrite server and proxy for 50 in json script.

The timeout is to try and speed the execution.

Added 4.3 LTS server and proxy (server confirmed, proxy not confirmed) and web scripting for 5.0

Tested with all versions with some SLE updates and none throw any errors and the 5.0 is not overwritten. 