### PR TITLE
Correct container path for 5.1-released

### DIFF
--- a/jenkins_pipelines/environments/manager-5.1-qe-sle-update-NUE
+++ b/jenkins_pipelines/environments/manager-5.1-qe-sle-update-NUE
@@ -22,8 +22,8 @@ node('sumaform-cucumber') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            string(name: 'server_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/containerfile', description: 'Proxy container registry'),
+            string(name: 'server_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/update/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/update/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),


### PR DESCRIPTION
Use correct container path for 5.1-released

"updates" in the path does not mean "with MLM updates", it means "it's an update to sle 15 sp7 :smile_cat: .