### PR TITLE
Don't install test-report-vibes using the venv

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -199,7 +199,7 @@ def run(params) {
                     echo testSummary
                     // Test Report Vibes (PoC)
                     sh(script: "pip install test-report-vibes", returnStdout: false)
-                    sh(script: "test-report-vibes ${resultdirbuild}/cucumber_report/cucumber_report.html.json -o ${resultdirbuild}/cucumber_report/test-report-vibes.html", returnStdout: true).trim()
+                    sh(script: "test-report-vibes ${resultdirbuild}/cucumber_report/cucumber_report.html.json -o ${resultdirbuild}/cucumber_report/test-report-vibes.html", returnStdout: true)
                     publishHTML( target: [
                                 allowMissing: true,
                                 alwaysLinkToLastBuild: false,

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -198,8 +198,8 @@ def run(params) {
                     def testSummary = sh(script: "${WORKSPACE}/venv/bin/python ${SCRIPT_DIR}/test_review_summary.py ${resultdirbuild}/cucumber_report/cucumber_report.html.json", returnStdout: true).trim()
                     echo testSummary
                     // Test Report Vibes (PoC)
-                    sh(script: "${WORKSPACE}/venv/bin/pip install test-report-vibes", returnStdout: false)
-                    sh(script: "${WORKSPACE}/venv/bin/test-report-vibes ${resultdirbuild}/cucumber_report/cucumber_report.html.json -o ${resultdirbuild}/cucumber_report/test-report-vibes.html", returnStdout: true).trim()
+                    sh(script: "pip install test-report-vibes", returnStdout: false)
+                    sh(script: "test-report-vibes ${resultdirbuild}/cucumber_report/cucumber_report.html.json -o ${resultdirbuild}/cucumber_report/test-report-vibes.html", returnStdout: true).trim()
                     publishHTML( target: [
                                 allowMissing: true,
                                 alwaysLinkToLastBuild: false,


### PR DESCRIPTION
This pull request updates the way the `test-report-vibes` tool is installed and executed in the Jenkins pipeline script. The commands now use the system-wide `pip` and `test-report-vibes` executables instead of those from the virtual environment. As for some reason, the pip on the venv can't find the new published package.

- Pipeline execution:
  * Updated the installation and execution of `test-report-vibes` to use the system-wide `pip` and executable, rather than the virtual environment versions. (`jenkins_pipelines/environments/common/pipeline.groovy`)