### PR TITLE
Fix BV cleanup pipeline channel and image profile deletion

### DIFF
--- a/jenkins_pipelines/scripts/test_environment_cleaner/test_environment_cleaner_program/test_environment_cleaner_api.py
+++ b/jenkins_pipelines/scripts/test_environment_cleaner/test_environment_cleaner_program/test_environment_cleaner_api.py
@@ -44,36 +44,41 @@ class ResourceManager:
             self.client.contentmanagement.removeProject(self.session_key, project['label'])
 
     def delete_software_channels(self):
+        """Delete only custom child channels (keeps all parent channels and vendor child channels)."""
+        # Specific child channels to delete by exact label match (use set for O(1) lookup)
+        specific_channels_to_delete = {
+            "ubuntu-2404-noble-amd64"
+        }
+
+        # No need to differentiate between versions (SUMA 4.3, 5.0, 5.1, 5.2 vs Uyuni)
+        # Uyuni BV is now gone, and the behavior should be the same across all versions and products
         channels = self.client.channel.listMyChannels(self.session_key)
-        product_version = self.get_product_version()
-
-
-        if all(version not in product_version for version in ["5.0", "4.3", "5.1"]):
-            for channel in channels:
-                if "custom" in channel['label'] and not any(protected in channel['label'] for protected in self.resources_to_keep):
-                    logger.info(f"Delete custom channel: {channel['label']}")
-                    self.client.channel.software.delete(self.session_key, channel['label'])
-            logging.warning("Delete only custom channels for uyuni")
-            return
 
         for channel in channels:
-            details = self.client.channel.software.getDetails(self.session_key, channel['label'])
-            if "appstream" in channel['label'] and details['parent_channel_label']:
-                if not any(protected in channel['label'] for protected in self.resources_to_keep):
-                    logger.info(f"Delete sub channel appstream: {channel['label']}")
-                    self.client.channel.software.delete(self.session_key, channel['label'])
+            channel_label = channel['label']
 
-        channels = self.client.channel.listMyChannels(self.session_key)
-        for channel in channels:
-            if "appstream" in channel['label'] and not any(protected in channel['label'] for protected in self.resources_to_keep):
-                logger.info(f"Delete parent channel appstream: {channel['label']}")
-                self.client.channel.software.delete(self.session_key, channel['label'])
+            # Skip protected channels early to avoid unnecessary API calls
+            if any(protected in channel_label for protected in self.resources_to_keep):
+                continue
 
-        channels = self.client.channel.listMyChannels(self.session_key)
-        for channel in channels:
-            if not any(protected in channel['label'] for protected in self.resources_to_keep):
-                logger.info(f"Delete common channel: {channel['label']}")
-                self.client.channel.software.delete(self.session_key, channel['label'])
+            # Pre-filter: only check details for potential deletion candidates
+            # (channels with "custom" in label or in specific list)
+            is_candidate = (
+                "custom" in channel_label.lower() or
+                channel_label in specific_channels_to_delete
+            )
+
+            if not is_candidate:
+                continue
+
+            # Get channel details to check if it's a child channel
+            # (only called for deletion candidates, avoiding N+1 query waste)
+            details = self.client.channel.software.getDetails(self.session_key, channel_label)
+
+            # Only delete child channels (those with a parent)
+            if details.get('parent_channel_label'):
+                logger.info(f"Delete child channel: {channel_label} (parent: {details['parent_channel_label']})")
+                self.client.channel.software.delete(self.session_key, channel_label)
 
     def delete_systems(self):
         systems = self.client.system.listSystems(self.session_key)
@@ -120,8 +125,23 @@ class ResourceManager:
         self.client.saltkey.delete(self.session_key, system_name)
 
     def delete_image_profiles(self):
-        self.client.image.profile.delete(self.session_key, "suse_os_image_15_sp6")
-        self.client.image.profile.delete(self.session_key, "suse_os_image_15_sp7")
+        try:
+            profiles = self.client.image.profile.listImageProfiles(self.session_key)
+        except xmlrpc.client.Fault as e:
+            logger.warning(f"Failed to list image profiles (fault {e.faultCode}): {e.faultString}")
+            return
+        except Exception:
+            logger.exception("Unexpected error listing image profiles")
+            raise
+
+        for profile in profiles:
+            try:
+                logger.info(f"Delete image profile: {profile['label']}")
+                self.client.image.profile.delete(self.session_key, profile['label'])
+            except xmlrpc.client.Fault as e:
+                logger.warning(f"Failed to delete profile {profile['label']} (fault {e.faultCode}): {e.faultString}")
+                # Continue with other profiles
+                continue
 
     def get_product_version(self):
         product_version = self.client.api.systemVersion()


### PR DESCRIPTION
## Fix BV cleanup pipeline channel and image profile deletion

### Problem

The BV cleanup pipeline had two issues:

1. **Image profile deletion failing** - The `delete_image_profiles` method tried to delete hardcoded profile names (`suse_os_image_15_sp6`, `suse_os_image_15_sp7`) that don't exist on servers where the retail stage had not been run, causing:
```
xmlrpc.client.Fault: <Fault 10011: 'redstone.xmlrpc.XmlRpcFault: Image Profile not found'>
```


3. **Custom child channels not being deleted** - The `delete_software_channels` method was not deleting certain custom child channels like:
- "Custom Channel for CentOS 7 DVD"
- "Custom Channel for Rocky 8 DVD" 
- "Ubuntu 24.04 Noble AMD64" (label: `ubuntu-2404-noble-amd64`)

### Solution

#### 1. Image Profile Deletion ([test_environment_cleaner_api.py:122-128](jenkins_pipelines/scripts/test_environment_cleaner/test_environment_cleaner_program/test_environment_cleaner_api.py#L122-L128))
- Changed to list all existing image profiles first
- Only delete profiles that actually exist
- Added error handling to prevent pipeline failure when retail profiles don't exist

#### 2. Channel Deletion ([test_environment_cleaner_api.py:46-73](jenkins_pipelines/scripts/test_environment_cleaner/test_environment_cleaner_program/test_environment_cleaner_api.py#L46-L73))
- **Simplified logic**: Now only deletes custom child channels
- **Keeps**: All parent channels, vendor distribution child channels (SUSE Client Tools, AppStream, etc.)
- **Deletes**:
- Child channels with "custom" in the label (e.g., `custom-centos-7-dvd`, `custom-rocky-8-dvd`)
- Specific non-custom child channels by exact match (currently `ubuntu-2404-noble-amd64`)
- **Protects**: Infrastructure channels containing `proxy`, `monitoring`, `build`, or `terminal`
- **Removed version differentiation**: Uyuni BV is gone; behavior is now consistent across all SUMA versions