### PR TITLE
Use underscore separator on multiple entries for the same ID

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -88,7 +88,7 @@ def update_custom_repositories(custom_repositories: dict[str, dict[str, str]], n
     final_id: str = mi_id
     i: int = 1
     while final_id in node_ids:
-        final_id = f"{mi_id}-{i}"
+        final_id = f"{mi_id}_{i}"
         i += 1
     node_ids[final_id] = url
     custom_repositories[node] = node_ids

--- a/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
@@ -185,7 +185,7 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         self.assertDictEqual({
             'test_node_1': {
                 '1234': '1234_url',
-                '1234-1': '2nd_1234_url',
+                '1234_1': '2nd_1234_url',
                 '5678': '5678_url'
             }
         }, custom_repos)
@@ -194,7 +194,7 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         self.assertDictEqual({
             'test_node_1': {
                 '1234': '1234_url',
-                '1234-1': '2nd_1234_url',
+                '1234_1': '2nd_1234_url',
                 '5678': '5678_url'
             },
             'test_node_2': {
@@ -206,8 +206,8 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         self.assertDictEqual({
             'test_node_1': {
                 '1234': '1234_url',
-                '1234-1': '2nd_1234_url',
-                '1234-2': '3rd_1234_url',
+                '1234_1': '2nd_1234_url',
+                '1234_2': '3rd_1234_url',
                 '5678': '5678_url'
             },
             'test_node_2': {


### PR DESCRIPTION
Spotted during 5.1.3 BV

This is a fun one.

When we have multiple entries for an MI assigned to the same node, we add a counter prefix preceeded by a - (minus sign).
This value is eventually carried over through Jenkins, Python scripts and ends up in our terraform.tfvars. 
See the following as an example:

```
PROXY_ADDITIONAL_REPOS = {
  43367 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43367/SUSE_Updates_Multi-Linux-Manager-Retail-Branch-Server-SLE_5.1_x86_64/"
  43367-1 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43367/SUSE_Updates_Multi-Linux-Manager-Proxy-SLE_5.1_x86_64/"
  43385 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43385/SUSE_Updates_MultiLinuxManagerTools_SLE-15_x86_64/"
  43404 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43404/SUSE_Updates_MultiLinuxManagerTools_SLE-15_x86_64/"
}
```

When Terraform/OpenTofu uses this values, it interprets the 43367-1 as a mathematical expression.
This end in the final repo name added on the host being:

```
1 | 43366_repo                                                                           | 43366_repo                                                                   | No      | ----      | ----    | http://download.suse.de/ibs/SUSE:/Maintenance:/43367/SUSE_Updates_Multi-Linux-Manager-Proxy-SLE_5.1_x86_64/
```

Potentially leading to errors or troubles when we have MIs with the same ID as the resulting one.


I hope changing the separator to something else forces OpenTofu to consider the keys as strings from the get go.