### PR TITLE
Remove finishing step from get results. Move it to secondary_finishing

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -121,12 +121,6 @@ def run(params) {
                 def error = 0
                 if (deployed) {
                     try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:finishing'"
-                    } catch(err) {
-                        println("ERROR: rake cucumber:finishing failed: ${err}")
-                        error = 1
-                    }
-                    try {
                         sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake utils:generate_test_report'"
                     } catch(err) {
                         println("ERROR: rake utils:generate_test_repor failed: ${err}")

--- a/jenkins_pipelines/environments/common/pipeline-playwright.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-playwright.groovy
@@ -92,12 +92,6 @@ def run(params) {
             stage('Get results') {
                 def error = 0
                 if (deployed) {
-                    try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/; ${env.exports} npm run cucumber:finishing'"
-                    } catch(err) {
-                        println("ERROR: rake cucumber:finishing failed: ${err}")
-                        error = 1
-                    }
                     sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep getresults"
                     publishHTML( target: [
                             allowMissing: true,

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -353,12 +353,6 @@ def run(params) {
                         if(must_test) {
                             if (deployed) {
                                 try {
-                                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:finishing'"
-                                } catch(Exception ex) {
-                                    println("ERROR: rake cucumber:finishing failed")
-                                    error = 1
-                                }
-                                try {
                                     sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake utils:generate_test_report'"
                                 } catch(Exception ex) {
                                     println("ERROR: rake utils:generate_test_repor failed")

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -148,12 +148,6 @@ def run(params) {
                 def error = 0
                 if (deployed) {
                     try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:finishing'"
-                    } catch(err) {
-                        println("ERROR: rake cucumber:finishing failed: ${err}")
-                        error = 1
-                    }
-                    try {
                         sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake utils:generate_test_report'"
                     } catch(err) {
                         println("ERROR: rake utils:generate_test_repor failed: ${err}")


### PR DESCRIPTION
## Context

Finishing rake is executed during get results. But the rake step is actually doing some testing. The get results should only be about getting results.
Move finishing to secondary finishing.

Depends on: https://github.com/uyuni-project/uyuni/pull/11882