### PR TITLE
Adapt CI pipeline groovy to new Jenkins

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -138,7 +138,13 @@ def run(params) {
                 if (params.run_secondary) {
                     def tags_list = ""
                     if (params.functional_scopes) {
-                        def transformed_scopes = params.functional_scopes.replaceAll(',', ' or ')
+                        // Re-add the @ prefix stripped from the job parameters
+                        // (Jenkins' Safe HTML markup formatter escapes @ as &#64; in Active Choices labels).
+                        // startsWith guard keeps backward compatibility with jobs still passing @-prefixed scopes.
+                        def transformed_scopes = params.functional_scopes.split(',')
+                                .collect { it.trim() }
+                                .collect { it.startsWith('@') ? it : "@${it}" }
+                                .join(' or ')
                         tags_list = "export TAGS='${transformed_scopes}'; "
                     }
 

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -12,7 +12,7 @@ def run(params) {
         // The junit plugin doesn't affect full paths
         GString junit_resultdir = "results/${env.BUILD_NUMBER}/results_junit"
         // Mutable: the AWS backend appends PUBLISH_CUCUMBER_REPORT below
-        def exports = "export BUILD_NUMBER=${env.BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
+        def exports = "export BUILD_NUMBER=${env.BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
         GString common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform --terraform-bin ${params.bin_path}"
 
 

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -1,17 +1,25 @@
 def run(params) {
     timestamps {
+        // Null-safe defaults for optional stage-control parameters (backward compat with env files that don't declare them)
+        def runDeploy    = params.deploy    == null ? true : params.deploy
+        def runCore      = params.core      == null ? true : params.core
+        def runSecondary = params.secondary == null ? true : params.secondary
+
         // Init path env variables
-        GString resultdir = "${WORKSPACE}/results"
-        GString resultdirbuild = "${resultdir}/${BUILD_NUMBER}"
+        GString resultdir = "${env.WORKSPACE}/results"
+        GString resultdirbuild = "${resultdir}/${env.BUILD_NUMBER}"
 
         // The junit plugin doesn't affect full paths
-        GString junit_resultdir = "results/${BUILD_NUMBER}/results_junit"
+        GString junit_resultdir = "results/${env.BUILD_NUMBER}/results_junit"
+        // Mutable: the AWS backend appends PUBLISH_CUCUMBER_REPORT below
+        def exports = "export BUILD_NUMBER=${env.BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
         GString common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform --terraform-bin ${params.bin_path}"
-        env.exports = "export BUILD_NUMBER=${BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
+
 
         if (params.deploy_parallelism) {
             common_params = "${common_params} --parallelism ${params.deploy_parallelism}"
         }
+        // Bastion support (from pipeline.groovy)
         if (params.bastion_ssh_key_file) {
             common_params = "${common_params} --bastion_ssh_key ${params.bastion_ssh_key_file} --bastion_user ${params.bastion_username}"
             if (params.bastion_hostname) {
@@ -21,8 +29,10 @@ def run(params) {
 
         def previous_commit = null
         def product_commit = null
-        def mirror_scope = env.JOB_BASE_NAME.split('-acceptance-tests')[0]
-        mirror_scope = mirror_scope.replaceAll("-dev", "")
+        // CI-job detection: acceptance-tests jobs get mirror sync, flaky-test labels,
+        // RRTG ingest and OBS/IBS product-commit tracking. Personal jobs skip them.
+        def isAcceptanceJob = env.JOB_BASE_NAME.contains('-acceptance-tests')
+        def mirror_scope = isAcceptanceJob ? env.JOB_BASE_NAME.split('-acceptance-tests')[0].replaceAll("-dev", "") : null
         def ci_label_map = [
                 '4.3' : '4.3_ci',
                 '5.0' : '5.0_ci',
@@ -30,12 +40,12 @@ def run(params) {
                 'Head': 'head_ci',
                 'uyuni': 'uyuni_podman_ci'
         ]
-        def ci_label = ci_label_map.find { k, v -> env.JOB_BASE_NAME.contains(k) }?.value ?: ''
-        def rrtg_version = env.JOB_BASE_NAME.find(/4\.3|5\.0|5\.1|Head/)?.toLowerCase()
+        def ci_label = isAcceptanceJob ? (ci_label_map.find { k, v -> env.JOB_BASE_NAME.contains(k) }?.value ?: '') : ''
+        def rrtg_version = isAcceptanceJob ? env.JOB_BASE_NAME.find(/4\.3|5\.0|5\.1|Head/)?.toLowerCase() : null
         if (!rrtg_version && env.JOB_BASE_NAME == 'uyuni-master-dev-acceptance-tests-podman') {
             rrtg_version = 'uyuni'
         }
-        if (params.show_product_changes) {
+        if (params.show_product_changes && isAcceptanceJob) {
             // Retrieve the hash commit of the last product built in OBS/IBS and previous job
             def prefix = env.JOB_BASE_NAME.split('-acceptance-tests')[0]
             if (prefix == "uyuni-master-dev") {
@@ -48,7 +58,7 @@ def run(params) {
             product_commit = "${requestJson.actions.lastBuiltRevision.SHA1}"
             product_commit = product_commit.substring(product_commit.indexOf('[') + 1, product_commit.indexOf(']'));
             print "Current product commit: ${product_commit}"
-            previous_commit = currentBuild.getPreviousBuild().description
+            previous_commit = currentBuild.getPreviousBuild()?.description
             if (previous_commit == null) {
                 previous_commit = product_commit
             } else {
@@ -57,117 +67,177 @@ def run(params) {
             print "Previous product commit: ${previous_commit}"
         }
         // Start pipeline
-        deployed = false
-        try {
-            stage('Clone terracumber, susemanager-ci and sumaform') {
-                if (params.show_product_changes) {
-                    // Rename build using product commit hash
-                    currentBuild.description =  "[${product_commit}]"
-                }
-                
-                // Create a directory for  to place the directory with the build results (if it does not exist)
-                sh "mkdir -p ${resultdir}"
-                git url: params.terracumber_gitrepo, branch: params.terracumber_ref
-                dir("susemanager-ci") {
-                    checkout scm
-                }
-                // Clone sumaform
-                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
-            
-                // Restore Terraform states from artifacts
-                if (params.use_previous_terraform_state) {
-                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
-                }
-
-                // run minima sync on mirror
-                if (mirror_scope != null) {
-                    sh "ssh root@minima-mirror-ci-bv.`hostname -d` -t \"test -x /usr/local/bin/minima-${mirror_scope}.sh && /usr/local/bin/minima-${mirror_scope}.sh || echo 'no mirror script for this scope'\""
-                }
+        def deployed = false
+        def isNewJenkins = env.JENKINS_URL?.contains('jenkins.mgr.suse.de')
+        def credInit = isNewJenkins
+                ? 'set +x; credFile=$(mktemp); echo "$SECRET_CONTENT" > "${credFile}"; chmod 600 "${credFile}"; . "${credFile}"; rm -f "${credFile}"; set -x'
+                : 'set +x; . /home/jenkins/.credentials; set -x'
+        def withCreds = { Closure body ->
+            if (isNewJenkins) {
+                withCredentials([string(credentialsId: 'sumaform-secrets', variable: 'SECRET_CONTENT')]) { body() }
+            } else {
+                body()
             }
-            stage('Deploy') {
-                // Provision the environment
-                if (params.terraform_init) {
-                    env.TERRAFORM_INIT = '--init'
-                } else {
-                    env.TERRAFORM_INIT = ''
-                }
-                env.TERRAFORM_TAINT = ''
-                if (params.terraform_taint) {
-                    switch(params.sumaform_backend) {
-                        case "libvirt":
-                            env.TERRAFORM_TAINT = " --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
-                            break;
-                        case "aws":
-                            env.TERRAFORM_TAINT = " --taint '.*(host).*'";
-                            env.exports = "${env.exports} export PUBLISH_CUCUMBER_REPORT=true;";
-                            break;
-                        default:
-                            println("ERROR: Unknown backend ${params.sumaform_backend}");
-                            sh "exit 1";
-                            break;
+        }
+        try {
+            withCreds {
+                stage('Clone terracumber, susemanager-ci and sumaform') {
+                    if (params.show_product_changes) {
+                        // Rename build using product commit hash (fall back to tf_file for personal jobs)
+                        currentBuild.description = product_commit ? "[${product_commit}]" : "[${params.tf_file}]"
+                    }
+                    // Create a directory for  to place the directory with the build results (if it does not exist)
+                    sh "mkdir -p ${resultdir}"
+                    git url: params.terracumber_gitrepo, branch: params.terracumber_ref
+                    dir("susemanager-ci") {
+                        checkout scm
+                    }
+                    // Always sync sumaform — the deploy stage needs the checkout regardless
+                    sh """
+                        #!/bin/bash
+                        ${credInit}
+                        ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync
+                    """
+                    // Restore Terraform states from artifacts
+                    if (params.use_previous_terraform_state && currentBuild.previousBuild != null) {
+                        copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
+                    }
+
+                    // run minima sync on mirror
+                    if (mirror_scope != null) {
+                        def domain = sh(script: "grep -oP 'domain\\s*=\\s*\"\\K[^\"]+' ${params.tf_file}", returnStdout: true).trim()
+                        sh "ssh root@minima-mirror-ci-bv.${domain} -t \"test -x /usr/local/bin/minima-${mirror_scope}.sh && /usr/local/bin/minima-${mirror_scope}.sh || echo 'no mirror script for this scope'\""
                     }
                 }
-                sh "set +x; source /home/jenkins/.credentials set -x; set -o pipefail; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.bin_path}; export TERRAFORM_PLUGINS=${params.bin_plugins_path}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} ${env.TERRAFORM_TAINT} --sumaform-backend ${params.sumaform_backend} --runstep provision | sed -E 's/([^.]+)module\\.([^.]+)\\.module\\.([^.]+)(\\.module\\.[^.]+)?(\\[[0-9]+\\])?(\\.module\\.[^.]+)?(\\.[^.]+)?(.*)/\\1\\2.\\3\\8/'"
-                deployed = true
-                // Collect and tag Flaky tests from the GitHub Board
-                def rakeTarget = ci_label ? "utils:collect_and_tag_flaky_tests[${ci_label}]" : "utils:collect_and_tag_flaky_tests"
-                def statusCode = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake ${rakeTarget}'", returnStatus:true
-            }
-            stage('Product changes') {
-                if (params.show_product_changes) {
-                    sh """
+                if (runDeploy) {
+                    stage('Deploy') {
+                        // Provision the environment
+                        if (params.terraform_init) {
+                            env.TERRAFORM_INIT = '--init'
+                        } else {
+                            env.TERRAFORM_INIT = ''
+                        }
+                        env.TERRAFORM_TAINT = ''
+                        if (params.terraform_taint) {
+                            switch (params.sumaform_backend) {
+                                case "libvirt":
+                                    env.TERRAFORM_TAINT = " --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
+                                    break;
+                                case "aws":
+                                    env.TERRAFORM_TAINT = " --taint '.*(host).*'";
+                                    exports = "${exports} export PUBLISH_CUCUMBER_REPORT=true;";
+                                    break;
+                                default:
+                                    println("ERROR: Unknown backend ${params.sumaform_backend}");
+                                    sh "exit 1";
+                                    break;
+                            }
+                        }
+                        if (isNewJenkins) {
+                            sh """
+                                sed -i '/HYPERVISOR_PRIVATE_SSH_KEY_PATH/d' ${resultdir}/sumaform/terraform.tfvars 2>/dev/null || true
+                                sed -i '/CONTROLLER_PUBLIC_SSH_KEY_PATH/d' ${resultdir}/sumaform/terraform.tfvars 2>/dev/null || true
+                                echo 'HYPERVISOR_PRIVATE_SSH_KEY_PATH="/home/jenkins/.ssh/id_ed25519.worker"' >> ${resultdir}/sumaform/terraform.tfvars
+                                echo 'CONTROLLER_PUBLIC_SSH_KEY_PATH="/home/jenkins/.ssh/id_ed25519.pub.controller"' >> ${resultdir}/sumaform/terraform.tfvars
+                            """
+                        }
+                        sh """
+                            #!/bin/bash
+                            ${credInit}
+                            set -o pipefail
+                            export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}
+                            export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}
+                            export TERRAFORM=${params.bin_path}
+                            export TERRAFORM_PLUGINS=${params.bin_plugins_path}
+                            ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} ${env.TERRAFORM_TAINT} --sumaform-backend ${params.sumaform_backend} --runstep provision | sed -E 's/([^.]+)module\\.([^.]+)\\.module\\.([^.]+)(\\.module\\.[^.]+)?(\\[[0-9]+\\])?(\\.module\\.[^.]+)?(\\.[^.]+)?(.*)/\\1\\2.\\3\\8/'
+                        """
+                        deployed = true
+                        // Collect and tag Flaky tests from the GitHub Board
+                        def rakeTarget = ci_label ? "utils:collect_and_tag_flaky_tests[${ci_label}]" : "utils:collect_and_tag_flaky_tests"
+                        def statusCode = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake ${rakeTarget}'", returnStatus: true
+                    }
+                } else {
+                    deployed = true
+                }
+                stage('Product changes') {
+                    if (params.show_product_changes) {
+                        sh """
                         # Comparison between:
                         #  - the previous git revision of spacewalk (or uyuni) repository pushed in IBS (or OBS)
                         #  - the git revision of the current spacewalk (or uyuni) repository pushed in IBS (or OBS)
                         # Note: This is a trade-off, we should be comparing the git revisions of all the packages composing our product
                         #       For that extra mile, we need a new tag in the repo metadata of each built, with the git revision of the related repository.
                     """
-                    sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/; git --no-pager log --pretty=format:\"%h %<(16,trunc)%cn  %s  %d\" ${previous_commit}..${product_commit}'", returnStatus:true
-                } else {
-                    println("Product changes disabled, checkbox 'show_product_changes' was not enabled'")
+                        sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/; git --no-pager log --pretty=format:\\\"%h %<(16,trunc)%cn  %s  %d\\\" ${previous_commit}..${product_commit}'", returnStatus: true
+                    } else {
+                        println("Product changes disabled, checkbox 'show_product_changes' was not enabled'")
+                    }
                 }
-            }
-            stage('Sanity Check') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:sanity_check'"
-            }
-            stage('Core - Setup') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:core'"
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:reposync'"
-            }
-            stage('Core - Proxy') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:proxy'"
-            }
-            stage('Core - Initialize clients') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake parallel:init_clients'"
-            }
-            stage('Secondary features') {
-                def tags_list = ""
-                if (params.functional_scopes) {
-                    def transformed_scopes = params.functional_scopes.replaceAll(',', ' or ')
-                    tags_list += "export TAGS=${transformed_scopes}; "
+                stage('Sanity Check') {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:sanity_check'"
                 }
-                def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list} cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:secondary'", returnStatus:true
-                def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list} cd /root/spacewalk/testsuite; ${env.exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus:true
-                def statusCode3 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list} cd /root/spacewalk/testsuite; ${env.exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus:true
-                sh "exit \$(( ${statusCode1}|${statusCode2}|${statusCode3} ))"
+                stage('Core - Setup') {
+                    if (runCore) {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:core'"
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:reposync'"
+                    }
+                }
+                stage('Core - Proxy') {
+                    if (runCore) {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:proxy'"
+                    }
+                }
+                stage('Core - Initialize clients') {
+                    if (runCore) {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                    }
+                }
+                stage('Secondary features') {
+                    if (runSecondary) {
+                        def tags_list = ""
+                        if (params.functional_scopes) {
+                            // Re-add the @ prefix stripped from the job parameters
+                            // (Jenkins' Safe HTML markup formatter escapes @ as &#64; in Active Choices labels).
+                            // startsWith guard keeps backward compatibility with jobs still passing @-prefixed scopes.
+                            def transformed_scopes = params.functional_scopes.split(',')
+                                    .collect { it.trim() }
+                                    .collect { it.startsWith('@') ? it : "@${it}" }
+                                    .join(' or ')
+                            tags_list = "export TAGS='${transformed_scopes}'; "
+                        }
+
+                        def cucumberCmd1 = "${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary"
+                        def cucumberCmd2 = "${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable"
+                        def cucumberCmd3 = "${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing"
+
+                        def encoded1 = cucumberCmd1.bytes.encodeBase64().toString()
+                        def encoded2 = cucumberCmd2.bytes.encodeBase64().toString()
+                        def encoded3 = cucumberCmd3.bytes.encodeBase64().toString()
+
+                        def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'echo ${encoded1} | base64 -d | bash'", returnStatus: true
+                        def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'echo ${encoded2} | base64 -d | bash'", returnStatus: true
+                        def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'echo ${encoded3} | base64 -d | bash'", returnStatus: true
+                        sh "exit \$(( ${statusCode1}|${statusCode2}|${statusCode3} ))"
+                    }
+                }
             }
         }
         finally {
             stage('Save TF state') {
-                    archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
+                archiveArtifacts artifacts: "results/sumaform/terraform.tfstate, results/sumaform/.terraform/**/*"
             }
 
             stage('Get results') {
                 def error = 0
                 if (deployed) {
                     try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:finishing'"
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:finishing'"
                     } catch(err) {
                         println("ERROR: rake cucumber:finishing failed: ${err}")
                         error = 1
                     }
                     try {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake utils:generate_test_report'"
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake utils:generate_test_report'"
                     } catch(err) {
                         println("ERROR: rake utils:generate_test_repor failed: ${err}")
                         error = 1
@@ -177,14 +247,14 @@ def run(params) {
                     if (params.sumaform_backend == "aws") {
                         try {
                             sh """
-                              ./terracumber-cli ${common_params} \
-                                --logfile ${resultdirbuild}/webserver.log \
-                                --runstep cucumber \
-                                --cucumber-cmd 'mkdir -p /mnt/www/${BUILD_NUMBER} && \
-                                                rsync -avz --no-owner --no-group  /root/spacewalk/testsuite/results/${BUILD_NUMBER}/ /mnt/www/${BUILD_NUMBER}/ && \
-                                                rsync -av --no-owner --no-group  /root/spacewalk/testsuite/spacewalk-debug.tar.bz2 /mnt/www/${BUILD_NUMBER}/ && \
-                                                rsync -av --no-owner --no-group  /root/spacewalk/testsuite/logs/ /mnt/www/${BUILD_NUMBER}/ && \
-                                                rsync -avz --no-owner --no-group  /root/spacewalk/testsuite/results/${BUILD_NUMBER}/results/cucumber_report/ /mnt/www/${BUILD_NUMBER}/'
+                              ./terracumber-cli ${common_params} \\
+                                --logfile ${resultdirbuild}/webserver.log \\
+                                --runstep cucumber \\
+                                --cucumber-cmd 'mkdir -p /mnt/www/${env.BUILD_NUMBER} && \\
+                                                rsync -avz --no-owner --no-group  /root/spacewalk/testsuite/results/${env.BUILD_NUMBER}/ /mnt/www/${env.BUILD_NUMBER}/ && \\
+                                                rsync -av --no-owner --no-group  /root/spacewalk/testsuite/spacewalk-debug.tar.bz2 /mnt/www/${env.BUILD_NUMBER}/ && \\
+                                                rsync -av --no-owner --no-group  /root/spacewalk/testsuite/logs/ /mnt/www/${env.BUILD_NUMBER}/ && \\
+                                                rsync -avz --no-owner --no-group  /root/spacewalk/testsuite/results/${env.BUILD_NUMBER}/results/cucumber_report/ /mnt/www/${env.BUILD_NUMBER}/'
                             """
                         } catch(err) {
                             println("ERROR: Exporting reports to external AWS Web Server: ${err}")
@@ -192,12 +262,12 @@ def run(params) {
                         }
                     }
                     publishHTML( target: [
-                                allowMissing: true,
-                                alwaysLinkToLastBuild: false,
-                                keepAll: true,
-                                reportDir: "${resultdirbuild}/results/cucumber_report/",
-                                reportFiles: 'index.html',
-                                reportName: "TestSuite Report"]
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: false,
+                            keepAll: true,
+                            reportDir: "${resultdirbuild}/results/cucumber_report/",
+                            reportFiles: 'index.html',
+                            reportName: "TestSuite Report"]
                     )
                     // skipPublishingChecks: Checks API not configured on this instance
                     catchError(buildResult: 'FAILURE', stageResult: 'SUCCESS') {
@@ -206,23 +276,30 @@ def run(params) {
                                 skipPublishingChecks: true
                     }
                     // Test Report Summary
-                    sh "python3 -m venv ${WORKSPACE}/venv"
-                    def SCRIPT_DIR = "${WORKSPACE}/susemanager-ci/jenkins_pipelines/scripts/test_review_summary"
-                    def testSummary = sh(script: "${WORKSPACE}/venv/bin/python ${SCRIPT_DIR}/test_review_summary.py ${resultdirbuild}/cucumber_report/cucumber_report.html.json", returnStdout: true).trim()
-                    echo testSummary
+                    try {
+                        sh "python3 -m venv ${env.WORKSPACE}/venv"
+                        def SCRIPT_DIR = "${env.WORKSPACE}/susemanager-ci/jenkins_pipelines/scripts/test_review_summary"
+                        def testSummary = sh(script: "${env.WORKSPACE}/venv/bin/python ${SCRIPT_DIR}/test_review_summary.py ${resultdirbuild}/cucumber_report/cucumber_report.html.json", returnStdout: true).trim()
+                        echo testSummary
+                    } catch(err) {
+                        println("WARNING: test review summary failed (non-fatal): ${err}")
+                    }
                 }
                 // Send email
                 sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
 
                 if (rrtg_version) {
-                    sh """
-                      set +x; source /home/jenkins/.credentials
-                      curl -sf -k -X POST \
-                        "https://su-agent.qe-hub.mgr.suse.de/api/rrtg/ingest/${rrtg_version}?build=${BUILD_NUMBER}" \
-                        -u "\${RRTG_USER}:\${RRTG_PASS}" \
-                        -H "Content-Type: application/json" \
-                      || echo "RRTG ingest failed (non-fatal)"
-                    """
+                    withCreds {
+                        sh """
+                          #!/bin/bash
+                          ${credInit}
+                          curl -sf -k -X POST \\
+                            "https://su-agent.qe-hub.mgr.suse.de/api/rrtg/ingest/${rrtg_version}?build=${env.BUILD_NUMBER}" \\
+                            -u "\${RRTG_USER}:\${RRTG_PASS}" \\
+                            -H "Content-Type: application/json" \\
+                          || echo "RRTG ingest failed (non-fatal)"
+                        """
+                    }
                 }
 
                 // Clean up old results

--- a/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
@@ -23,21 +23,24 @@ node('sumaform-cucumber') {
             booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
             booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
-            booleanParam(name: 'show_product_changes', defaultValue: true, description: 'Show the product changes since the last build'),
+            booleanParam(name: 'show_product_changes', defaultValue: false, description: 'Show the product changes since the last build'),
+            booleanParam(name: 'run_deployment', defaultValue: true, description: 'Run sumaform deployment'),
+            booleanParam(name: 'run_core', defaultValue: true, description: 'Run core testsuite'),
+            booleanParam(name: 'run_secondary', defaultValue: true, description: 'Run secondary testsuite'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
             activeChoice(name: 'functional_scopes', description: 'Choose the functional scopes that you want to test', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [
-                    '@scope_smdba', '@scope_spacecmd', '@scope_spacewalk_utils', '@scope_visualization',
-                    '@scope_notification_message', '@scope_virtual_host_manager', '@scope_subscription_matching',
-                    '@scope_formulas', '@scope_sp_migration', '@scope_cve_audit', '@scope_onboarding',
-                    '@scope_content_lifecycle_management', '@scope_res', '@scope_recurring_actions',
-                    '@scope_maintenance_windows', '@scope_building_container_images', '@scope_kubernetes_integration',
-                    '@scope_openscap', '@scope_deblike', '@scope_action_chains', '@scope_salt_ssh',
-                    '@scope_tomcat', '@scope_changing_software_channels', '@scope_monitoring', '@scope_salt',
-                    '@scope_cobbler', '@scope_sumatoolbox', '@scope_virtualization', '@scope_hub', '@scope_retail',
-                    '@scope_configuration_channels', '@scope_content_staging', '@scope_proxy',
-                    '@scope_traditional_client', '@scope_api', '@scope_power_management',
-                    '@scope_retracted_patches', '@scope_ansible'
+                    'scope_smdba', 'scope_spacecmd', 'scope_spacewalk_utils', 'scope_visualization',
+                    'scope_notification_message', 'scope_virtual_host_manager', 'scope_subscription_matching',
+                    'scope_formulas', 'scope_sp_migration', 'scope_cve_audit', 'scope_onboarding',
+                    'scope_content_lifecycle_management', 'scope_res', 'scope_recurring_actions',
+                    'scope_maintenance_windows', 'scope_building_container_images', 'scope_kubernetes_integration',
+                    'scope_openscap', 'scope_deblike', 'scope_action_chains', 'scope_salt_ssh',
+                    'scope_tomcat', 'scope_changing_software_channels', 'scope_monitoring', 'scope_salt',
+                    'scope_cobbler', 'scope_sumatoolbox', 'scope_virtualization', 'scope_hub', 'scope_retail',
+                    'scope_configuration_channels', 'scope_content_staging', 'scope_proxy',
+                    'scope_traditional_client', 'scope_api', 'scope_power_management',
+                    'scope_retracted_patches', 'scope_ansible'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_scopes']"]])
         ])

--- a/jenkins_pipelines/environments/personal/maxime
+++ b/jenkins_pipelines/environments/personal/maxime
@@ -27,17 +27,17 @@ node('sumaform-cucumber') {
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
             activeChoice(name: 'functional_scopes', description: 'Choose the functional scopes that you want to test', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [
-                    '@scope_smdba', '@scope_spacecmd', '@scope_spacewalk_utils', '@scope_visualization',
-                    '@scope_notification_message', '@scope_virtual_host_manager', '@scope_subscription_matching',
-                    '@scope_formulas', '@scope_sp_migration', '@scope_cve_audit', '@scope_onboarding',
-                    '@scope_content_lifecycle_management', '@scope_res', '@scope_recurring_actions',
-                    '@scope_maintenance_windows', '@scope_building_container_images', '@scope_kubernetes_integration',
-                    '@scope_openscap', '@scope_deblike', '@scope_action_chains', '@scope_salt_ssh',
-                    '@scope_tomcat', '@scope_changing_software_channels', '@scope_monitoring', '@scope_salt',
-                    '@scope_cobbler', '@scope_sumatoolbox', '@scope_virtualization', '@scope_hub', '@scope_retail',
-                    '@scope_configuration_channels', '@scope_content_staging', '@scope_proxy',
-                    '@scope_traditional_client', '@scope_api', '@scope_power_management',
-                    '@scope_retracted_patches', '@scope_ansible'
+                    'scope_smdba', 'scope_spacecmd', 'scope_spacewalk_utils', 'scope_visualization',
+                    'scope_notification_message', 'scope_virtual_host_manager', 'scope_subscription_matching',
+                    'scope_formulas', 'scope_sp_migration', 'scope_cve_audit', 'scope_onboarding',
+                    'scope_content_lifecycle_management', 'scope_res', 'scope_recurring_actions',
+                    'scope_maintenance_windows', 'scope_building_container_images', 'scope_kubernetes_integration',
+                    'scope_openscap', 'scope_deblike', 'scope_action_chains', 'scope_salt_ssh',
+                    'scope_tomcat', 'scope_changing_software_channels', 'scope_monitoring', 'scope_salt',
+                    'scope_cobbler', 'scope_sumatoolbox', 'scope_virtualization', 'scope_hub', 'scope_retail',
+                    'scope_configuration_channels', 'scope_content_staging', 'scope_proxy',
+                    'scope_traditional_client', 'scope_api', 'scope_power_management',
+                    'scope_retracted_patches', 'scope_ansible'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_scopes']"]]),
         ])

--- a/terracumber_config/tf_files/MLM-5.2-PRG.tf
+++ b/terracumber_config/tf_files/MLM-5.2-PRG.tf
@@ -118,7 +118,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "5.2-nightly"
+  product_version = "head"
 
   // Cucumber repository configuration for the controller
   git_username = var.GIT_USER


### PR DESCRIPTION
## What does this PR ? 

  - New Jenkins support (jenkins.mgr.suse.de): Auto-detects the new Jenkins instance via JENKINS_URL and switches credential loading from the legacy /home/jenkins/.credentials file to a withCredentials block backed by the sumaform-secrets credential ID. SSH keys for the hypervisor and controller are injected into terraform.tfvars on new Jenkins only.
  - Personal job isolation (isAcceptanceJob flag): Pipeline now detects whether the job is an acceptance-test job or a personal/dev job. Mirror sync, flaky-test collection, RRTG ingest, and OBS/IBS product-commit tracking are skipped for personal jobs, preventing side-effects and spurious failures.
  - Active Choices @ prefix fix: Jenkins' Safe HTML markup formatter escapes @ as &#64; in Active Choices checkbox labels, causing the scope values to arrive without the @ prefix at runtime. Scope values in all env files are now stored without @, and both pipeline.groovy and pipeline-personal.groovy re-add the prefix programmatically before passing tags to Cucumber.
  - Bug fixes and cleanup: Null-safe getPreviousBuild()?.description call; previousBuild != null guard before copyArtifacts; env.WORKSPACE/env.BUILD_NUMBER references fixed; env.exports replaced with a local def exports to avoid shared-state pollution; minima mirror domain now read from the tf_file instead of relying on hostname -d; deployed declared as def; stage conditionals moved inside stage blocks for cleaner pipeline graph.
  - MLM-5.2-PRG.tf: product_version updated from 5.2-nightly to head.
