### PR TITLE
Switch to 5.2-released (currently 5.2 beta 1)

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
@@ -52,14 +52,10 @@ node('sumaform-cucumber') {
     mutableParams.sumaform_backend = "libvirt"
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
-    // TODO: replace with final values
-    mutableParams.product_version_display = "head"
+    mutableParams.product_version_display = "5.2-released"
     mutableParams.non_MU_channels_tasks_file = "susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_52.json"
-    // mutableParams.product_version_display = "5.2-released"
-    // mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_52.json'
-    mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_micro_build_validation_nue.tfvars'
+    mutableParams.deployment_tfvars = "susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_micro_build_validation_nue.tfvars"
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(mutableParams)
-
 }

--- a/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
@@ -74,12 +74,9 @@ node('sumaform-cucumber') {
     mutableParams.sumaform_backend = "libvirt"
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
-    // TODO: replace with final values
-    mutableParams.product_version_display = "head"
+    mutableParams.product_version_display = "5.2-released"
     mutableParams.non_MU_channels_tasks_file = "susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_52.json"
-    // mutableParams.product_version_display = "5.2-released"
-    // mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_52.json'
-    mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_nue.tfvars'
+    mutableParams.deployment_tfvars = "susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_nue.tfvars"
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"
     pipeline.run(mutableParams)


### PR DESCRIPTION
In 5.2 Build Validation, now we start to have usable 5.2 branches, it's time to drift away from Head.

This PR switches from Head product to 5.2-released product (currently 5.2 beta 1).
