### PR TITLE
Add Tumbleweed devel repo for Podman 6.0 testing

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
@@ -150,6 +150,9 @@ module "cucumber_testsuite" {
       database_disk_size    = 60
       login_timeout         = 28800
       large_deployment      = true
+      additional_repos = {
+        podman6_repo = "https://download.opensuse.org/repositories/devel:/microos/openSUSE_Tumbleweed/"
+      }
     }
     proxy_containerized = {
       provider_settings = {
@@ -158,6 +161,9 @@ module "cucumber_testsuite" {
       runtime              = "podman"
       container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containerfile"
       container_tag        = "latest"
+      additional_repos = {
+        podman6_repo = "https://download.opensuse.org/repositories/devel:/microos/openSUSE_Tumbleweed/"
+      }
     }
     suse_minion = {
       image             = "tumbleweedo"


### PR DESCRIPTION
Adding the TW devel repo to be able to pull Podman 6.0 with its updated dependencies, so we can test them regularly before its official release in Tumbleweed.

See https://github.com/SUSE/spacewalk/issues/31060