### PR TITLE
Salt Shaker: Fix flavor to "python311" for SLES15SP7

### DIFF
--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp7
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-next-sles15sp7
@@ -6,7 +6,7 @@ node('salt-shaker-tests') {
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([
-            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Salt package flavor to test'),
+            choice(name: 'salt_flavor', choices: ['python311', 'bundle'], description: 'Salt package flavor to test'),
             booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
             booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
             booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),

--- a/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp7
+++ b/jenkins_pipelines/environments/salt-shaker/manager-salt-shaker-products-testing-sles15sp7
@@ -6,7 +6,7 @@ node('salt-shaker-tests') {
         disableConcurrentBuilds(),
         pipelineTriggers([cron('H 0 * * *')]),
         parameters([
-            choice(name: 'salt_flavor', choices: ['classic', 'bundle'], description: 'Salt package flavor to test'),
+            choice(name: 'salt_flavor', choices: ['python311', 'bundle'], description: 'Salt package flavor to test'),
             booleanParam(name: 'run_unit_tests', defaultValue: true, description: 'Run the Salt unit tests'),
             booleanParam(name: 'run_integration_tests', defaultValue: true, description: 'Run the Salt integration tests'),
             booleanParam(name: 'run_functional_tests', defaultValue: true, description: 'Run the Salt functional tests'),


### PR DESCRIPTION
This PR defines `python311` as the default flavor for SLE15SP7 jobs for classic Salt.

The primary python interpreter in SLE15SP7 is still Python 3.6, so even having https://github.com/openSUSE/salt-test/pull/10 merged won't help in the case of 15SP7.