### PR TITLE
Fix SLFO PR repo key collision causing arch mismatch

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -132,24 +132,36 @@ def slfo_pullrequest_client_tool_url(pr_id: str, arch: str = "x86_64") -> str:
     return f"{IBS_URL_PREFIX}{root}{tail}"
 
 
-def slfo_pullrequest_repo_key(pr_id: str) -> str:
-    """Inner dict key for SLFO PullRequest client-tools repos (not an MI id)."""
-    return f"slfo_pr_{pr_id}"
+def slfo_pullrequest_repo_key(pr_id: str, minion: str, arch: str) -> str:
+    """Inner dict key for SLFO PullRequest client-tools repos (not an MI id).
+
+    Args:
+        pr_id: SLFO PullRequest id
+        minion: Minion shortname (e.g. 'sles160', not 'sles160_minion')
+        arch: Architecture (e.g. 'x86_64' or 'aarch64')
+
+    Returns:
+        Repository key in format: slfo_pr_{id}_{minion}_{arch}
+    """
+    return f"slfo_pr_{pr_id}_{minion}_{arch}"
 
 
 def apply_slfo_pullrequest_client_tools(
     custom_repositories: dict[str, dict[str, str]], pr_id: str
 ) -> None:
-    repo_key = slfo_pullrequest_repo_key(pr_id)
-
     # x86_64 minions
     url_x86_64 = slfo_pullrequest_client_tool_url(pr_id, arch="x86_64")
-    update_custom_repositories(custom_repositories, "sles160_minion", repo_key, url_x86_64)
-    update_custom_repositories(custom_repositories, "slmicro62_minion", repo_key, url_x86_64)
+    for node in ["sles160_minion", "slmicro62_minion"]:
+        minion_shortname = node.removesuffix("_minion")
+        update_custom_repositories(custom_repositories, node,
+                                  slfo_pullrequest_repo_key(pr_id, minion_shortname, "x86_64"), url_x86_64)
 
     # aarch64 minion
     url_aarch64 = slfo_pullrequest_client_tool_url(pr_id, arch="aarch64")
-    update_custom_repositories(custom_repositories, "opensuse160arm_minion", repo_key, url_aarch64)
+    node = "opensuse160arm_minion"
+    minion_shortname = node.removesuffix("_minion")
+    update_custom_repositories(custom_repositories, node,
+                              slfo_pullrequest_repo_key(pr_id, minion_shortname, "aarch64"), url_aarch64)
 
 
 def update_custom_repositories(custom_repositories: dict[str, dict[str, str]], node: str, mi_id: str, url: str):

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator_README.md
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator_README.md
@@ -63,7 +63,7 @@ Manager 4.3, `50-micro` / `50-sles` for 5.0, `51-micro` / `51-sles` for 5.1, `52
 `-i`, `--mi_ids`: A space-separated list of MI IDs.
 `-f`, `--file`: Path to a file containing MI IDs, each on a new line.
 `-e`, `--no_embargo`: Reject any MIs that are currently under embargo.
-`--slfo-pull-request`: SLFO PullRequest id for `sles160_minion`, `slmicro62_minion` (x86_64), and `opensuse160arm_minion` (aarch64 SLE-16 client-tools) on stable 5.1 / 5.2 only (independent of MI ids). Rejected for `-beta` versions, which receive a fixed `:ToTest` URL automatically. In `custom_repositories.json`, those entries use the inner key pattern `slfo_pr_<id>` (not the bare PR id) so they cannot collide with MI id keys.
+`--slfo-pull-request`: SLFO PullRequest id for `sles160_minion`, `slmicro62_minion` (x86_64), and `opensuse160arm_minion` (aarch64 SLE-16 client-tools) on stable 5.1 / 5.2 only (independent of MI ids). Rejected for `-beta` versions, which receive a fixed `:ToTest` URL automatically. In `custom_repositories.json`, those entries use the inner key pattern `slfo_pr_{id}_{minion}_{arch}` (includes minion name and architecture) to ensure each repository has a unique name, preventing race conditions where minions could pick up the wrong-architecture repository.
 
 Example:
 
@@ -104,6 +104,26 @@ MI-based maintenance URLs from the dynamic map (e.g. **`opensuse160arm_minion`**
 (`Multi-Linux-Manager-Server-5.3-x86_64/` and `Multi-Linux-Manager-Proxy-5.3-x86_64/`). On the stable `51-*` / `52-sles` / `52-micro` flows,
 equivalent URLs for `sles160_minion` / `slmicro62_minion` (x86_64) and `opensuse160arm_minion` (aarch64) are only added when
 `--slfo-pull-request <id>` is provided.
+
+**Example SLFO PullRequest Output:**
+
+When using `--slfo-pull-request 362`, the generated JSON includes unique repository keys:
+
+```json
+{
+  "sles160_minion": {
+    "slfo_pr_362_sles160_x86_64": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/"
+  },
+  "slmicro62_minion": {
+    "slfo_pr_362_slmicro62_x86_64": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/"
+  },
+  "opensuse160arm_minion": {
+    "slfo_pr_362_opensuse160arm_aarch64": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/"
+  }
+}
+```
+
+The key format `slfo_pr_{id}_{minion}_{arch}` ensures that each minion's repository has a globally unique name within the JSON, preventing repository collisions in downstream tooling.
 
 ## Logging
 

--- a/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
@@ -236,13 +236,13 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         self.assertDictEqual(
             {
                 'sles160_minion': {
-                    'slfo_pr_12345': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/'
+                    'slfo_pr_12345_sles160_x86_64': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/'
                 },
                 'slmicro62_minion': {
-                    'slfo_pr_12345': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/'
+                    'slfo_pr_12345_slmicro62_x86_64': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/'
                 },
                 'opensuse160arm_minion': {
-                    'slfo_pr_12345': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/'
+                    'slfo_pr_12345_opensuse160arm_aarch64': 'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/'
                 },
             },
             custom_repos,
@@ -297,7 +297,7 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         repos = captured['repos']
         self.assertIn('opensuse160arm_minion', repos)
         self.assertEqual(
-            repos['opensuse160arm_minion'].get('slfo_pr_12345'),
+            repos['opensuse160arm_minion'].get('slfo_pr_12345_opensuse160arm_aarch64'),
             'http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/12345:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/',
         )
         self.assertIn('sles160_minion', repos)


### PR DESCRIPTION
Make repo keys unique by including minion name and architecture: `slfo_pr_{id}_{minion}_{arch}`

Previously every SLFO PullRequest client-tools entry used the same inner key `slfo_pr_{id}` across `sles160_minion`, `slmicro62_minion` (x86_64) and `opensuse160arm_minion` (aarch64). This prevents race conditions where minions pick up wrong-arch repos.

Rebased on current `master`, so it now uses the `sles160_minion` node name introduced by #2125 (Standardize on `sles*` node prefix).

`custom_repositories.json` diff before/after the change:

```diff
   "opensuse160arm_minion": {
-    "slfo_pr_362": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/"
+    "slfo_pr_362_opensuse160arm_aarch64": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/"
   },
   "sles160_minion": {
-    "slfo_pr_362": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/"
+    "slfo_pr_362_sles160_x86_64": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/"
   },
   "slmicro62_minion": {
-    "slfo_pr_362": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/"
+    "slfo_pr_362_slmicro62_x86_64": "http://download.suse.de/ibs/SUSE:/SLFO:/Products:/MultiLinuxManagerTools:/PullRequest:/362:/SLES/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/"
   },
```

Tests: `pytest jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py jenkins_pipelines/scripts/tests/test_v53_beta_client_tools.py` — 31 passed.
