### PR TITLE
Fix sle160_minion node key and add opensuse160arm_minion JSON generator tests

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -46,7 +46,7 @@ def parse_cli_args() -> argparse.Namespace:
         dest="slfo_pull_request",
         metavar="ID",
         type=_slfo_pr_id,
-        help="SLFO PullRequest id for sles160_minion and slmicro62_minion (stable 51-* / 52-* only; beta uses :ToTest automatically)",
+        help="SLFO PullRequest id for sle160_minion, slmicro62_minion (x86_64), and opensuse160arm_minion (aarch64) on stable 51-* / 52-* only; rejected for *-beta versions (beta uses :ToTest automatically)",
     )
     args = parser.parse_args()
     if args.slfo_pull_request is not None:
@@ -122,10 +122,10 @@ def supports_slfo_pull_request(version: str) -> bool:
 def slfo_pullrequest_client_tool_url(pr_id: str, arch: str = "x86_64") -> str:
     """Return the stable SLE-16 MultiLinuxManagerTools URL for the given PullRequest id and architecture.
 
-    This URL is used for sles160_minion, slmicro62_minion (x86_64), and opensuse160arm_minion (aarch64).
+    This URL is used for sle160_minion, slmicro62_minion (x86_64), and opensuse160arm_minion (aarch64).
     SL Micro 6.2 consumes the same SLE-16 client-tools repo on the stable PullRequest path.
-    Beta client tools do not use PullRequest URLs - they are served from a static
-    :ToTest project baked into repository_versions/v52_nodes.py.
+    Beta client tools do not use PullRequest URLs - they are served from static
+    :ToTest definitions in repository_versions/*_nodes.py.
     """
     root = "/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest"
     tail = f":/{pr_id}:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-{arch}/"
