### PR TITLE
Catch unstable builds and skip junit publishing checks

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -160,8 +160,11 @@ def run(params) {
                             reportName: 'TestSuite Report (multiple-cucumber)'
                     ])
                     // skipPublishingChecks: Checks API not configured on this instance
-                    // skipMarkingBuildUnstable: prevents warning icon when checks are skipped
-                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true, skipMarkingBuildUnstable: true
+                    catchError(buildResult: 'FAILURE', stageResult: 'SUCCESS') {
+                        junit allowEmptyResults: true,
+                                testResults: "${junit_resultdir}/*.xml",
+                                skipPublishingChecks: true
+                    }
                 }
                 // Send email
                 // Clean up old results

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -374,8 +374,11 @@ def run(params) {
                                             reportName: "TestSuite Report for Pull Request ${builder_project}:${pull_request_number}"]
                                 )
                                 // skipPublishingChecks: Checks API not configured on this instance
-                                // skipMarkingBuildUnstable: prevents warning icon when checks are skipped
-                                junit allowEmptyResults: true, testResults: "results/${BUILD_NUMBER}/results_junit/*.xml", skipPublishingChecks: true, skipMarkingBuildUnstable: true
+                                catchError(buildResult: 'FAILURE', stageResult: 'SUCCESS') {
+                                    junit allowEmptyResults: true,
+                                            testResults: "${junit_resultdir}/*.xml",
+                                            skipPublishingChecks: true
+                                }
                             }
                             if (fileExists("results/${BUILD_NUMBER}")) {
                                 archiveArtifacts artifacts: "results/${BUILD_NUMBER}/**/*"

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -187,9 +187,11 @@ def run(params) {
                                 reportName: "TestSuite Report"]
                     )
                     // skipPublishingChecks: Checks API not configured on this instance
-                    // skipMarkingBuildUnstable: prevents warning icon when checks are skipped
-                    junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true, skipMarkingBuildUnstable: true
-
+                    catchError(buildResult: 'FAILURE', stageResult: 'SUCCESS') {
+                        junit allowEmptyResults: true,
+                                testResults: "${junit_resultdir}/*.xml",
+                                skipPublishingChecks: true
+                    }
                     // Test Report Summary
                     sh "python3 -m venv ${WORKSPACE}/venv"
                     def SCRIPT_DIR = "${WORKSPACE}/susemanager-ci/jenkins_pipelines/scripts/test_review_summary"


### PR DESCRIPTION
The disable option is not working as expected. Just use a catch to remove the warning. This is just cosmetic.