### PR TITLE
ci jenkins host is different than worker, update variable

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -13,7 +13,6 @@ def run(params) {
 
         deployed = false
         def isNewJenkins = env.JENKINS_URL?.contains('jenkins.mgr.suse.de')
-        def jenkinsHost = env.JENKINS_URL.replaceAll('https?://', '').replaceAll('/$', '')
         def credInit = isNewJenkins
             ? 'set +x; credFile=$(mktemp); echo "$SECRET_CONTENT" > "${credFile}"; chmod 600 "${credFile}"; . "${credFile}"; rm -f "${credFile}"; set -x'
             : 'set +x; . /home/jenkins/.credentials; set -x'
@@ -129,10 +128,10 @@ def run(params) {
                         commonArgs += " --inject SERVER_CONTAINER_IMAGE=${server_container_image}"
                         commonArgs += " --inject CUCUMBER_GITREPO=${params.cucumber_gitrepo}"
                         commonArgs += " --inject CUCUMBER_BRANCH=${params.cucumber_ref}"
-                        commonArgs += " --inject S390_LOCAL_USER=\"jenkins@${jenkinsHost}\""
                         if (isNewJenkins) {
                             commonArgs += " --inject HYPERVISOR_PRIVATE_SSH_KEY_PATH=\"/home/jenkins/.ssh/id_ed25519.worker\""
                             commonArgs += " --inject PUBLIC_SSH_KEY_PATH=\"/home/jenkins/.ssh/id_ed25519.pub.controller\""
+                            commonArgs += " --inject S390_LOCAL_USER=\"jenkins@jenkins.mgr.suse.de\""
                         }
                         if (product_version) { commonArgs += " --inject PRODUCT_VERSION=${product_version}" }
                         if (base_os) { commonArgs += " --inject BASE_OS=${base_os}" }


### PR DESCRIPTION
## What does this PR ?

Because we now have two Jenkins worker, we need to parse the jenkins host for feilong deployment.
The initial implementation rely on Jenkins Controller hostname that is not correct for ci.
So default value will be jenkins-worker.mgr.suse.de and set value when new Jenkins will be jenkins.mgr.suse.de
