### PR TITLE
Add TF and pipeline files for Uyuni Main CI

### DIFF
--- a/jenkins_pipelines/environments/uyuni-main-dev-acceptance-tests-podman
+++ b/jenkins_pipelines/environments/uyuni-main-dev-acceptance-tests-podman
@@ -1,0 +1,39 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([cron('H H/4 * * *')]),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'bin_path', choices: ['/usr/bin/tofu', '/usr/bin/terraform'], description: 'Binary path'),
+            choice(name: 'bin_plugins_path', choices: ['/usr/bin'], description: 'Plugins path'),
+            string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            booleanParam(name: 'show_product_changes', defaultValue: false, description: 'Show the product changes since the last build'),
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
+            extendedChoice(name: 'functional_scopes',  multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30, value: '@scope_smdba,@scope_spacecmd,@scope_spacewalk_utils,@scope_visualization,@scope_notification_message,@scope_virtual_host_manager,@scope_subscription_matching,@scope_formulas,@scope_sp_migration,@scope_cve_audit,@scope_onboarding,@scope_content_lifecycle_management,@scope_res,@scope_recurring_actions,@scope_maintenance_windows,@scope_building_container_images,@scope_kubernetes_integration,@scope_openscap,@scope_deblike,@scope_action_chains,@scope_salt_ssh,@scope_tomcat,@scope_changing_software_channels,@scope_monitoring,@scope_salt,@scope_cobbler,@scope_sumatoolbox,@scope_virtualization,@scope_hub,@scope_retail,@scope_configuration_channels,@scope_content_staging,@scope_proxy,@scope_traditional_client,@scope_api,@scope_power_management,@scope_retracted_patches,@scope_ansible,@scope_reportdb,@scope_containerized_proxy', description: 'Choose the functional scopes that you want to test')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 15, unit: 'HOURS') {
+        //Capybara configuration
+        capybara_timeout = 10
+        default_timeout = 250
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline.groovy"
+        pipeline.run(params)
+    }
+}

--- a/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
@@ -17,7 +17,7 @@ variable "CUCUMBER_GITREPO" {
 
 variable "CUCUMBER_BRANCH" {
   type = string
-  default = "main"
+  default = "master"
 }
 
 variable "CUCUMBER_RESULTS" {

--- a/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
@@ -1,0 +1,242 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-main-dev-acceptance-tests-podman"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "export PRODUCT='Uyuni' && run-testsuite"
+}
+
+variable "CUCUMBER_GITREPO" {
+  type = string
+  default = "https://github.com/uyuni-project/uyuni.git"
+}
+
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "main"
+}
+
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/spacewalk/testsuite"
+}
+
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results Uyuni-Main podman $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results Uyuni-Main podman: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins-env-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "jenkins@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for main, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for main, as it is public
+}
+
+variable "PROMETHEUS_PUSH_GATEWAY_URL" {
+  type = string
+  default = null
+}
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-01.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "uyuni-main"
+
+  // Cucumber repository configuration for the controller
+  git_username  = var.GIT_USER
+  git_password  = var.GIT_PASSWORD
+  git_repo      = var.CUCUMBER_GITREPO
+  branch        = var.CUCUMBER_BRANCH
+
+  cc_username   = var.SCC_USER
+  cc_password   = var.SCC_PASSWORD
+
+  images        = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+
+  use_avahi     = false
+  name_prefix   = "uyuni-ci-main-podman-"
+  domain        = "mgr.suse.de"
+  from_email    = "root@suse.de"
+
+  no_auth_registry          = "registry.mgr.suse.de"
+  auth_registry             = "registry.mgr.suse.de:5000/cucutest"
+  auth_registry_username    = "cucutest"
+  auth_registry_password    = "cucusecret"
+  git_profiles_repo         = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/temporary"
+
+  container_server          = true
+  container_proxy           = true
+
+  mirror                    = "minima-mirror-ci-bv.mgr.suse.de"
+  use_mirror_images         = true
+  server_http_proxy         = "http-proxy.mgr.suse.de:3128"
+  custom_download_endpoint  = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
+
+  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  host_settings = {
+    controller = {
+      provider_settings = {
+        mac       = "aa:b2:93:01:00:d0"
+        memory    = 4096
+        vcpu      = 4
+        cpu_model = "host-passthrough"
+      }
+    }
+    server_containerized = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:d1"
+      }
+      runtime               = "podman"
+      container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/main/containerfile"
+      container_tag         = "latest"
+      main_disk_size        = 40
+      repository_disk_size  = 250
+      database_disk_size    = 60
+      login_timeout         = 28800
+      large_deployment      = true
+    }
+    proxy_containerized = {
+      provider_settings = {
+        mac = "aa:b2:93:01:00:d2"
+      }
+      runtime              = "podman"
+      container_repository = "registry.opensuse.org/systemsmanagement/uyuni/main/containerfile"
+      container_tag        = "latest"
+    }
+    suse_minion = {
+      image             = "tumbleweedo"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:d6"
+      }
+    }
+    suse_sshminion = {
+      image             = "tumbleweedo"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:d8"
+      }
+    }
+    rhlike_minion = {
+      image             = "rocky8o"
+      provider_settings = {
+        mac    = "aa:b2:93:01:00:d9"
+        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+        // Also, openscap cannot run with less than 1.25 GB of RAM
+        vcpu   = 2
+        memory = 2048
+      }
+    }
+    deblike_minion = {
+      image             = "ubuntu2404o"
+      provider_settings = {
+        mac = "aa:b2:93:01:00:db"
+      }
+    }
+    build_host = {
+      image             = "sles15sp7o"
+      provider_settings = {
+        mac    = "aa:b2:93:01:00:dd"
+        memory = 2048
+      }
+    }
+    pxeboot_minion = {
+      image = "sles15sp7o"
+    }
+    dhcp_dns = {
+      name       = "dhcp-dns"
+      image      = "opensuse156o"
+      hypervisor = {
+        host        = "suma-01.mgr.suse.de"
+        user        = "root"
+        private_key = file("~/.ssh/id_ed25519")
+      }
+    }
+  }
+  provider_settings = {
+    pool               = "ssd"
+    network_name       = null
+    bridge             = "br0"
+    additional_network = "192.168.118.0/24"
+  }
+}
+
+
+resource "null_resource" "configure_quality_intelligence" {
+
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+
+  provisioner "remote-exec" {
+    inline = [ "echo export QUALITY_INTELLIGENCE=true >> ~/.bashrc",
+      "echo export PROMETHEUS_PUSH_GATEWAY_URL=${var.PROMETHEUS_PUSH_GATEWAY_URL} >> ~/.bashrc",
+      "source ~/.bashrc"
+    ]
+    connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+      host     = "${module.cucumber_testsuite.configuration.controller.hostname}"
+    }
+  }
+
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}


### PR DESCRIPTION
This PR adds TF and pipeline files for the new Jenkins job to run acceptance tests at the new `Uyuni:Main` setup (new Git workflow).

I used the `uyuni-master-dev-acceptance-tests-podman` job as reference, and adjusted it according to the new VMs, new "product_version", and the expectations for the new `uyuni-main-dev-acceptance-tests-podman` job..

See related PR to infra: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/1178

After this PR, I still need to prepare some changes for sumaform before I can finally setup this new project in our Jenkins.