### PR TITLE
QE: Switch to slmicro 6.2 and tumbleweed as base OS for RKE2 personal pipelines

### DIFF
--- a/terracumber_config/tf_files/personal/main_rke2_head.tf
+++ b/terracumber_config/tf_files/personal/main_rke2_head.tf
@@ -34,7 +34,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
+  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false
@@ -81,6 +81,7 @@ module "cucumber_testsuite" {
       }
     }
     server_kubernetes = {
+      image = "slmicro62o"
       provider_settings = {
         mac    = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["server"]
         vcpu   = 2

--- a/terracumber_config/tf_files/personal/main_rke2_uyuni.tf
+++ b/terracumber_config/tf_files/personal/main_rke2_uyuni.tf
@@ -80,6 +80,7 @@ module "cucumber_testsuite" {
       }
     }
     server_kubernetes = {
+      image = "tumbleweedo"
       provider_settings = {
         mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["server"]
       }


### PR DESCRIPTION
Switch to slmicro 6.2 and tumbleweed as base OS for RKE2 personal pipelines.