### PR TITLE
QE: Put the whole url of the oci in the name

### DIFF
--- a/terracumber_config/tf_files/MLM-Head-RKE2-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-RKE2-NUE.tf
@@ -168,8 +168,7 @@ module "cucumber_testsuite" {
       runtime                        = "rke2"
       container_tag                  = "latest"
       container_repository           = "registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/containerfile/suse/multi-linux-manager/5.2/x86_64"
-      helm_chart_name                = "server-helm"
-      helm_chart_url                 = "oci://registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/charts/suse/multi-linux-manager/5.2"
+      helm_chart_url                 = "oci://registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/charts/suse/multi-linux-manager/5.2/server-helm"
     }
     proxy_kubernetes = {
       image = "sles15sp7o"
@@ -182,8 +181,7 @@ module "cucumber_testsuite" {
       runtime                     = "rke2"
       container_tag               = "latest"
       container_repository        = "registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/containerfile/suse/multi-linux-manager/5.2/x86_64"
-      helm_chart_name             = "proxy-helm"
-      helm_chart_url              = "oci://registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/charts/suse/multi-linux-manager/5.2"
+      helm_chart_url              = "oci://registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/charts/suse/multi-linux-manager/5.2/proxy-helm"
     }
     dhcp_dns = {
       name        = "dhcp-dns"

--- a/terracumber_config/tf_files/Uyuni-Master-RKE2-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-RKE2-NUE.tf
@@ -148,8 +148,7 @@ module "cucumber_testsuite" {
       runtime                        = "rke2"
       container_tag                  = "latest"
       container_repository           = "registry.opensuse.org/systemsmanagement/uyuni/master/containerfile/uyuni"
-      helm_chart_name                = "server-helm"
-      helm_chart_url                 = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni"
+      helm_chart_url                 = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server-helm"
 
       login_timeout = 28800
       main_disk_size = 40
@@ -168,8 +167,7 @@ module "cucumber_testsuite" {
       runtime = "rke2"
       container_tag = "latest"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containerfile/uyuni"
-      helm_chart_name = "proxy-helm"
-      helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni"
+      helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/proxy-helm"
       login_timeout = 28800
     }
   }


### PR DESCRIPTION
Put the whole url of the oci in the name instead of split it.