### PR TITLE
Testsuite change server

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-NUE.tf
@@ -102,7 +102,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-01.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-04.mgr.suse.de/system"
 }
 
 module "cucumber_testsuite" {

--- a/terracumber_config/tf_files/MLM-Head-podman-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-podman-NUE.tf
@@ -97,7 +97,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-01.mgr.suse.de/system"
+  uri = "qemu+tcp://suma-03.mgr.suse.de/system"
 }
 
 module "cucumber_testsuite" {

--- a/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
@@ -90,7 +90,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://suma-01.mgr.suse.de/system"
+  uri = "qemu+tcp://cthulhu.mgr.suse.de/system"
 }
 
 module "cucumber_testsuite" {


### PR DESCRIPTION
Due to broken suma-01 moving important testsuites to other hosts

- Uyuni-Main to cthulhu
- MLM Head to suma-03
- MLM 5.1 to suma-04