### PR TITLE
Change quoting in HCL to quoted keys in terraform.tfvars before deploying

### DIFF
--- a/jenkins_pipelines/scripts/tf_vars_generator/prepare_tfvars.py
+++ b/jenkins_pipelines/scripts/tf_vars_generator/prepare_tfvars.py
@@ -14,27 +14,46 @@ class TfvarsGenerator:
         self.data = {}
 
     # --- HCL FORMATTING ---
+    def hcl_key(self, key, top_level=False):
+        """Format an HCL object/map key safely."""
+        key = str(key)
+        if top_level:
+            return key
+        if re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', key):
+            return key
+        safe_key = key.replace('\\', '\\\\').replace('"', '\\"')
+        return f'"{safe_key}"'
+
     def to_hcl(self, obj, indent_level=0):
         indent = "  " * indent_level
+
         if isinstance(obj, dict):
             lines = []
             for key, value in obj.items():
+                formatted_key = self.hcl_key(key, top_level=(indent_level == 0))
                 formatted_value = self.to_hcl(value, indent_level + 1)
+
                 if isinstance(value, dict):
-                    lines.append(f"{indent}{key} = {{\n{formatted_value}\n{indent}}}")
+                    lines.append(f"{indent}{formatted_key} = {{\n{formatted_value}\n{indent}}}")
                 else:
-                    lines.append(f"{indent}{key} = {formatted_value}")
+                    lines.append(f"{indent}{formatted_key} = {formatted_value}")
+
             return "\n".join(lines)
+
         elif isinstance(obj, list):
             items = [self.to_hcl(item, 0) for item in obj]
             return f"[{', '.join(items)}]"
+
         elif isinstance(obj, str):
-            safe_str = obj.replace('"', '\\"')
+            safe_str = obj.replace('\\', '\\\\').replace('"', '\\"')
             return f'"{safe_str}"'
+
         elif isinstance(obj, bool):
             return str(obj).lower()
+
         elif obj is None:
             return "null"
+
         else:
             return str(obj)
 


### PR DESCRIPTION
Solves:

