### PR TITLE
Use old worker ssh key path

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -125,7 +125,7 @@ def run(params) {
                         commonArgs += " --inject CUCUMBER_GITREPO=${params.cucumber_gitrepo}"
                         commonArgs += " --inject CUCUMBER_BRANCH=${params.cucumber_ref}"
                         if (isNewJenkins) {
-                            commonArgs += " --inject PRIVATE_SSH_KEY_PATH=\"/home/jenkins/.ssh/id_ed25519.worker\""
+                            commonArgs += " --inject PRIVATE_SSH_KEY_PATH=\"/home/jenkins/.ssh/id_ed25519.oldworker\""
                             commonArgs += " --inject PUBLIC_SSH_KEY_PATH=\"/home/jenkins/.ssh/id_ed25519.pub.controller\""
                         }
                         if (product_version) { commonArgs += " --inject PRODUCT_VERSION=${product_version}" }


### PR DESCRIPTION
## What does PR do ?

For feilong VM, the public ssh key is baked into the image and can't be updated for now. 
To leviate the issue, add the .ssh/id_ed25519 from jenkins-worker.mgr.suse.de to jenkins.mgr.suse.de worker container.