### PR TITLE
Move null_resource for configuring quality intelligence to a separate…

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-NUE.tf
@@ -243,27 +243,8 @@ module "cucumber_testsuite" {
     bridge = "br0"
     additional_network = "192.168.51.0/24"
   }
-}
 
-resource "null_resource" "configure_quality_intelligence" {
-
-  triggers = {
-    always_run = "${timestamp()}"
-  }
-
-  provisioner "remote-exec" {
-    inline = [ "echo export QUALITY_INTELLIGENCE=true >> ~/.bashrc",
-      "echo export PROMETHEUS_PUSH_GATEWAY_URL=${var.PROMETHEUS_PUSH_GATEWAY_URL} >> ~/.bashrc",
-      "source ~/.bashrc"
-    ]
-    connection {
-      type     = "ssh"
-      user     = "root"
-      password = "linux"
-      host     = "${module.cucumber_testsuite.configuration.controller.hostname}"
-    }
-  }
-
+  prometheus_push_gateway_url = var.PROMETHEUS_PUSH_GATEWAY_URL
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
@@ -249,27 +249,8 @@ module "cucumber_testsuite" {
     bridge = "br0"
     additional_network = "192.168.50.0/24"
   }
-}
 
-resource "null_resource" "configure_quality_intelligence" {
-
-  triggers = {
-    always_run = "${timestamp()}"
-  }
-
-  provisioner "remote-exec" {
-    inline = [ "echo export QUALITY_INTELLIGENCE=true >> ~/.bashrc",
-      "echo export PROMETHEUS_PUSH_GATEWAY_URL=${var.PROMETHEUS_PUSH_GATEWAY_URL} >> ~/.bashrc",
-      "source ~/.bashrc"
-    ]
-    connection {
-      type     = "ssh"
-      user     = "root"
-      password = "linux"
-      host     = "${module.cucumber_testsuite.configuration.controller.hostname}"
-    }
-  }
-
+  prometheus_push_gateway_url = var.PROMETHEUS_PUSH_GATEWAY_URL
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
@@ -213,28 +213,8 @@ module "cucumber_testsuite" {
     bridge             = "br0"
     additional_network = "192.168.118.0/24"
   }
-}
 
-
-resource "null_resource" "configure_quality_intelligence" {
-
-  triggers = {
-    always_run = "${timestamp()}"
-  }
-
-  provisioner "remote-exec" {
-    inline = [ "echo export QUALITY_INTELLIGENCE=true >> ~/.bashrc",
-      "echo export PROMETHEUS_PUSH_GATEWAY_URL=${var.PROMETHEUS_PUSH_GATEWAY_URL} >> ~/.bashrc",
-      "source ~/.bashrc"
-    ]
-    connection {
-      type     = "ssh"
-      user     = "root"
-      password = "linux"
-      host     = "${module.cucumber_testsuite.configuration.controller.hostname}"
-    }
-  }
-
+  prometheus_push_gateway_url = var.PROMETHEUS_PUSH_GATEWAY_URL
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/Uyuni-Master-playwright-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-playwright-NUE.tf
@@ -215,27 +215,8 @@ module "cucumber_testsuite" {
     bridge             = "br1"
     additional_network = "192.168.117.0/24"
   }
-}
 
-
-resource "null_resource" "configure_quality_intelligence" {
-
-  triggers = {
-    always_run = "${timestamp()}"
-  }
-
-  provisioner "remote-exec" {
-    inline = [ "echo export QUALITY_INTELLIGENCE=true >> ~/.bashrc",
-      "echo export PROMETHEUS_PUSH_GATEWAY_URL=${var.PROMETHEUS_PUSH_GATEWAY_URL} >> ~/.bashrc"
-    ]
-    connection {
-      type     = "ssh"
-      user     = "root"
-      password = "linux"
-      host     = "${module.cucumber_testsuite.configuration.controller.hostname}"
-    }
-  }
-
+  prometheus_push_gateway_url = var.PROMETHEUS_PUSH_GATEWAY_URL
 }
 
 output "configuration" {

--- a/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
@@ -213,28 +213,8 @@ module "cucumber_testsuite" {
     bridge             = "br0"
     additional_network = "192.168.102.0/24"
   }
-}
 
-
-resource "null_resource" "configure_quality_intelligence" {
-
-  triggers = {
-    always_run = "${timestamp()}"
-  }
-
-  provisioner "remote-exec" {
-    inline = [ "echo export QUALITY_INTELLIGENCE=true >> ~/.bashrc",
-      "echo export PROMETHEUS_PUSH_GATEWAY_URL=${var.PROMETHEUS_PUSH_GATEWAY_URL} >> ~/.bashrc",
-      "source ~/.bashrc"
-    ]
-    connection {
-      type     = "ssh"
-      user     = "root"
-      password = "linux"
-      host     = "${module.cucumber_testsuite.configuration.controller.hostname}"
-    }
-  }
-
+  prometheus_push_gateway_url = var.PROMETHEUS_PUSH_GATEWAY_URL
 }
 
 output "configuration" {


### PR DESCRIPTION
## What does this PR ?

Use sumaform native support for Quality Intelligence environment variables

Replace the null_resource "configure_quality_intelligence" remote-exec provisioner with the new prometheus_push_gateway_url input variable now supported natively by the cucumber_testsuite sumaform module.

## Changes

The following files have the null_resource "configure_quality_intelligence" block removed and prometheus_push_gateway_url = var.PROMETHEUS_PUSH_GATEWAY_URL added to their module "cucumber_testsuite" call:
  - MLM-5.1-NUE.tf
  - SUSEManager-5.0-NUE.tf
  - Uyuni-Main-podman-NUE.tf
  - Uyuni-Master-playwright-NUE.tf
  - Uyuni-Master-podman-NUE.tf

##  Why

The null_resource workaround appended QUALITY_INTELLIGENCE and PROMETHEUS_PUSH_GATEWAY_URL to ~/.bashrc via SSH after Salt had already run. It was fragile (re-ran on every terraform apply) and duplicated what sumaform's Salt/grains system already handles for all other environment variables.

Sumaform now accepts prometheus_push_gateway_url as a module input and sets both variables in the controller's ~/.bashrc during initial provisioning, using the same Jinja template mechanism as all other controller env vars.

-  Depends on: https://github.com/uyuni-project/sumaform/pull/2200