### PR TITLE
Add debian 12 to BV list of minions

### DIFF
--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
@@ -15,7 +15,8 @@ node('sumaform-cucumber') {
             'oracle9_minion, oracle9_sshminion, oracle10_minion, oracle10_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, rocky10_minion, rocky10_sshminion, ' +
             'ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ubuntu2604_minion, ubuntu2604_sshminion, ' +
-            'debian13_minion, debian13_sshminion, raspios13_minion, raspios13_sshminion, ' +
+            'debian12_minion, debian12_sshminion, debian13_minion, debian13_sshminion, ' +
+            // 'raspios13_minion, raspios13_sshminion, ' +
             'opensuse160arm_minion, opensuse160arm_sshminion, ' +
             'sles15sp5s390_minion, sles15sp5s390_sshminion, ' +
             'slemicro53_minion, slemicro54_minion, slemicro55_minion, ' +

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-head-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-head-qe-build-validation
@@ -15,8 +15,9 @@ node('sumaform-cucumber') {
             // 'liberty10_minion, liberty10_sshminion, ' +
             'oracle9_minion, oracle9_sshminion, oracle10_minion, oracle10_sshminion, ' +
             'rocky8_minion, rocky8_sshminion, rocky9_minion, rocky9_sshminion, rocky10_minion, rocky10_sshminion, ' +
-            'ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ubuntu2604_minion, ubuntu2604_sshminion, ' +
-            'debian13_minion, debian13_sshminion, ' +
+            'ubuntu2204_minion, ubuntu2204_sshminion, ubuntu2404_minion, ubuntu2404_sshminion, ' +
+            // 'ubuntu2604_minion, ubuntu2604_sshminion, ' +
+            'debian12_minion, debian12_sshminion, debian13_minion, debian13_sshminion, ' +
             // 'raspios13_minion, raspios13_sshminion, ' +
             'opensuse160arm_minion, opensuse160arm_sshminion, ' +
             'sles15sp5s390_minion, sles15sp5s390_sshminion, ' +


### PR DESCRIPTION
Add debian 12 to BV list of minions.

Also commented out ubuntu 26, it's not there yet available to be deployed. 