### PR TITLE
remove warning from junit plugin configuration

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -5,7 +5,7 @@ def run(params) {
         GString resultdirbuild = "${resultdir}/${env.BUILD_NUMBER}"
 
         // The junit plugin doesn't affect full paths
-        GString junit_resultdir = "${resultdirbuild}/results_junit"
+        GString junit_resultdir = "results/${BUILD_NUMBER}/results_junit"
         GString exports = "export BUILD_NUMBER=${env.BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
         String tfvariables_file  = 'susemanager-ci/terracumber_config/tf_files/personal/variables.tf'
         String tfvars_infra_description = "susemanager-ci/terracumber_config/tf_files/personal/environment.tfvars"
@@ -159,7 +159,9 @@ def run(params) {
                             reportFiles: 'index.html',
                             reportName: 'TestSuite Report (multiple-cucumber)'
                     ])
-                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml"
+                    // skipPublishingChecks: Checks API not configured on this instance
+                    // skipMarkingBuildUnstable: prevents warning icon when checks are skipped
+                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true, skipMarkingBuildUnstable: true
                 }
                 // Send email
                 // Clean up old results

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -373,7 +373,9 @@ def run(params) {
                                             reportFiles: 'index.html',
                                             reportName: "TestSuite Report for Pull Request ${builder_project}:${pull_request_number}"]
                                 )
-                                junit allowEmptyResults: true, testResults: "results/${BUILD_NUMBER}/results_junit/*.xml"
+                                // skipPublishingChecks: Checks API not configured on this instance
+                                // skipMarkingBuildUnstable: prevents warning icon when checks are skipped
+                                junit allowEmptyResults: true, testResults: "results/${BUILD_NUMBER}/results_junit/*.xml", skipPublishingChecks: true, skipMarkingBuildUnstable: true
                             }
                             if (fileExists("results/${BUILD_NUMBER}")) {
                                 archiveArtifacts artifacts: "results/${BUILD_NUMBER}/**/*"

--- a/jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-salt-shaker.groovy
@@ -107,7 +107,9 @@ def run(params) {
                 def error = 0
                 if (deployed) {
                     sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep saltshaker_getresults"
-                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true
+                    // skipPublishingChecks: Checks API not configured on this instance
+                    // skipMarkingBuildUnstable: prevents warning icon when checks are skipped
+                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true, skipMarkingBuildUnstable: true
                 }
                 // Send email
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep saltshaker_mail"

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -186,7 +186,9 @@ def run(params) {
                                 reportFiles: 'index.html',
                                 reportName: "TestSuite Report"]
                     )
-                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true
+                    // skipPublishingChecks: Checks API not configured on this instance
+                    // skipMarkingBuildUnstable: prevents warning icon when checks are skipped
+                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true, skipMarkingBuildUnstable: true
 
                     // Test Report Summary
                     sh "python3 -m venv ${WORKSPACE}/venv"


### PR DESCRIPTION
## What does this PR

Remove the warning when you remove a warning ... 
For Junit archive, junit want to publish using an API but we don't have it configure.
So I disabled this warning, but disabling this warning create a new warning because I disable this warning.
So disable the warning warning us that a warning has been disabled.