### PR TITLE
Increase the memory on Full BV controllers

### DIFF
--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_sles_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_sles_build_validation_nue.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:92:42:01:00"
     name = "controller"
+    memory = 24576
   }
   server_containerized = {
     mac  = "aa:b2:92:42:01:01"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_nue.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:92:42:01:50"
     name = "controller"
+    memory = 24576
   }
   server_containerized = {
     mac  = "aa:b2:92:42:01:51"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm_sandbox_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm_sandbox_build_validation_nue.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:93:01:02:80"
     name = "controller"
+    memory = 24576
   }
   server_containerized = {
     mac   = "aa:b2:93:01:02:81"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_nue.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:93:02:01:a0"
     name = "controller"
+    memory = 24576
   }
   server_containerized = {
     mac   = "aa:b2:93:02:01:a1"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_slc.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:93:04:05:6c"
     name = "controller"
+    memory = 24576
   }
   server_containerized = {
     mac   = "aa:b2:93:04:05:6d"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_nue.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:92:42:00:a0"
     name = "controller"
+    memory = 24576
   }
   # SUMA 4.3 uses VM-based Server, not containerized
   server = {

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:92:05:00:a0"
     name = "controller"
+    memory = 24576
   }
   server = {
     mac   = "aa:b2:92:05:00:a1"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_micro_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_micro_build_validation_nue.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:92:42:00:50"
     name = "controller"
+    memory = 24576
   }
   server_containerized = {
     mac             = "aa:b2:92:42:00:51"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_micro_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_micro_build_validation_slc.tfvars
@@ -3,6 +3,7 @@ ENVIRONMENT_CONFIGURATION = {
   controller = {
     mac  = "aa:b2:92:05:00:00"
     name = "controller"
+    memory = 24576
   }
   server_containerized = {
     mac   = "aa:b2:92:05:00:01"


### PR DESCRIPTION
Related card: https://github.com/SUSE/spacewalk/issues/30416

This pull request increases the memory allocation for the `controller` node to 24GB (24576 MB) across several build validation environment configuration files. This change ensures that all relevant controller nodes have sufficient resources for their workloads.

Resource allocation updates:

* Increased the `memory` property to 24576 for the `controller` node in the following environment configuration files:
  - `mlm51_sles_build_validation_nue.tfvars`
  - `mlm52_sles_build_validation_nue.tfvars`
  - `mlm_sandbox_build_validation_nue.tfvars`
  - `mlmhead_build_validation_nue.tfvars`
  - `mlmhead_build_validation_slc.tfvars`
  - `suma43_build_validation_nue.tfvars`
  - `suma43_build_validation_slc.tfvars`
  - `suma50_micro_build_validation_nue.tfvars`
  - `suma50_micro_build_validation_slc.tfvars`