### PR TITLE
Append AI secrets to bashrc on the controller

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -63,6 +63,18 @@ def run(params) {
                     deployed = true
                     // Collect and tag Flaky tests from the GitHub Board
                     def statusCode = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake utils:collect_and_tag_flaky_tests'", returnStatus: true
+
+                    // Setup AI Test Reviewer
+                    if (deployed && fileExists("${env.HOME}/.ai_secrets")) {
+                        sh """
+                        set +x
+                        SECRETS_B64=\$(sed '/^\$/d; s/^/export /' "\$HOME/.ai_secrets" | base64 -w0)
+                        ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd "grep -q '# BEGIN ai_secrets' /root/.bashrc || { echo '# BEGIN ai_secrets'; echo \${SECRETS_B64} | base64 -d; echo '# END ai_secrets'; } >> /root/.bashrc"
+                        """
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake ai_test_reviewer:setup'"
+                    } else {
+                        println("Skipping AI secrets upload: deployed=${deployed}, file present=${fileExists("${env.HOME}/.ai_secrets")}")
+                    }
                 }
             }
             stage('Product changes') {


### PR DESCRIPTION
This pull request introduces an enhancement to the test pipeline by adding an automated setup step for an AI Test Reviewer, which is conditionally executed based on deployment status and the presence of a secrets file. The main changes are as follows:

**AI Test Reviewer Integration:**

* Added a conditional step in the pipeline to set up the AI Test Reviewer if the deployment is successful and the `.ai_secrets` file exists in the user's home directory. This includes securely injecting secrets into `/root/.bashrc` and running the setup rake task.
* Added logging to indicate when the AI secrets upload step is skipped, providing visibility into the conditional execution.

It depends on: https://github.com/uyuni-project/uyuni/pull/11820