### PR TITLE
Update container repository on code-cov env

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage-SLC.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage-SLC.tf
@@ -155,7 +155,7 @@ module "cucumber_testsuite" {
         vcpu = 6
       }
       runtime               = "podman"
-      container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/master/containerfile"
+      container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/main/containerfile"
       container_tag         = "latest"
       main_disk_size        = 40
       repository_disk_size  = 250
@@ -169,7 +169,7 @@ module "cucumber_testsuite" {
         memory = 16384
       }
       runtime               = "podman"
-      container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/master/containerfile"
+      container_repository  = "registry.opensuse.org/systemsmanagement/uyuni/main/containerfile"
       container_tag         = "latest"
     }
     suse_minion = {


### PR DESCRIPTION
This pull request updates the container repository references in the `Uyuni-Master-tests-code-coverage-SLC.tf` configuration to use the `main` branch instead of `master`. This ensures the test suite uses the latest and correct container images.

Repository reference updates:

* Updated the `container_repository` value from `master` to `main` for both the main test suite and the proxy in the `module "cucumber_testsuite"` block in `Uyuni-Master-tests-code-coverage-SLC.tf`. [[1]](diffhunk://#diff-e80342f2f29d1956dc1a8e264c9d9890290e95b06b90cc0925e55c8440e875f5L158-R158) [[2]](diffhunk://#diff-e80342f2f29d1956dc1a8e264c9d9890290e95b06b90cc0925e55c8440e875f5L172-R172)