@@ -144,7 +144,7 @@ def apply_slfo_pullrequest_client_tools(
 
     # x86_64 minions
     url_x86_64 = slfo_pullrequest_client_tool_url(pr_id, arch="x86_64")
-    update_custom_repositories(custom_repositories, "sles160_minion", repo_key, url_x86_64)
+    update_custom_repositories(custom_repositories, "sle160_minion", repo_key, url_x86_64)
     update_custom_repositories(custom_repositories, "slmicro62_minion", repo_key, url_x86_64)
 
     # aarch64 minion
@@ -172,8 +172,9 @@ def find_valid_repos(mi_ids: set[str], version: str, slfo_pull_request_id: str |
     Args:
         mi_ids: Set of MI ID strings
         version: SUMA version (43, 50-sles, 51-sles, etc.)
-        slfo_pull_request_id: Optional SLFO PullRequest id for sles160_minion and
-            slmicro62_minion; only valid for stable 51-* / 52-* versions.
+        slfo_pull_request_id: Optional SLFO PullRequest id for sle160_minion,
+            slmicro62_minion (x86_64), and opensuse160arm_minion (aarch64); only
+            valid for stable 51-* / 52-* versions.
         max_workers: Number of concurrent HTTP requests (default: 20)
     """
     version_data = get_version_nodes(version)

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator_README.md
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator_README.md
@@ -20,17 +20,17 @@ This Python script automates the process of gathering and processing open QAM
 (Quality Assurance Maintenance) requests for SUSE Linux Enterprise Server (SLES)
 that affect SUSE Manager. The output is a JSON file, which can be fed into the
 BV (Build Validation) testsuite pipeline for further testing. It supports SUSE
-Manager / MLM 4.3, 5.0, 5.1 and 5.2 (including 5.2 beta).
+Manager / MLM 4.3, 5.0, 5.1, 5.2 (stable), and 5.3 beta placeholders.
 
 The script allows users to input Maintenance Incident (MI) IDs and generates the
 appropriate repository information for the selected version's nodes (servers,
 proxies, and clients). The supported `--version` values are: `43`, `50-micro`,
-`50-sles`, `51-micro`, `51-sles`, `52-micro`, `52-sles`, `52-micro-beta`,
-`52-sles-beta`.
+`50-sles`, `51-micro`, `51-sles`, `52-micro`, `52-sles`, `53-micro-beta`,
+`53-sles-beta`.
 
 ## Features
 
-- Support for SUSE Manager / MLM 4.3, 5.0, 5.1 and 5.2 (including 5.2 beta): the
+- Support for SUSE Manager / MLM 4.3, 5.0, 5.1, 5.2 (stable), and 5.3 beta placeholders: the
 version is selected via `--version`.
 - Flexible MI ID Input: MI IDs can be provided via CLI arguments or by reading
 from a file.
@@ -38,10 +38,10 @@ from a file.
 information for the SUSE Manager BV testsuite pipeline.
 - Embargo Checks: The script has an option to reject Maintenance Incidents (MIs)
 that are under embargo.
-- SLFO client tools for `sles160_minion` / `slmicro62_minion`:
+- SLFO client tools for `sle160_minion` / `slmicro62_minion` (x86_64) and `opensuse160arm_minion` (aarch64):
   - Stable `51-*` / `52-sles` / `52-micro`: use `--slfo-pull-request <id>` to
     inject a `:PullRequest:/<id>` client-tools URL (independent of MI IDs).
-  - Beta `52-sles-beta` / `52-micro-beta`: a static `:ToTest` URL is baked in
+  - Beta `53-sles-beta` / `53-micro-beta`: a static `:ToTest` URL is baked in
     and applied automatically; `--slfo-pull-request` is rejected for beta
     versions because the Beta project cannot toggle maintenance on/off under
     the git workflow.
@@ -59,11 +59,11 @@ python3.11 maintenance_json_generator.py [options]
 Options:
 
 `-v`, `--version`: Specifies the SUSE Manager version. Options are `43` for SUSE
-Manager 4.3, `50-micro` / `50-sles` for 5.0, `51-micro` / `51-sles` for 5.1, and `52-micro` / `52-sles` for 5.2 (including `52-micro-beta` / `52-sles-beta`). Default is `51-sles`.
+Manager 4.3, `50-micro` / `50-sles` for 5.0, `51-micro` / `51-sles` for 5.1, `52-micro` / `52-sles` for 5.2 (stable), and `53-micro-beta` / `53-sles-beta` for 5.3 beta placeholders. Default is `51-sles`.
 `-i`, `--mi_ids`: A space-separated list of MI IDs.
 `-f`, `--file`: Path to a file containing MI IDs, each on a new line.
 `-e`, `--no_embargo`: Reject any MIs that are currently under embargo.
-`--slfo-pull-request`: SLFO PullRequest id for `sles160_minion` and `slmicro62_minion` on stable 5.1 / 5.2 only (independent of MI ids). Rejected for `-beta` versions, which receive a fixed `:ToTest` URL automatically. In `custom_repositories.json`, those entries use the inner key pattern `slfo_pr_<id>` (not the bare PR id) so they cannot collide with MI id keys.
+`--slfo-pull-request`: SLFO PullRequest id for `sle160_minion`, `slmicro62_minion` (x86_64), and `opensuse160arm_minion` (aarch64 SLE-16 client-tools) on stable 5.1 / 5.2 only (independent of MI ids). Rejected for `-beta` versions, which receive a fixed `:ToTest` URL automatically. In `custom_repositories.json`, those entries use the inner key pattern `slfo_pr_<id>` (not the bare PR id) so they cannot collide with MI id keys.
 
 Example:
 
@@ -87,23 +87,22 @@ For **`43`**, **`50-micro`**, and **`50-sles`**, the output always includes stat
 repository URLs for **`slmicro60_minion`** and **`slmicro61_minion`** (`slmicro60_salt`,
 `slmicro61_salt`, `slmicro6_salt_bundle`) in addition to MI-based maintenance URLs.
 
-For **`52-sles-beta`** and **`52-micro-beta`**, the output always includes fixed `:ToTest`
-client-tools URLs independently of MI IDs. **`slmicro60_minion`** and **`slmicro61_minion`**
-use the **SL-Micro-6** MultiLinuxManagerTools-Beta **`:ToTest`** path (inner key
-`slmicro6_client_tools`). **`slmicro62_minion`** and **`sles160_minion`** share the same
-**SLES-16** MultiLinuxManagerTools-Beta **`:ToTest`** path under the inner key
-**`sles16_client_tools`**. In addition, **`52-sles-beta`** always includes fixed `http://`
+For **`53-sles-beta`** and **`53-micro-beta`**, the output always includes fixed `:ToTest`
+client-tools URLs independently of MI IDs. **`slmicro62_minion`** and **`sle160_minion`**
+share the same **SLES-16** MultiLinuxManagerTools-Beta **`:ToTest`** path under the inner key
+**`sles16_client_tools`**. **`opensuse160arm_minion`** and other client minions receive
+MI-based maintenance URLs from the dynamic map (e.g. **`opensuse160arm_minion`** uses
+`MultiLinuxManagerTools-Beta_SLE-16_aarch64`). In addition, **`53-sles-beta`** always includes fixed `http://`
 `server` and `proxy` ToTest image repos; path fragments live in
-**`v52_uyuni_tools_sles_static_repos_beta`** and are prefixed with **`IBS_URL_PREFIX`** in
-**`get_v52_static_and_client_tools`** (they are not pre-built `http://` strings in the dict).
-URLs resolve under
-`SUSE:/SLE-15-SP7:/Update:/Products:/MultiLinuxManager52:/ToTest/images-SP7/repo/`
-(`SUSE-Multi-Linux-Manager-Server-SLE-5.2-POOL-x86_64-Media1/` and
-`SUSE-Multi-Linux-Manager-Proxy-SLE-5.2-POOL-x86_64-Media1/`). **`52-micro-beta`** pins
+**`v53_uyuni_tools_sles_static_repos_beta`** and are prefixed with **`IBS_URL_PREFIX`** in
+**`get_v53_static_and_client_tools`**. URLs resolve under
+`SUSE:/SLE-15-SP7:/Update:/Products:/MultiLinuxManager53:/ToTest/images-SP7/repo/`
+(`SUSE-Multi-Linux-Manager-Server-SLE-5.3-POOL-x86_64-Media1/` and
+`SUSE-Multi-Linux-Manager-Proxy-SLE-5.3-POOL-x86_64-Media1/`). **`53-micro-beta`** pins
 `server_uyuni_tools` and `proxy_uyuni_tools` to the `http://`
-`SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/` tree
-(`Multi-Linux-Manager-Server-5.2-x86_64/` and `Multi-Linux-Manager-Proxy-5.2-x86_64/`). On the stable `51-*` / `52-sles` / `52-micro` flows,
-equivalent URLs for `sles160_minion` / `slmicro62_minion` are only added when
+`SLFO:/Products:/Multi-Linux-Manager:/5.3:/ToTest/product/repo/` tree
+(`Multi-Linux-Manager-Server-5.3-x86_64/` and `Multi-Linux-Manager-Proxy-5.3-x86_64/`). On the stable `51-*` / `52-sles` / `52-micro` flows,
+equivalent URLs for `sle160_minion` / `slmicro62_minion` (x86_64) and `opensuse160arm_minion` (aarch64) are only added when
 `--slfo-pull-request <id>` is provided.
 
 ## Logging
@@ -134,18 +133,20 @@ Repository definitions live under
   `get_v50_nodes_sorted(v43_client_tools, variant)`.
 - `v51_nodes.py` / `v52_nodes.py`: the helpers
   `get_v51_static_and_client_tools(variant)` and
-  `get_v52_static_and_client_tools(variant, beta)`, which return a
-  `(static_repos, dynamic_repos)` pair per variant. For **`52-sles-beta`**, fixed
-  ToTest **server** / **proxy** image URLs are defined in
-  `v52_uyuni_tools_sles_static_repos_beta` (separate from MI-based
-  `v52_uyuni_tools_sles_repos_beta`). For **`52-micro-beta`** / **`52-sles-beta`**, dynamic
-  client minions include **`opensuse160arm_minion`** (`MultiLinuxManagerTools-Beta_SLE-16_aarch64`),
-  alongside **`opensuse156arm_minion`** (SLE-15 aarch64), in **`v52_nodes_dynamic_client_tools_repos_beta`**.
+  `get_v52_static_and_client_tools(variant)`, which return a
+  `(static_repos, dynamic_repos)` pair per variant for stable 5.1 / 5.2.
+- `v53_nodes.py`: the helper `get_v53_static_and_client_tools(variant, beta=True)`
+  for 5.3 beta placeholders. For **`53-sles-beta`**, fixed ToTest **server** / **proxy**
+  image URLs are defined in `v53_uyuni_tools_sles_static_repos_beta`. For
+  **`53-micro-beta`** / **`53-sles-beta`**, dynamic client minions include
+  **`opensuse160arm_minion`** (`MultiLinuxManagerTools-Beta_SLE-16_aarch64`),
+  alongside **`opensuse156arm_minion`** (SLE-15 aarch64), in
+  `v53_nodes_dynamic_client_tools_repos_beta`.
 
 `repository_versions/__init__.py` aggregates everything into the
 `nodes_by_version` mapping, whose keys are exactly the strings accepted by
 `--version` (`43`, `50-micro`, `50-sles`, `51-micro`, `51-sles`, `52-micro`,
-`52-sles`, `52-micro-beta`, `52-sles-beta`) and whose values are
+`52-sles`, `53-micro-beta`, `53-sles-beta`) and whose values are
 `{"static": ..., "dynamic": ...}` dicts consumed by the main script.
 
 ## Error Handling

--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v53_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v53_nodes.py
@@ -63,7 +63,7 @@ v53_nodes_static_client_tools_repositories_beta: Dict[str, Dict[str, str]] = {
     "slmicro62_minion": {
         "sles16_client_tools": "/SLFO:/Products:/MultiLinuxManagerTools-Beta:/SLES-16:/ToTest/product/repo/Multi-Linux-ManagerTools-Beta-SLE-16-x86_64/"
     },
-    "sles160_minion": {
+    "sle160_minion": {
         "sles16_client_tools": "/SLFO:/Products:/MultiLinuxManagerTools-Beta:/SLES-16:/ToTest/product/repo/Multi-Linux-ManagerTools-Beta-SLE-16-x86_64/"
     },
 }

--- a/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
@@ -235,15 +235,73 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
 
         self.assertDictEqual(
             {
-                'sles160_minion': {
+                'sle160_minion': {
                     'slfo_pr_12345': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/'
                 },
                 'slmicro62_minion': {
                     'slfo_pr_12345': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/'
                 },
+                'opensuse160arm_minion': {
+                    'slfo_pr_12345': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/'
+                },
             },
             custom_repos,
         )
+
+    def test_slfo_pullrequest_client_tool_url_embeds_architecture(self):
+        x86_url = slfo_pullrequest_client_tool_url('362', arch='x86_64')
+        aarch64_url = slfo_pullrequest_client_tool_url('362', arch='aarch64')
+
+        self.assertIn('Multi-Linux-ManagerTools-SLE-16-x86_64/', x86_url)
+        self.assertIn('Multi-Linux-ManagerTools-SLE-16-aarch64/', aarch64_url)
+        self.assertNotIn('aarch64', x86_url)
+        self.assertNotIn('x86_64', aarch64_url)
+
+    def test_v51_dynamic_includes_opensuse160arm_sle16_aarch64(self):
+        _static, dynamic = get_v51_static_and_client_tools('sles')
+
+        self.assertIn('opensuse160arm_minion', dynamic)
+        self.assertIn(
+            '/SUSE_Updates_MultiLinuxManagerTools_SLE-16_aarch64/',
+            dynamic['opensuse160arm_minion'],
+        )
+
+    def test_v52_dynamic_includes_opensuse160arm_sle16_aarch64(self):
+        _static, dynamic = get_v52_static_and_client_tools('sles')
+
+        self.assertIn('opensuse160arm_minion', dynamic)
+        self.assertIn(
+            '/SUSE_Updates_MultiLinuxManagerTools_SLE-16_aarch64/',
+            dynamic['opensuse160arm_minion'],
+        )
+
+    def test_opensuse160arm_not_in_v51_static_client_tools(self):
+        static, _dynamic = get_v51_static_and_client_tools('sles')
+        self.assertNotIn('opensuse160arm_minion', static)
+
+    def test_opensuse160arm_not_in_v52_static_client_tools(self):
+        static, _dynamic = get_v52_static_and_client_tools('sles')
+        self.assertNotIn('opensuse160arm_minion', static)
+
+    @patch('json_generator.maintenance_json_generator.validate_and_store_results')
+    def test_slfo_pullrequest_injects_opensuse160arm_in_find_valid_repos(self, _mock_validate):
+        captured: dict[str, dict[str, dict[str, str]]] = {}
+
+        def _capture(_ids, custom_repositories, *_args, **_kwargs):
+            captured['repos'] = custom_repositories
+
+        _mock_validate.side_effect = _capture
+
+        find_valid_repos(set(), '52-sles', slfo_pull_request_id='12345')
+
+        repos = captured['repos']
+        self.assertIn('opensuse160arm_minion', repos)
+        self.assertEqual(
+            repos['opensuse160arm_minion'].get('slfo_pr_12345'),
+            'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/',
+        )
+        self.assertIn('sle160_minion', repos)
+        self.assertIn('slmicro62_minion', repos)
 
     def test_slfo_pull_request_rejected_for_unsupported_versions(self):
         # --slfo-pull-request is only supported for 51-* and 52-* versions
@@ -266,7 +324,7 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
 
     @patch('json_generator.maintenance_json_generator.validate_and_store_results')
     def test_beta_version_injects_totest_static_urls(self, _mock_validate):
-        # Beta versions must auto-populate sles160_minion and slmicro62_minion
+        # Beta versions must auto-populate sle160_minion and slmicro62_minion
         # from the static :ToTest map (no --slfo-pull-request required).
         # Updated to test 5.3 beta (5.2 is now stable)
         captured: dict[str, dict[str, dict[str, str]]] = {}
@@ -279,13 +337,13 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         find_valid_repos(set(), '53-sles-beta')
 
         repos = captured['repos']
-        self.assertIn('sles160_minion', repos)
+        self.assertIn('sle160_minion', repos)
         self.assertIn('slmicro62_minion', repos)
         sles16_url = (
             'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools-Beta:/SLES-16:'
             '/ToTest/product/repo/Multi-Linux-ManagerTools-Beta-SLE-16-x86_64/'
         )
-        self.assertEqual(repos['sles160_minion'].get('sles16_client_tools'), sles16_url)
+        self.assertEqual(repos['sle160_minion'].get('sles16_client_tools'), sles16_url)
         self.assertEqual(repos['slmicro62_minion'].get('sles16_client_tools'), sles16_url)
         self.assertEqual(
             repos['server'].get('mlm53_sles_beta_totest_images_sp7'),

--- a/jenkins_pipelines/scripts/tests/test_v53_beta_client_tools.py
+++ b/jenkins_pipelines/scripts/tests/test_v53_beta_client_tools.py
@@ -9,26 +9,26 @@ from repository_versions.v53_nodes import (
 
 
 class V53BetaClientToolsTest(unittest.TestCase):
-    def test_slmicro62_minion_matches_sles160_path_and_key(self):
+    def test_slmicro62_minion_matches_sle160_path_and_key(self):
         beta = v53_nodes_static_client_tools_repositories_beta
         self.assertIn("sles16_client_tools", beta["slmicro62_minion"])
         self.assertNotIn("slmicro6_client_tools", beta["slmicro62_minion"])
         self.assertEqual(
             beta["slmicro62_minion"]["sles16_client_tools"],
-            beta["sles160_minion"]["sles16_client_tools"],
+            beta["sle160_minion"]["sles16_client_tools"],
         )
         path = beta["slmicro62_minion"]["sles16_client_tools"]
         self.assertIn("MultiLinuxManagerTools-Beta:/SLES-16:", path)
         self.assertNotIn("SL-Micro-6", path)
 
     def test_v53_beta_does_not_define_slmicro60(self):
-        # v53 beta intentionally only defines slmicro62_minion and sles160_minion
+        # v53 beta intentionally only defines slmicro62_minion and sle160_minion
         # slmicro60_minion is not part of the 5.3 beta client tools structure
         beta = v53_nodes_static_client_tools_repositories_beta
         self.assertNotIn("slmicro60_minion", beta)
         # Verify the expected minions ARE defined
         self.assertIn("slmicro62_minion", beta)
-        self.assertIn("sles160_minion", beta)
+        self.assertIn("sle160_minion", beta)
 
     def test_sles_beta_static_image_urls_are_prefixed_in_getter(self):
         static, _dynamic = get_v53_static_and_client_tools("sles", beta=True)
@@ -39,10 +39,17 @@ class V53BetaClientToolsTest(unittest.TestCase):
 
     def test_opensuse160arm_beta_dynamic_uses_sle16_aarch64(self):
         _static, dynamic = get_v53_static_and_client_tools("sles", beta=True)
+        self.assertIn("opensuse160arm_minion", dynamic)
         self.assertIn(
             "/SUSE_Updates_MultiLinuxManagerTools-Beta_SLE-16_aarch64/",
             dynamic["opensuse160arm_minion"],
         )
+
+    def test_opensuse160arm_not_in_v53_beta_static_client_tools(self):
+        beta = v53_nodes_static_client_tools_repositories_beta
+        self.assertNotIn("opensuse160arm_minion", beta)
+        self.assertIn("sle160_minion", beta)
+        self.assertIn("slmicro62_minion", beta)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Rename `sles160_minion` to `sle160_minion` in the maintenance JSON generator, v53 beta node definitions, and README so generated `custom_repositories.json` keys align with the build-validation node name.
- Extend SLFO PullRequest client-tools coverage to include `opensuse160arm_minion` with the aarch64 SLE-16 repo URL.
- Add regression tests for `opensuse160arm_minion` across stable 5.1/5.2 and 5.3 beta flows:
  - dynamic maintenance suffix for SLE-16 aarch64
  - exclusion from static client-tools maps
  - end-to-end injection via `find_valid_repos(..., slfo_pull_request_id=...)`

## Test plan

- [x] `cd jenkins_pipelines/scripts && python3 -m unittest tests.test_maintenance_json_generator tests.test_v53_beta_client_tools -v`
