### PR TITLE
Salt Shaker: use Salt Bundle for sumaform deployment on Leap156

### DIFF
--- a/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap156.tf
+++ b/terracumber_config/tf_files/salt-shaker/Salt-Shaker-Testing-Leap156.tf
@@ -111,7 +111,6 @@ module "salt-shaker-products-testing" {
   provider_settings  = {
     mac = "aa:b2:93:02:02:29"
   }
-  install_salt_bundle = false
 }
 
 output "configuration" {


### PR DESCRIPTION
This PR removes a leftover on `salt-shaker-products-testing-leap156` that is causing a failing deployment for the related Salt Shaker jenkins job. See: https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-testing-leap156/

NOTE: the others jobs for Leap156 are successfully deployed and running, the leftover was only found for `manager-salt-shaker-products-testing-leap156/`.