### PR TITLE
change cucumber_report.html to index.html for mail template

### DIFF
--- a/terracumber_config/mail_templates/mail-template-jenkins-backup.txt
+++ b/terracumber_config/mail_templates/mail-template-jenkins-backup.txt
@@ -4,7 +4,7 @@
 Build:   $urlprefix/$timestamp
 Console: $urlprefix/$timestamp/console
 Results: $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp
-Report:  $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp/cucumber_report/cucumber_report.html
+Report:  $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp/cucumber_report/index.html
 Logs:    $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp/spacewalk-debug.tar.bz2
 
 Please notice this is a staging area for test suite and CI refactorings,

--- a/terracumber_config/mail_templates/mail-template-jenkins-pull-request.txt
+++ b/terracumber_config/mail_templates/mail-template-jenkins-pull-request.txt
@@ -6,7 +6,7 @@ Results for $timestamp build.
 Build:   $urlprefix/$timestamp
 Console: $urlprefix/$timestamp/console
 Results: $urlprefix/$timestamp/artifact/results/$timestamp
-Report:  $urlprefix/$timestamp/artifact/results/$timestamp/cucumber_report/cucumber_report.html
+Report:  $urlprefix/$timestamp/artifact/results/$timestamp/cucumber_report/index.html
 Logs:    $urlprefix/$timestamp/artifact/results/$timestamp/spacewalk-debug.tar.bz2
 
 #################################################################

--- a/terracumber_config/mail_templates/mail-template-jenkins.txt
+++ b/terracumber_config/mail_templates/mail-template-jenkins.txt
@@ -4,7 +4,7 @@
 Build:   $urlprefix/$timestamp
 Console: $urlprefix/$timestamp/console
 Results: $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp
-Report:  $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp/cucumber_report/cucumber_report.html
+Report:  $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp/cucumber_report/index.html
 Logs:    $urlprefix/$timestamp/execution/node/3/ws/results/$timestamp/spacewalk-debug.tar.bz2
 Pipeline: https://ci.suse.de/blue/organizations/jenkins/uyuni-prs-ci-tests/detail/uyuni-prs-ci-tests/$timestamp/pipeline
 

--- a/terracumber_config/mail_templates/mail-template-local.txt
+++ b/terracumber_config/mail_templates/mail-template-local.txt
@@ -2,7 +2,7 @@
 # SUMMARY
 #################################################################
 Results: $urlprefix-$timestamp
-Report:  $urlprefix-$timestamp/cucumber_report/cucumber_report.html
+Report:  $urlprefix-$timestamp/cucumber_report/index.html
 Logs:    $urlprefix-$timestamp/spacewalk-debug.tar.bz2
  
 #################################################################


### PR DESCRIPTION
Something has changed and the old URL return 404 Not Found.

The new combined cucumber report can now be found when calling index.html