### PR TITLE
Fix Hub Env

### DIFF
--- a/terracumber_config/tf_files/MLM-Test-Hub.tf
+++ b/terracumber_config/tf_files/MLM-Test-Hub.tf
@@ -118,10 +118,10 @@ module "base_core" {
 }
 
 module "hub" {
-  source = "./modules/server"
+  source = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
   name = "hub"
-  product_version = "5.2-released"
+  product_version = "head-staging"
   image = "sles15sp7o"
   provider_settings = {
     mac = "aa:b2:93:01:01:31"
@@ -130,12 +130,15 @@ module "hub" {
   }
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
+  runtime              = "podman"
+  container_repository = "registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile"
+  container_tag        = "latest"
 }
 
 module "prh1" {
-  source = "./modules/server"
+  source = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
-  product_version = "5.2-released"
+  product_version = "head-staging"
   name = "prh1"
   auto_accept                    = true
   from_email                     = "root@suse.de"
@@ -146,12 +149,15 @@ module "prh1" {
   }
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
+  runtime              = "podman"
+  container_repository = "registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile"
+  container_tag        = "latest"
 }
 
 module "prh2" {
-  source = "./modules/server"
+  source = "./modules/server_containerized"
   base_configuration = module.base_core.configuration
-  product_version = "5.2-released"
+  product_version = "head-staging"
   name = "prh2"
   auto_accept                    = true
   from_email                     = "root@suse.de"
@@ -162,6 +168,9 @@ module "prh2" {
   }
   additional_packages = [ "venv-salt-minion" ]
   install_salt_bundle = true
+  runtime              = "podman"
+  container_repository = "registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile"
+  container_tag        = "latest"
 }
 
 


### PR DESCRIPTION
This pull request updates the deployment configuration in `MLM-Test-Hub.tf` to use containerized server modules and modernizes the environment settings for the `hub`, `prh1`, and `prh2` modules. The main changes involve switching to a container-based deployment with Podman and updating product versions and image sources.

**Containerization and Deployment Updates:**

* Switched the `source` for the `hub`, `prh1`, and `prh2` modules from `./modules/server` to `./modules/server_containerized`, enabling containerized deployments. [[1]](diffhunk://#diff-8f16293faa65ca6f976b75792fdb022ec8e9d029bb9d65760cf7a7623cc8a24cL121-R124) [[2]](diffhunk://#diff-8f16293faa65ca6f976b75792fdb022ec8e9d029bb9d65760cf7a7623cc8a24cR152-R160)
* Added new parameters to each module: `runtime` set to `"podman"`, `container_repository` pointing to the SUSE registry for the appropriate container image, and `container_tag` set to `"latest"`. [[1]](diffhunk://#diff-8f16293faa65ca6f976b75792fdb022ec8e9d029bb9d65760cf7a7623cc8a24cR133-R141) [[2]](diffhunk://#diff-8f16293faa65ca6f976b75792fdb022ec8e9d029bb9d65760cf7a7623cc8a24cR152-R160) [[3]](diffhunk://#diff-8f16293faa65ca6f976b75792fdb022ec8e9d029bb9d65760cf7a7623cc8a24cR171-R173)

**Version and Image Updates:**

* Updated the `product_version` for all three modules from `"5.2-released"` to `"head-staging"`, and set the `image` to `"sles15sp7o"` for the `hub` module. [[1]](diffhunk://#diff-8f16293faa65ca6f976b75792fdb022ec8e9d029bb9d65760cf7a7623cc8a24cL121-R124) [[2]](diffhunk://#diff-8f16293faa65ca6f976b75792fdb022ec8e9d029bb9d65760cf7a7623cc8a24cR152-R160)

These changes modernize the deployment approach and ensure the latest container images and versions are used for testing.