### PR TITLE
Wire jenkins user for feilong

### DIFF
--- a/.github/workflows/sumaform-validation.yml
+++ b/.github/workflows/sumaform-validation.yml
@@ -113,6 +113,7 @@ jobs:
           variable "SCC_PTF_USER" { default="" }
           variable "SCC_PTF_PASSWORD" { default="" }
           variable "ZVM_ADMIN_TOKEN" { default="" }
+          variable "S390_LOCAL_USER" { default="" }
           variable "GIT_USER" { default="" }
           variable "GIT_PASSWORD" { default="" }
           variable "SERVER_CONTAINER_REPOSITORY" { default="" }
@@ -169,6 +170,7 @@ jobs:
           variable "SCC_PTF_USER" { default="" }
           variable "SCC_PTF_PASSWORD" { default="" }
           variable "ZVM_ADMIN_TOKEN" { default="" }
+          variable "S390_LOCAL_USER" { default="" }
           variable "GIT_USER" { default="" }
           variable "GIT_PASSWORD" { default="" }
           variable "SERVER_CONTAINER_REPOSITORY" { default="" }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -128,6 +128,7 @@ def run(params) {
                         commonArgs += " --inject SERVER_CONTAINER_IMAGE=${server_container_image}"
                         commonArgs += " --inject CUCUMBER_GITREPO=${params.cucumber_gitrepo}"
                         commonArgs += " --inject CUCUMBER_BRANCH=${params.cucumber_ref}"
+                        commonArgs += " --inject S390_LOCAL_USER=\"jenkins@${env.JENKINS_URL}\""
                         if (isNewJenkins) {
                             commonArgs += " --inject PRIVATE_SSH_KEY_PATH=\"/home/jenkins/.ssh/id_ed25519.oldworker\""
                             commonArgs += " --inject PUBLIC_SSH_KEY_PATH=\"/home/jenkins/.ssh/id_ed25519.pub.controller\""

--- a/terracumber_config/tf_files/templates/build-validation-multi-providers.tf
+++ b/terracumber_config/tf_files/templates/build-validation-multi-providers.tf
@@ -221,6 +221,7 @@ module "build_validation_module" {
   scc_ptf_user     = var.SCC_PTF_USER
   scc_ptf_password = var.SCC_PTF_PASSWORD
   zvm_admin_token  = var.ZVM_ADMIN_TOKEN
+  s390_local_user  = var.S390_LOCAL_USER
 
   git_user          = var.GIT_USER
   git_password      = var.GIT_PASSWORD

--- a/terracumber_config/tf_files/templates/build-validation-single-provider.tf
+++ b/terracumber_config/tf_files/templates/build-validation-single-provider.tf
@@ -76,6 +76,7 @@ module "build_validation_module" {
   scc_ptf_user     = var.SCC_PTF_USER
   scc_ptf_password = var.SCC_PTF_PASSWORD
   zvm_admin_token  = var.ZVM_ADMIN_TOKEN
+  s390_local_user  = var.S390_LOCAL_USER
 
   git_user          = var.GIT_USER
   git_password      = var.GIT_PASSWORD

--- a/terracumber_config/tf_files/variables/build-validation-variables.tf
+++ b/terracumber_config/tf_files/variables/build-validation-variables.tf
@@ -170,3 +170,9 @@ variable "PUBLIC_SSH_KEY_PATH" {
   default     = "./salt/controller/id_ed25519.pub"
   description = "Path to public ssh key used for access"
 }
+
+variable "S390_LOCAL_USER" {
+  type        = string
+  default     = "jenkins@jenkins-worker.mgr.suse.de"
+  description = "Jenkins worker from where the deployment is executed."
+}


### PR DESCRIPTION
## What does this PR change ?

For feilong to be able to deploy and configure a minion, it needs to access the Jenkins Worker.

Add support to configure this variable so we can specify any jenkins worker. By default jenkins-worker.mgr.suse.de