### PR TITLE
Fix multiple uyuni version

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -31,7 +31,10 @@ def run(params) {
                 'uyuni': 'uyuni_podman_ci'
         ]
         def ci_label = ci_label_map.find { k, v -> env.JOB_BASE_NAME.contains(k) }?.value ?: ''
-        def rrtg_version = env.JOB_BASE_NAME.find(/4\.3|5\.0|5\.1|Head|uyuni/)?.toLowerCase()
+        def rrtg_version = env.JOB_BASE_NAME.find(/4\.3|5\.0|5\.1|Head/)?.toLowerCase()
+        if (!rrtg_version && env.JOB_BASE_NAME == 'uyuni-master-dev-acceptance-tests-podman') {
+            rrtg_version = 'uyuni'
+        }
         if (params.show_product_changes) {
             // Retrieve the hash commit of the last product built in OBS/IBS and previous job
             def prefix = env.JOB_BASE_NAME.split('-acceptance-tests')[0]


### PR DESCRIPTION
Currently we have3 uyuni pipeline: uyuni-main-dev-acceptance-tests-podman, uyuni-master-dev-acceptance-tests-AWS and uyuni-master-dev-acceptance-tests-podman. We only want to track uyuni-master-dev-acceptance-tests-podman.. They are creating a mess in the db. Only track master.