### PR TITLE
4.3 Maintanance MIs cannot be found without LTS extension

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
@@ -101,13 +101,13 @@ v43_client_tools: dict[str, Dict[str, str]] = {
 
 # Dictionary for SUMA 4.3 Server and Proxy
 v43_nodes: Dict[str, Dict[str, str]] = {
-    "server": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3_x86_64/",
-               "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3_x86_64/",
+    "server": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Server_4.3-LTS_x86_64/",
+               "/SUSE_Updates_SLE-Product-SUSE-Manager-Server_4.3-LTS_x86_64/",
                "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",
                "/SUSE_Updates_SLE-Module-Web-Scripting_15-SP4_x86_64/",
                "/SUSE_Updates_SLE-Module-Server-Applications_15-SP4_x86_64/"},
-    "proxy": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Proxy_4.3_x86_64/",
-              "/SUSE_Updates_SLE-Product-SUSE-Manager-Proxy_4.3_x86_64/",
+    "proxy": {"/SUSE_Updates_SLE-Module-SUSE-Manager-Proxy_4.3-LTS_x86_64/",
+              "/SUSE_Updates_SLE-Product-SUSE-Manager-Proxy_4.3-LTS_x86_64/",
               "/SUSE_Updates_SLE-Module-Basesystem_15-SP4_x86_64/",
               "/SUSE_Updates_SLE-Module-Server-Applications_15-SP4_x86_64/"}
 }


### PR DESCRIPTION
## Description

SLE MU I have errors with packages devoted to 4.3:
`ERROR - MI IDs <...> do not exist in custom_repositories dictionary.`

Going to the maintenance URL links now contain `LTS` see: https://download.suse.de/ibs/SUSE:/Maintenance:/40342/.
This way JSON can be generated.