### PR TITLE
Enable OVAL data synchronization in HEAD refenv

### DIFF
--- a/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
@@ -146,6 +146,7 @@ module "cucumber_testsuite" {
       runtime = "podman"
       container_repository = "registry.suse.de/devel/galaxy/manager/head/containerfile"
       container_tag = "latest"
+      enable_oval_metadata = true
     }
     proxy_containerized = {
       provider_settings = {


### PR DESCRIPTION
Depends on https://github.com/uyuni-project/sumaform/pull/1913

Enable syncing of OVAL data in the HEAD reference environment.