### PR TITLE
Uyuni AWS CI: use Leap 16 image for the controller

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky9", "opensuse156o", "opensuse160o", "tumbleweedo", "sles15sp7o", "ubuntu2404"]
+  images = ["rocky9", "opensuse160o", "tumbleweedo", "sles15sp7o", "ubuntu2404"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"


### PR DESCRIPTION
Substitutes Leap 15.6 (no longer available in AWS) with 16.0 as image for the controller in Uyuni AWS CI.

- [ ] Depends on https://github.com/uyuni-project/sumaform/pull/2203