### PR TITLE
PoC: Integrate test-report-vibes

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -193,10 +193,22 @@ def run(params) {
                                 skipPublishingChecks: true
                     }
                     // Test Report Summary
-                    sh "python3 -m venv ${WORKSPACE}/venv"
+                    sh "python3.11 -m venv ${WORKSPACE}/venv"
                     def SCRIPT_DIR = "${WORKSPACE}/susemanager-ci/jenkins_pipelines/scripts/test_review_summary"
                     def testSummary = sh(script: "${WORKSPACE}/venv/bin/python ${SCRIPT_DIR}/test_review_summary.py ${resultdirbuild}/cucumber_report/cucumber_report.html.json", returnStdout: true).trim()
                     echo testSummary
+
+                    // Test Report Vibes (PoC)
+                    sh(script: "${WORKSPACE}/venv/bin/pip install test-report-vibes==0.2.1")
+                    sh(script: "${WORKSPACE}/venv/bin/test-report-vibes ${resultdirbuild}/cucumber_report/cucumber_report.html.json -o ${resultdirbuild}/cucumber_report/test-report-vibes.html")
+                    publishHTML( target: [
+                                allowMissing: true,
+                                alwaysLinkToLastBuild: false,
+                                keepAll: true,
+                                reportDir: "${resultdirbuild}/cucumber_report/",
+                                reportFiles: 'test-report-vibes.html',
+                                reportName: "TestSuite Vibes"]
+                    )
                 }
                 // Send email
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"


### PR DESCRIPTION
Added [test-report-vibes](https://github.com/srbarrios/test-report-vibes) integration.

You can see a demo here:
https://oscarbarrios.tech/test-report-vibes/examples/sample_report_with_classifiers.html

**What TestSuite Vibes have:**

- Filters report data to failing, undefined, and pending steps. **It does not show green tests.**
- Keeps scenario context (all steps), plus optional screenshots from embeddings/hooks
- Groups issues by feature and includes pass/fail stats across the full run
- Builds a deterministic executive summary (no external AI/LLM calls)
- Optionally classifies failing scenarios by tags such as @new_issue and @flaky

