### PR TITLE
Add SLE Micro 5.5 to 5.0 server repo in json generator

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v50_nodes.py
@@ -6,6 +6,7 @@ v50_nodes: Dict[str, Set[str]] = {
         "/SUSE_Products_SUSE-Manager-Server_5.0_x86_64/",
         "/SUSE_Updates_SUSE-Manager-Server_5.0_x86_64/",
         "/SUSE_Updates_SLE-Module-Web-Scripting_15-SP6_x86_64/",
+        "/SUSE_Updates_SLE-Micro_5.5_x86_64/",
     },
     "proxy": {
         "/SUSE_Products_SUSE-Manager-Proxy_5.0_x86_64/",


### PR DESCRIPTION
Add SLE Micro 5.5 to 5.0 server repo in json generator, otherwise packages like podman don't get tested for server host OS