### PR TITLE
Fix/replace active choice with extended choice

### DIFF
--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-4.3-qe-mi-validation-sles
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-4.3-qe-mi-validation-sles
@@ -13,9 +13,7 @@ node('sumaform-cucumber') {
             string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
-                return [ 'sles15sp4_minion:selected' ]
-            """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
+            extendedChoice(name: 'minions_to_run', description: 'Node list to run during BV', multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', value: 'sles15sp4_minion', defaultValue: 'sles15sp4_minion', visibleItemCount: 10),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.0-qe-mi-validation-bci
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.0-qe-mi-validation-bci
@@ -13,9 +13,7 @@ node('sumaform-cucumber') {
             string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
-                return [ 'sles15sp6_minion:selected' ]
-            """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
+            extendedChoice(name: 'minions_to_run', description: 'Node list to run during BV', multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', value: 'sles15sp6_minion', defaultValue: 'sles15sp6_minion', visibleItemCount: 10),
             string(name: 'server_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp6/update/products/manager50/update/containerfile', description: 'Server container registry'),
             string(name: 'proxy_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp6/update/products/manager50/update/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.0-qe-mi-validation-mgrtools
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.0-qe-mi-validation-mgrtools
@@ -13,9 +13,7 @@ node('sumaform-cucumber') {
             string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
-                return [ 'sles15sp6_minion:selected' ]
-            """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
+            extendedChoice(name: 'minions_to_run', description: 'Node list to run during BV', multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', value: 'sles15sp6_minion', defaultValue: 'sles15sp6_minion', visibleItemCount: 10),
             string(name: 'server_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp6/update/products/manager50/update/containerfile', description: 'Server container registry'),
             string(name: 'proxy_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp6/update/products/manager50/update/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.1-qe-mi-validation-bci
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.1-qe-mi-validation-bci
@@ -13,9 +13,7 @@ node('sumaform-cucumber') {
             string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
-                return [ 'sles15sp7_minion:selected' ]
-            """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
+            extendedChoice(name: 'minions_to_run', description: 'Node list to run during BV', multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', value: 'sles15sp7_minion', defaultValue: 'sles15sp7_minion', visibleItemCount: 10),
             string(name: 'server_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/update/containerfile', description: 'Server container registry'),
             string(name: 'proxy_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/update/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.1-qe-mi-validation-mgrtools
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.1-qe-mi-validation-mgrtools
@@ -13,9 +13,7 @@ node('sumaform-cucumber') {
             string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
-                return [ 'sles15sp7_minion:selected' ]
-            """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
+            extendedChoice(name: 'minions_to_run', description: 'Node list to run during BV', multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', value: 'sles15sp7_minion', defaultValue: 'sles15sp7_minion', visibleItemCount: 10),
             string(name: 'server_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/update/containerfile', description: 'Server container registry'),
             string(name: 'proxy_container_repository', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/update/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),


### PR DESCRIPTION
## Description

SLE MU pipelines failing with:

```
Started by user Manager Team

Rebuilds build #369

Obtained jenkins_pipelines/environments/sle-maintenance-update/manager-4.3-qe-mi-validation-sles from git https://github.com/SUSE/susemanager-ci.git

[Pipeline] Start of Pipeline

[Pipeline] node

Running on manager-jenkins-worker in /home/jenkins/workspace/manager-4.3-qe-mi-validation-sles

[Pipeline] {

[Pipeline] }

[Pipeline] // node

[Pipeline] End of Pipeline

Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 987d6de7-5322-4c7f-8da3-b9f4c78f589c

java.lang.NoSuchMethodError: No such DSL method 'activeChoice' found among steps [acceptGitLabMR, addGitLabMRComment, ansiColor, archive, bat, build, catchError, checkout, compareVersions, deleteDir, dir, dockerFingerprintFrom, dockerFingerprintRun, echo, emailext, emailextrecipients, envVarsForTool, error, fileExists, findFiles, getContext, git, gitlabBuilds, gitlabCommitStatus, httpRequest, input, ircNotify, isUnix, jiraComment, jiraIssueSelector, jiraSearch, junit, labelledShell, library, libraryResource, load, lock, logstash, logstashSend, mail, milestone, node, nodesByLabel, notifyEndpoints, parallel, powershell, prependToFile, properties, publishChecks, publishHTML, publishIssues, pwd, pwsh, readCSV, readFile, readJSON, readManifest, readMavenPom, readProperties, readTrusted, readYaml, recordCoverage, recordIssues, resolveScm, retry, scanForIssues, script, setGerritReview, setGitHubPullRequestStatus, sh, sha1, sha256, sleep, sloccountPublish, sshagent, stage, stash, step, svn, tar, task, tee, timeout, timestamps, tm, tool, touch, unarchive, unstable, unstash, untar, unzip, updateGitlabCommitStatus, validateDeclarativePipeline, verifySha1, verifySha256, waitForBuild, waitForQualityGate, waitUntil, warnError, withChecks, withContext, withCredentials, withDockerContainer, withDockerRegistry, withDockerServer, withEnv, withGroovy, wrap, writeCSV, writeFile, writeJSON, writeMavenPom, writeYaml, ws, zip] or symbols [CrossCoreEmbeddedStudioParser, GitUsernamePassword, JsonContent, JsonContentEntry, MD5Sum, Number, Open, PVSStudio, RequestHeader, TextContent, TextContentEntry, URLTrigger, URLTriggerEntry, XMLContent, XMLContentEntry, acuCobol, agent, ajc, all, allBranchesSame, allOf, allowRunOnStatus, always, analysisParser, androidLintParser, ansibleLint, ant, antFromApache, antOutcome, antPath, antTarget, any, anyOf, apiToken, apiTokenProperty, aquaScanner, architecture, archiveArtifacts, armCc, artifactManager, asIsGITScm, assembla, attachments, authorInChangelog, authorizationMatrix, axivion, axivionSuite, batchFile, bitbucket, bitbucketBranchDiscovery, bitbucketBuildStatusNotifications, bitbucketForkDiscovery, bitbucketPublicRepoPullRequestFilter, bitbucketPullRequestDiscovery, bitbucketServer, bitbucketSshCheckout, bitbucketTagDiscovery, bitbucketTrustEveryone, bitbucketTrustNobody, bitbucketTrustProject, bitbucketTrustTeam, bitbucketWebhookConfiguration, bitbucketWebhookRegistration, bluepearl, booleanParam, brakeman, branch, branchCreated, branches, brokenBuildSuspects, brokenTestsSuspects, browser, buckminster, buildButton, buildCancellationPolicy, buildDescription, buildDiscarder, buildDiscarders, buildName, buildParameter, buildRetention, buildSelector, buildSingleRevisionOnly, buildUser, buildUserVars, buildingTag, builtInNode, cadence, cargo, caseInsensitive, caseSensitive, ccm, certificate, cgit, changeAbandoned, changeMerged, changeRequest, changeRestored, changelog, changelogBase, changelogToBranch, changeset, checkStyle, checkoutOption, checkoutToSubdirectory, choice, choiceParam, clair, clang, clangAnalyzer, clangTidy, cleanAfterCheckout, cleanBeforeCheckout, cleanWs, clock, cloneOption, close, cmake, cobertura, coberturaAdapter, coberturaReportAdapter, codeAnalysis, codeChecker, codeGeneratorParser, codeNarc, command, commentAdded, commentAddedContains, commentPattern, commit, commitChanged, commitMessagePattern, configFile, configFileProvider, consoleUrlProvider, contributor, coolflux, copyArtifactPermission, copyArtifacts, copyartifact, coverageTotalsColumn, cpd, cppCheck, cppLint, created, credentials, cron, crumb, cssLint, cssText, cssUrl, cucumber, culprits, dart, default, defaultDisplayUrlProvider, defaultFolderConfiguration, defaultView, deleted, demand, dependencyTrackPublisher, description, detekt, developers, diabC, disableConcurrentBuilds, disableRestartFromStage, disableResume, discoverOtherRefs, discoverOtherRefsTrait, discoverReferenceBuild, diskSpace, diskSpaceMonitor, docFx, docker, dockerCert, dockerLint, dockerServer, dockerTool, dockerfile, downstream, doxygen, drMemory, draftPublished, dscanner, dumb, dupFinder, durabilityHint, eclipse, elasticSearch, email-ext, embeddedEngineerParser, envInject, envVars, envVarsFilter, environment, equals, erlc, errorProne, esLint, excludeCategory, excludeFile, excludeMessage, excludeModule, excludeNamespace, excludePackage, excludeType, experimentalFlags, expression, extendedChoice, extendedEmailPublisher, faviconUrl, file, fileParam, filePath, findBugs, fingerprint, fingerprints, fisheye, flake8, flawfinder, flexSdk, folderConfigFiles, frameOptions, freeStyle, freeStyleJob, fromDocker, fromScm, fromSource, fxcop, gcc, gcc3, gcc4, gendarme, gerrit, gerrit-trigger, ghsMulti, git, gitBranchDiscovery, gitHooks, gitHub, gitHubBranchDiscovery, gitHubBranchHeadAuthority, gitHubEvents, gitHubExcludeArchivedRepositories, gitHubExcludeForkedRepositories, gitHubExcludePrivateRepositories, gitHubExcludePublicRepositories, gitHubForkDiscovery, gitHubIgnoreDraftPullRequestFilter, gitHubPRStatus, gitHubPlugin, gitHubPullRequestDiscovery, gitHubSshCheckout, gitHubTagDiscovery, gitHubTopicsFilter, gitHubTrustContributors, gitHubTrustEveryone, gitHubTrustNobody, gitHubTrustPermissions, gitLab, gitLabConnection, gitList, gitParameter, gitSCM, gitTagDiscovery, gitTool, gitUsernamePassword, gitWeb, gitblit, github, githubBranches, githubPRAddLabels, githubPRClosePublisher, githubPRComment, githubPRMessage, githubPRRemoveLabels, githubPRStatusPublisher, githubPlugin, githubProjectProperty, githubPullRequests, githubPush, gitiles, gitlab, globalConfigFiles, gnat, gnuFortran, goLint, goVet, gogs, groovy, groovyScript, group, grype, hadoLint, hashChanged, headRegexFilter, headWildcardFilter, hidden, hiddenParam, hyperlink, hyperlinkToModels, iar, iarCstat, ibLinter, ideaInspection, ignoreOnPush, inbound, includeCategory, includeFile, includeMessage, includeModule, includeNamespace, includePackage, includeType, infer, inheriting, inheritingGlobal, installSource, intel, invalids, isRestartedRun, issues, istanbulCobertura, istanbulCoberturaAdapter, jacoco, jacocoAdapter, java, javaDoc, javadoc, jcReport, jdk, jdkInstaller, jgit, jgitapache, jnlp, jobBuildDiscarder, jobConfigHistory, jobDsl, jobName, jsHint, jsLint, jsUrl, junitParser, junitTestResultStorage, keepSwarmClient, kiln, klocWork, kotlin, ktLint, label, labels, labelsAdded, labelsExist, labelsNotExist, labelsPatternExists, labelsRemoved, lastCompleted, lastDuration, lastFailure, lastGrantedAuthorities, lastStable, lastSuccess, lastSuccessful, lastWithArtifacts, latestSavedBuild, legacy, legacySCM, lfs, list, local, localBranch, localBranchTrait, location, logParser, logRotator, loggedInUsersCanDoAnything, logstash, mailer, maskPasswords, masterBuild, maven, maven3Mojos, mavenConsole, mavenErrors, mavenGlobalConfig, mavenMojos, mavenWarnings, message, metrowerksCodeWarrior, mineRepository, modelsim, modernSCM, msBuild, multiBranchProjectDisplayNaming, multibranch, myPy, myView, nagFortran, namedBranchesDifferent, newContainerPerStage, noGITScm, node, nodeProperties, nonInheriting, nonMergeable, none, nonresumable, not, oelintAdv, organizationFolder, otDockerLint, overrideIndexTriggers, owaspDependencyCheck, paneStatus, parallelsAlwaysFailFast, parameters, password, patchsetCreated, pattern, pcLint, pep8, perBuildTag, perforce, perlCritic, permalink, permanent, phabricator, php, phpCodeSniffer, phpStan, pipeline, pipeline-model, pipeline-model-docker, pipelineTriggers, pit, plainText, plugin, pmdParser, pollSCM, polyspaceParser, prefast, preserveStashes, previous, prism, privateStateChanged, projectNamingStrategy, protoLint, proxy, pruneStaleBranch, pruneStaleTag, pruneTags, publishCoverage, pullRequest, pullRequests, puppetLint, pyDocStyle, pyLint, qacSourceCodeAnalyser, qtTranslation, queueItemAuthenticator, quietPeriod, rabbitMq, rateLimit, rateLimitBuilds, recipients, recordCoverage, recordIssues, redis, redmine, refSpecs, refUpdated, remoteName, requestor, rerunCheck, resharperInspectCode, resourceRoot, responseTime, restriction, restrictions, retainOnlyVariables, revApi, rfLint, rhodeCode, robocopy, ruboCop, rule, run, runParam, sSHLauncher, sarif, scala, schedule, scmGit, scmRetryCount, script, scriptApproval, scriptApprovalLink, search, security, shell, simian, simpleBuildDiscarder, simpleTheme, simulinkCheckParser, skipDefaultCheckout, skipStagesAfterUnstable, slave, sonarQube, sourceFiles, sourceRegexFilter, sourceWildcardFilter, sparseCheckoutPaths, specific, sphinxBuild, spotBugs, ssh, sshPublicKey, sshUserPrivateKey, standard, status, statusOnPublisherError, string, stringParam, styleCop, styleLint, submodule, submoduleOption, sunC, suppressAutomaticTriggering, suppressFolderAutomaticTriggering, svnPhabricator, swapSpace, swiftLint, syslog, tag, tagList, tags, taskScanner, taskingVx, teamFoundation, teamSlugFilter, text, textParam, tiCss, timestamper, timestamperConfig, timezone, tmpSpace, tnsdl, toolLocation, topicChanged, triggeredBy, trivy, tsLint, unsecured, untrusted, upstream, upstreamDevelopers, url, user, userIdentity, userOrGroup, userSeed, usernameColonPassword, usernamePassword, validatingString, veracodePipelineScanner, viewgit, viewsTabBar, warningsParsers, warningsPlugin, weather, wipStateChanged, withAnt, withSonarQubeEnv, workspace, x509ClientCert, xlc, xmlLint, yamlLint, yuiCompressor, zip, zptLint] or globals [currentBuild, docker, env, fileLoader, ownership, params, pipeline, scm, simpleBuild]

	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:219)

	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:124)

	at jdk.internal.reflect.GeneratedMethodAccessor137.invoke(Unknown Source)

	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.base/java.lang.reflect.Method.invoke(Method.java:566)

	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:98)

	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)

	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1225)

	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1034)

	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:41)

	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)

	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)

	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:180)

	at org.kohsuke.groovy.sandbox.GroovyInterceptor.onMethodCall(GroovyInterceptor.java:23)

	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:163)

	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:178)

	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:182)

	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:152)

	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:17)

	at org.jenkinsci.plugins.workflow.cps.LoggingInvoker.methodCall(LoggingInvoker.java:105)

	at WorkflowScript.run(WorkflowScript:16)

	at ___cps.transform___(Native Method)

	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:90)

	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:116)

	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:85)

	at jdk.internal.reflect.GeneratedMethodAccessor136.invoke(Unknown Source)

	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.base/java.lang.reflect.Method.invoke(Method.java:566)

	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)

	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55)

	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45)

	at jdk.internal.reflect.GeneratedMethodAccessor133.invoke(Unknown Source)

	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.base/java.lang.reflect.Method.invoke(Method.java:566)

	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)

	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55)

	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45)

	at jdk.internal.reflect.GeneratedMethodAccessor133.invoke(Unknown Source)

	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.base/java.lang.reflect.Method.invoke(Method.java:566)

	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)

	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55)

	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45)

	at jdk.internal.reflect.GeneratedMethodAccessor133.invoke(Unknown Source)

	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.base/java.lang.reflect.Method.invoke(Method.java:566)

	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)

	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)

	at com.cloudbees.groovy.cps.Next.step(Next.java:83)

	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:152)

	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:146)

	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:136)

	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:275)

	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:146)

	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)

	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:51)

	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:187)

	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:423)

	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:331)

	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:295)

	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:97)

	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)

	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)

	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)

	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)

	at jenkins.util.ErrorLoggingExecutorService.lambda$wrap$0(ErrorLoggingExecutorService.java:51)

	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)

	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)

	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)

	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)

	at java.base/java.lang.Thread.run(Thread.java:829)

Finished: FAILURE
```

This change makes the parameter to be supported.