### PR TITLE
Re-enable problematic minions

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-head-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-head-qe-build-validation
@@ -9,17 +9,19 @@ node('sumaform-cucumber') {
             'sles160_minion, sles160_sshminion, ' +
             'salt_migration_minion, ' +
             'alma8_minion, alma8_sshminion, alma9_minion, alma9_sshminion, alma10_minion, alma10_sshminion, ' +
-            // 'amazon2023_minion, amazon2023_sshminion, ' +
+            'amazon2023_minion, amazon2023_sshminion, ' +
             'centos7_minion, centos7_sshminion, ' +
-            // 'liberty9_minion, liberty9_sshminion, liberty10_minion, liberty10_sshminion, ' +
-            // 'oracle9_minion, oracle9_sshminion, oracle10_minion, oracle10_sshminion, ' +
+            'liberty9_minion, liberty9_sshminion, ' +
+            // 'liberty10_minion, liberty10_sshminion, ' +
+            'oracle9_minion, oracle9_sshminion, ' +
+            // 'oracle10_minion, oracle10_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, rocky10_minion, rocky10_sshminion, ' +
             'ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ubuntu2604_minion, ubuntu2604_sshminion, ' +
             // 'debian13_minion, debian13_sshminion, raspios13_minion, raspios13_sshminion, ' +
             'opensuse160arm_minion, opensuse160arm_sshminion, ' +
-            // 'sles15sp5s390_minion, sles15sp5s390_sshminion, ' +
-            'slemicro53_minion, slemicro54_minion, slemicro55_minion'
-            // 'slmicro60_minion, slmicro61_minion, slmicro62_minion'
+            'sles15sp5s390_minion, sles15sp5s390_sshminion, ' +
+            'slemicro53_minion, slemicro54_minion, slemicro55_minion, ' +
+            'slmicro60_minion, slmicro61_minion, slmicro62_minion'
     properties([
         buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '5')),
         disableConcurrentBuilds(),

--- a/jenkins_pipelines/environments/build-validation/manager-head-qe-build-validation-BACKUP
+++ b/jenkins_pipelines/environments/build-validation/manager-head-qe-build-validation-BACKUP
@@ -15,7 +15,7 @@ node('sumaform-cucumber-slc1') {
             'oracle9_minion, oracle9_sshminion, oracle10_minion, oracle10_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, rocky10_minion, rocky10_sshminion, ' +
             'ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ubuntu2604_minion, ubuntu2604_sshminion, ' +
-            'debian13_minion, debian13_sshminion, ' +
+            'debian13_minion, debian13_sshminion, raspios13_minion, raspios13_sshminion, ' +
             'opensuse160arm_minion, opensuse160arm_sshminion, ' +
             'sles15sp5s390_minion, sles15sp5s390_sshminion, ' +
             'slemicro53_minion, slemicro54_minion, slemicro55_minion, ' +


### PR DESCRIPTION
All minions fixed by @NamelessOne91 and me in 5.1.3 full BV and 5.2 beta 1 full BV,
excepted Leap 16 (problem with minima).

We did not test in head, but the changes were done in sumaform and on the mirror, so it should work.