### PR TITLE
json_generator: use SP7 Development Tools repo for sle15sp7_minion (v4.3)

### DIFF
--- a/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
+++ b/jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py
@@ -56,7 +56,7 @@ v43_client_tools: dict[str, Set[str]] = {
                         "/SUSE_Updates_SLE-Module-Server-Applications_15-SP7_x86_64/",
                         "/SUSE_Updates_SLE-Module-Systems-Management_15-SP7_x86_64/",
                         "/SUSE_Updates_SLE-Module-Python3_15-SP7_x86_64/",
-                        "/SUSE_Updates_SLE-Module-Development-Tools_15-SP6_x86_64/"},
+                        "/SUSE_Updates_SLE-Module-Development-Tools_15-SP7_x86_64/"},
     "sles15sp5s390_minion": {"/SUSE_Updates_SLE-Manager-Tools_15_s390x/",
                             "/SUSE_Updates_SLE-Module-Basesystem_15-SP5_s390x/",
                             "/SUSE_Updates_SLE-Module-Server-Applications_15-SP5_s390x/",


### PR DESCRIPTION
## What does this PR change?

In `jenkins_pipelines/scripts/json_generator/repository_versions/v43_nodes.py`,
the `sle15sp7_minion` entry set Development Tools to
`SLE-Module-Development-Tools_15-SP6_x86_64` while every other module in that
entry is `15-SP7`, and the v5.1/v5.3 node maps already use `15-SP7`. This points
it at the `15-SP7` Development Tools repo.

Found via Copilot on SUSE/susemanager-ci#2125, split out as a separate fix.

Issue: SUSE/spacewalk#31321
