### PR TITLE
Fix null interpolation of container registry params and missing HCL brace

### DIFF
--- a/.github/workflows/sumaform-validation.yml
+++ b/.github/workflows/sumaform-validation.yml
@@ -177,7 +177,7 @@ jobs:
           variable "SERVER_CONTAINER_REPOSITORY" { default="" }
           variable "PROXY_CONTAINER_REPOSITORY" { default="" }
           variable "SERVER_CONTAINER_IMAGE" { default="" }
-          variable "SERVER_ADDITIONAL_REPOS" { default={} 
+          variable "SERVER_ADDITIONAL_REPOS" { default={} }
           variable "PROXY_ADDITIONAL_REPOS" { default={} }
           variable "BASE_OS" { default="" }
           variable "PRODUCT_VERSION" { default="" }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-cleanup.groovy
@@ -8,7 +8,7 @@ def run(params) {
         GString resultdir = "${WORKSPACE}/results"
         GString resultdirbuild = "${resultdir}/${BUILD_NUMBER}"
         GString exports = "export BUILD_NUMBER=${BUILD_NUMBER}; export BUILD_VALIDATION=true; "
-        String proxy_container_repository = params.proxy_container_repository ?: null
+        String proxy_container_repository = params.proxy_container_repository ?: ''
         String serverHostname = null
         String controllerHostname = null
         String hypervisorUrl = null
@@ -52,7 +52,7 @@ def run(params) {
         // Define shared environment variables for terraform calls
         GString environmentVars = """
                 export TF_VAR_SERVER_CONTAINER_REPOSITORY='unused'
-                export TF_VAR_PROXY_CONTAINER_REPOSITORY=${proxy_container_repository}
+                export TF_VAR_PROXY_CONTAINER_REPOSITORY='${proxy_container_repository}'
                 export TERRAFORM=${params.bin_path}
                 export TERRAFORM_PLUGINS=${params.bin_plugins_path}
             """

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -42,8 +42,8 @@ def run(params) {
         def products_and_salt_migration_stage_result_fail = false
         def retail_stage_result_fail = false
         def containerization_stage_result_fail = false
-        def server_container_repository = params.server_container_repository ?: null
-        def proxy_container_repository = params.proxy_container_repository ?: null
+        def server_container_repository = params.server_container_repository ?: ''
+        def proxy_container_repository = params.proxy_container_repository ?: ''
         def server_container_image = params.server_container_image ?: ''
         // Parameters used for sandbox pipeline
         def product_version = params.product_version ?: ''


### PR DESCRIPTION
Addresses the Copilot review comments raised on #2106, which were valid but out of scope for that pure-rename PR. All three issues pre-exist on `master`, so they are fixed here independently.

### Changes

1. **`pipeline-build-validation.groovy`** — `server_/proxy_container_repository` were initialized with `?: null` and then unconditionally injected via `--inject ..._CONTAINER_REPOSITORY=${value}`. When the parameter is unset, Groovy interpolates the literal string `"null"`, which the tfvars generator treats as a real registry value. Changed to `?: ''` to match the existing `server_container_image` handling.

2. **`pipeline-build-validation-cleanup.groovy`** — same `?: null` issue for `proxy_container_repository`, exported as `TF_VAR_PROXY_CONTAINER_REPOSITORY`. Changed to `?: ''` and quoted the export so an empty value stays empty instead of becoming the literal string `null`.

3. **`.github/workflows/sumaform-validation.yml`** — the `SERVER_ADDITIONAL_REPOS` variable in the Static BV heredoc was missing its closing `}`, producing invalid HCL in the generated `variables.tf` and failing `tofu plan`. Added the missing brace.

No functional change beyond the corrected empty/unset handling.