### PR TITLE
Add HTML report publishing for test results

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -200,6 +200,14 @@ def run(params) {
                     // Test Report Vibes (PoC)
                     sh(script: "pip install test-report-vibes", returnStdout: false).trim()
                     sh(script: "test-report-vibes ${resultdirbuild}/cucumber_report/cucumber_report.html.json -o test-report-vibes.html", returnStdout: true).trim()
+                    publishHTML( target: [
+                                allowMissing: true,
+                                alwaysLinkToLastBuild: false,
+                                keepAll: true,
+                                reportDir: "${resultdirbuild}/results/cucumber_report/",
+                                reportFiles: 'test-report-vibes.html',
+                                reportName: "TestSuite Vibes"]
+                    )
                 }
                 // Send email
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"


### PR DESCRIPTION
This pull request adds integration for publishing enhanced test reports generated by the Test Report Vibes tool to the Jenkins pipeline. The main change is the addition of the `publishHTML` step to make the generated HTML report easily accessible from Jenkins.

**Test reporting improvements:**

* Added a `publishHTML` step to the pipeline to publish the `test-report-vibes.html` report from the `cucumber_report` directory, making the enhanced test report available in Jenkins.