```
[2026-05-21T12:28:24.369Z] + set -e -o pipefail

[2026-05-21T12:28:24.369Z] + set +x

[2026-05-21T12:28:24.369Z] + export TERRAFORM=/usr/bin/tofu

[2026-05-21T12:28:24.369Z] + TERRAFORM=/usr/bin/tofu

[2026-05-21T12:28:24.369Z] + export TERRAFORM_PLUGINS=/usr/bin

[2026-05-21T12:28:24.369Z] + TERRAFORM_PLUGINS=/usr/bin

[2026-05-21T12:28:24.369Z] + ./terracumber-cli --outputdir /home/jenkins/workspace/manager-5.0-sles-qe-build-validation/results --tf susemanager-ci/terracumber_config/tf_files/templates/build-validation-single-provider.tf --gitfolder /home/jenkins/workspace/manager-5.0-sles-qe-build-validation/results/sumaform --tf_variables_description_file=susemanager-ci/terracumber_config/tf_files/variables/build-validation-variables.tf --terraform-bin /usr/bin/tofu --logfile /home/jenkins/workspace/manager-5.0-sles-qe-build-validation/results/60/sumaform.log --init --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning|server_extra_nfs_mounts).*' --custom-repositories /home/jenkins/workspace/manager-5.0-sles-qe-build-validation/custom_repositories.json --sumaform-backend libvirt --skip-variables-check --tf_configuration_files /home/jenkins/workspace/manager-5.0-sles-qe-build-validation/results/sumaform/terraform.tfvars --runstep provision

[2026-05-21T12:28:24.369Z] 2026-05-21 14:28:24,364 - __main__ - INFO - Running terraform...

[2026-05-21T12:28:24.369Z] 2026-05-21 14:28:24,364 - INFO - Running terraform...

[2026-05-21T12:28:24.624Z] OpenTofu encountered problems during initialization, including problems

[2026-05-21T12:28:24.624Z] with the configuration, described below.

[2026-05-21T12:28:24.624Z] 

[2026-05-21T12:28:24.624Z] The OpenTofu configuration must be valid before initialization so that

[2026-05-21T12:28:24.624Z] OpenTofu can determine which modules and providers need to be installed.

[2026-05-21T12:28:24.624Z] ╷

[2026-05-21T12:28:24.624Z] │ Error: Missing key/value separator

[2026-05-21T12:28:24.624Z] │ 

[2026-05-21T12:28:24.624Z] │   on terraform.tfvars line 71:

[2026-05-21T12:28:24.624Z] │   66: PROXY_ADDITIONAL_REPOS = {

[2026-05-21T12:28:24.624Z] │   67:   43842 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43842/SUSE_Updates_SLE-Product-SLES_15-SP6-LTSS_x86_64/"

[2026-05-21T12:28:24.624Z] │   68:   43844 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43844/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"

[2026-05-21T12:28:24.624Z] │   69:   43911 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43911/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"

[2026-05-21T12:28:24.624Z] │   70:   43925 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43925/SUSE_Updates_SLE-Manager-Tools_15_x86_64/"

[2026-05-21T12:28:24.624Z] │   71:   43925_1 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43925/SUSE_Updates_SLE-Product-SLES_15-SP6-LTSS_x86_64/"

[2026-05-21T12:28:24.624Z] │ 

[2026-05-21T12:28:24.624Z] │ Expected an equals sign ("=") to mark the beginning of the attribute value.

[2026-05-21T12:28:24.624Z] │ If you intended to given an attribute name containing periods or spaces,

[2026-05-21T12:28:24.624Z] │ write the name in quotes to create a string literal.

[2026-05-21T12:28:24.624Z] ╵

[2026-05-21T12:28:24.624Z] 

[2026-05-21T12:28:24.624Z] ╷

[2026-05-21T12:28:24.624Z] │ Error: Missing key/value separator

[2026-05-21T12:28:24.624Z] │ 

[2026-05-21T12:28:24.624Z] │   on terraform.tfvars line 71:

[2026-05-21T12:28:24.624Z] │   66: PROXY_ADDITIONAL_REPOS = {

[2026-05-21T12:28:24.624Z] │   67:   43842 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43842/SUSE_Updates_SLE-Product-SLES_15-SP6-LTSS_x86_64/"

[2026-05-21T12:28:24.624Z] │   68:   43844 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43844/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"

[2026-05-21T12:28:24.624Z] │   69:   43911 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43911/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"

[2026-05-21T12:28:24.624Z] │   70:   43925 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43925/SUSE_Updates_SLE-Manager-Tools_15_x86_64/"

[2026-05-21T12:28:24.624Z] │   71:   43925_1 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43925/SUSE_Updates_SLE-Product-SLES_15-SP6-LTSS_x86_64/"

[2026-05-21T12:28:24.624Z] │ 

[2026-05-21T12:28:24.624Z] │ Expected an equals sign ("=") to mark the beginning of the attribute value.

[2026-05-21T12:28:24.624Z] │ If you intended to given an attribute name containing periods or spaces,

[2026-05-21T12:28:24.624Z] │ write the name in quotes to create a string literal.

[2026-05-21T12:28:24.624Z] ╵

[2026-05-21T12:28:24.624Z] ╷

[2026-05-21T12:28:24.624Z] │ Error: Missing key/value separator

[2026-05-21T12:28:24.624Z] │ 

[2026-05-21T12:28:24.624Z] │   on terraform.tfvars line 71:

[2026-05-21T12:28:24.624Z] │   66: PROXY_ADDITIONAL_REPOS = {

[2026-05-21T12:28:24.624Z] │   67:   43842 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43842/SUSE_Updates_SLE-Product-SLES_15-SP6-LTSS_x86_64/"

[2026-05-21T12:28:24.624Z] │   68:   43844 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43844/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"

[2026-05-21T12:28:24.624Z] │   69:   43911 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43911/SUSE_Updates_SUSE-Manager-Proxy_5.0_x86_64/"

[2026-05-21T12:28:24.624Z] │   70:   43925 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43925/SUSE_Updates_SLE-Manager-Tools_15_x86_64/"

[2026-05-21T12:28:24.624Z] │   71:   43925_1 = "http://download.suse.de/ibs/SUSE:/Maintenance:/43925/SUSE_Updates_SLE-Product-SLES_15-SP6-LTSS_x86_64/"

[2026-05-21T12:28:24.624Z] │ 

[2026-05-21T12:28:24.624Z] │ Expected an equals sign ("=") to mark the beginning of the attribute value.

[2026-05-21T12:28:24.624Z] │ If you intended to given an attribute name containing periods or spaces,

[2026-05-21T12:28:24.624Z] │ write the name in quotes to create a string literal.

[2026-05-21T12:28:24.624Z] ╵


```