### PR TITLE
QE: Change the VM way we execute the benchemark pipeline

### DIFF
--- a/jenkins_pipelines/environments/uyuni-master-dev-benchmark-tests-RKE2
+++ b/jenkins_pipelines/environments/uyuni-master-dev-benchmark-tests-RKE2
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('sumaform-cucumber') {
+node('sumaform-cucumber-slc1') {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10')),
         disableConcurrentBuilds(),
@@ -8,7 +8,7 @@ node('sumaform-cucumber') {
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
             string(name: 'cucumber_ref', defaultValue: 'master', description: 'Testsuite Git reference (branch, tag...)'),
-            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-NUE.tf', description: 'Path to the tf file to be used'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
             choice(name: 'sumaform_backend', choices: ['libvirt', 'aws'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),

--- a/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
@@ -85,7 +85,7 @@ terraform {
 }
 
 provider "libvirt" {
-  uri = "qemu+tcp://https://moscowmule.mgr.slc1.suse.org//system"
+  uri = "qemu+tcp://moscowmule.mgr.slc1.suse.org/system"
 }
 
 module "cucumber_testsuite" {
@@ -118,24 +118,18 @@ module "cucumber_testsuite" {
   images = ["tumbleweedo", "opensuse156o"]
 
   use_avahi    = false
-  name_prefix  = "uyuni-ci-master-benchmark-rke2-"
-  domain       = "mgr.suse.de"
+  name_prefix  = "uyuni-benchmark-master-"
+  domain       = "mgr.slc1.suse.org"
   from_email   = "root@suse.de"
-
-  no_auth_registry = "registry.mgr.suse.de"
-  auth_registry      = "registry.mgr.suse.de:5000/cucutest"
-  auth_registry_username = "cucutest"
-  auth_registry_password = "cucusecret"
-  git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/temporary"
   
   container_server = true
   container_proxy  = true
 
-  mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
+  mirror                   = "minima-mirror-ci-bv.mgr.slc1.suse.org"
   use_mirror_images        = true
 
-  # server_http_proxy = "http-proxy.mgr.suse.de:3128"
-  custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
+  # server_http_proxy = "http-proxy.mgr.slc1.suse.org:3128"
+  custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.slc1.suse.org:445"
 
   # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
   host_settings = {


### PR DESCRIPTION
Change the VM way we execute the benchemark pipeline. The matter of this pipeline is just a controller that points to different RKE2 cluster, so we don't need many things.