### PR TITLE
Reflect controller host OS move to openSUSE Leap 16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ image for testing Pull Requests built with the open build service. This needs to
 | Buildhost   | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
 | Terminal    | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
 | DHCP-DNS    | Leap 15.6     | Leap 15.6     | Leap 15.6    | Leap 15.6    | Leap 15.6    | Leap 15.6     | -            |
-| Controller  | Leap 15.6     | Leap 15.6     | Leap 15.6    | Leap 15.6    | Leap 15.6    | Leap 15.6     | Leap 15.6    |
+| Controller  | Leap 16.0     | Leap 16.0     | Leap 16.0    | Leap 16.0    | Leap 16.0    | Leap 16.0     | Leap 16.0    |
 | Server      | Tumbleweed    | Tumbleweed    | SL Micro 6.1 | SL Micro 6.2 | SL Micro 6.1 | SLE Micro 5.5 | SLES 15 SP4  |
 | Proxy       | Tumbleweed    | Tumbleweed    | SL Micro 6.1 | SL Micro 6.2 | SL Micro 6.1 | SLE Micro 5.5 | SLES 15 SP4  |
 
@@ -81,7 +81,7 @@ image for testing Pull Requests built with the open build service. This needs to
 
 |             | 5.2          | 5.1          | 5.0           | 4.3          |
 |-------------|--------------|--------------|---------------|--------------|
-| Controller  | Leap 15.6    | Leap 15.6    | Leap 15.6     | Leap 15.6    |
+| Controller  | Leap 16.0    | Leap 16.0    | Leap 16.0     | Leap 16.0    |
 | Server      | SL Micro 6.2 | SL Micro 6.1 | SLES 15 SP6   | SLES 15 SP4  |
 | Proxy       | SL Micro 6.2 | SL Micro 6.1 | SLES 15 SP6   | SLES 15 SP4  |
 | Minion      | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP6   | SLES 15 SP4  |
@@ -90,7 +90,7 @@ image for testing Pull Requests built with the open build service. This needs to
 
 |             | 5.2          | 5.1          | 5.0           | 4.3          |
 |-------------|--------------|--------------|---------------|--------------|
-| Controller  | Leap 15.6    | Leap 15.6    | Leap 15.6     | Leap 15.6    |
+| Controller  | Leap 16.0    | Leap 16.0    | Leap 16.0     | Leap 16.0    |
 | Server      | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP6   | SLES 15 SP4  |
 | Proxy       | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP6   | SLES 15 SP4  |
 | Minion      | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP6   | SLES 15 SP4  |
@@ -99,7 +99,7 @@ image for testing Pull Requests built with the open build service. This needs to
 
 |             | 5.2          | 5.1          | 5.0           | 4.3          |
 |-------------|--------------|--------------|---------------|--------------|
-| Controller  | Leap 15.6    | Leap 15.6    | Leap 15.6     | -            |
+| Controller  | Leap 16.0    | Leap 16.0    | Leap 16.0     | -            |
 | Server      | SL Micro 6.2 | SL Micro 6.1 | SLE Micro 5.5 | -            |
 | Proxy       | SL Micro 6.2 | SL Micro 6.1 | SLE Micro 5.5 | -            |
 | Minion      | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP6   | -            |

--- a/terracumber_config/tf_files/MLM-5.1-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-NUE.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ci-51-"

--- a/terracumber_config/tf_files/MLM-5.1-SLC.tf
+++ b/terracumber_config/tf_files/MLM-5.1-SLC.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ci-51-"

--- a/terracumber_config/tf_files/MLM-5.1-refenv-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-refenv-NUE.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ref-51-"

--- a/terracumber_config/tf_files/MLM-5.2-PRG.tf
+++ b/terracumber_config/tf_files/MLM-5.2-PRG.tf
@@ -134,7 +134,7 @@ module "cucumber_testsuite" {
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ci-52-podman-"

--- a/terracumber_config/tf_files/MLM-Head-RKE2-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-RKE2-NUE.tf
@@ -135,7 +135,7 @@ module "cucumber_testsuite" {
   cc_ptf_password = var.SCC_PTF_PASSWORD
   scc_slmicro_pass = var.SCC_MICRO_CREDENTIALS
 
-  images = ["slmicro62o", "opensuse156o"]
+  images = ["slmicro62o", "opensuse156o", "opensuse160o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ci-head-rke2-"

--- a/terracumber_config/tf_files/MLM-Head-podman-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-podman-NUE.tf
@@ -116,7 +116,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ci-head-podman-"

--- a/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
@@ -120,7 +120,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ref-head-"

--- a/terracumber_config/tf_files/MLM-Test-Hexagon-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Test-Hexagon-NUE.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-test-hexagon-"

--- a/terracumber_config/tf_files/MLM-Test-Ion-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Test-Ion-NUE.tf
@@ -116,7 +116,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "mlm-test-ion-"

--- a/terracumber_config/tf_files/MLM-Test-Naica-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Test-Naica-NUE.tf
@@ -116,7 +116,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "mlm-test-naica-"

--- a/terracumber_config/tf_files/MLM-Test-Orion-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Test-Orion-NUE.tf
@@ -116,7 +116,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-test-orion-"

--- a/terracumber_config/tf_files/MLM-Test-Vega-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Test-Vega-NUE.tf
@@ -114,7 +114,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-test-vega-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -102,7 +102,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-ci-43-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLC.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLC.tf
@@ -104,7 +104,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-ci-43-"

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["centos7o", "opensuse156o", "sles15sp4o", "ubuntu2204o"]
+  images = ["centos7o", "opensuse156o", "opensuse160o", "sles15sp4o", "ubuntu2204o"]
 
   use_avahi    = false
   name_prefix  = "suma-ref-43-"

--- a/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-ci-50-"

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLC.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLC.tf
@@ -116,7 +116,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-ci-50-"

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
@@ -120,7 +120,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-ref-50-"

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-SLC.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-SLC.tf
@@ -120,7 +120,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
 
   use_avahi    = false
   name_prefix  = "suma-ref-50-"

--- a/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
@@ -107,7 +107,7 @@ module "cucumber_testsuite" {
   cc_username   = var.SCC_USER
   cc_password   = var.SCC_PASSWORD
 
-  images        = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+  images        = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
 
   use_avahi     = false
   name_prefix   = "uyuni-ci-main-podman-"

--- a/terracumber_config/tf_files/Uyuni-Master-AWS.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-AWS.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky9", "opensuse156o", "tumbleweedo", "sles15sp7o", "ubuntu2404"]
+  images = ["rocky9", "opensuse156o", "opensuse160o", "tumbleweedo", "sles15sp7o", "ubuntu2404"]
 
   use_avahi    = false
   name_prefix  = "uyuni-master-"
@@ -143,7 +143,7 @@ module "cucumber_testsuite" {
 
   host_settings = {
     controller = {
-      image = "opensuse156o"
+      image = "opensuse160o"
       provider_settings = {
         instance_type = "c6i.xlarge"
         private_ip = "172.16.3.5"

--- a/terracumber_config/tf_files/Uyuni-Master-RKE2-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-RKE2-NUE.tf
@@ -116,7 +116,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["tumbleweedo", "opensuse156o"]
+  images = ["tumbleweedo", "opensuse156o", "opensuse160o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-ci-master-rke2-"

--- a/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
@@ -115,7 +115,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["tumbleweedo", "opensuse156o"]
+  images = ["tumbleweedo", "opensuse156o", "opensuse160o"]
 
   use_avahi    = false
   name_prefix  = "uyuni-benchmark-master-"

--- a/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
@@ -107,7 +107,7 @@ module "cucumber_testsuite" {
   cc_username   = var.SCC_USER
   cc_password   = var.SCC_PASSWORD
 
-  images        = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+  images        = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
 
   use_avahi     = false
   name_prefix   = "uyuni-ci-master-podman-"

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
 
   use_avahi    = false
   name_prefix  = "uyuni-ref-master-"

--- a/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage-SLC.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-tests-code-coverage-SLC.tf
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
 
   use_avahi    = false
   name_prefix  = "suma-codecov-"

--- a/terracumber_config/tf_files/personal/main_43.tf
+++ b/terracumber_config/tf_files/personal/main_43.tf
@@ -28,7 +28,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "sles15sp4o", "ubuntu2204o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "sles15sp4o", "ubuntu2204o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false

--- a/terracumber_config/tf_files/personal/main_50.tf
+++ b/terracumber_config/tf_files/personal/main_50.tf
@@ -34,7 +34,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slemicro55o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false

--- a/terracumber_config/tf_files/personal/main_51.tf
+++ b/terracumber_config/tf_files/personal/main_51.tf
@@ -35,7 +35,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false

--- a/terracumber_config/tf_files/personal/main_head.tf
+++ b/terracumber_config/tf_files/personal/main_head.tf
@@ -34,7 +34,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o", "slmicro62o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false

--- a/terracumber_config/tf_files/personal/main_head_staging.tf
+++ b/terracumber_config/tf_files/personal/main_head_staging.tf
@@ -34,7 +34,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro61o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o", "slmicro62o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false

--- a/terracumber_config/tf_files/personal/main_rke2_head.tf
+++ b/terracumber_config/tf_files/personal/main_rke2_head.tf
@@ -34,7 +34,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false

--- a/terracumber_config/tf_files/personal/main_rke2_uyuni.tf
+++ b/terracumber_config/tf_files/personal/main_rke2_uyuni.tf
@@ -34,7 +34,7 @@ module "cucumber_testsuite" {
   cc_username   = var.SCC_USER
   cc_password   = var.SCC_PASSWORD
 
-  images        = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+  images        = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
 
   ssh_key_path  = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi     = false

--- a/terracumber_config/tf_files/personal/main_uyuni.tf
+++ b/terracumber_config/tf_files/personal/main_uyuni.tf
@@ -34,7 +34,7 @@ module "cucumber_testsuite" {
   cc_username   = var.SCC_USER
   cc_password   = var.SCC_PASSWORD
 
-  images        = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+  images        = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
 
   ssh_key_path  = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi     = false

--- a/terracumber_config/tf_files/tfvars/PR-tfvars/PR-testing-manager43.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-tfvars/PR-testing-manager43.tfvars
@@ -1,7 +1,7 @@
 ############ Spacewalk unique variables ############
 
 IMAGE                  = "sles15sp4o"
-IMAGES                 = ["rocky9o", "opensuse156o", "sles15sp4o", "ubuntu2204o"]
+IMAGES                 = ["rocky9o", "opensuse156o", "opensuse160o", "sles15sp4o", "ubuntu2204o"]
 SERVER_IMAGE           = "sles15sp4o"
 PROXY_IMAGE            = "sles15sp4o"
 SUSE_MINION_IMAGE      = "sles15sp4o"

--- a/terracumber_config/tf_files/tfvars/PR-tfvars/PR-testing-uyuni.tfvars
+++ b/terracumber_config/tf_files/tfvars/PR-tfvars/PR-testing-uyuni.tfvars
@@ -3,7 +3,7 @@
 IMAGE                  = "opensuse155-ci-pro"
 SERVER_IMAGE           = "leapmicro55o"
 PROXY_IMAGE            = "leapmicro55o"
-IMAGES                 = ["rocky9o", "opensuse156o", "opensuse155-ci-pro", "ubuntu2404o", "sles15sp4o", "leapmicro55o"]
+IMAGES                 = ["rocky9o", "opensuse156o", "opensuse160o", "opensuse155-ci-pro", "ubuntu2404o", "sles15sp4o", "leapmicro55o"]
 SUSE_MINION_IMAGE      = "opensuse156o"
 PRODUCT_VERSION        = "uyuni-pr"
 MAIL_TEMPLATE_ENV_FAIL = "../mail_templates/mail-template-jenkins-pull-request-env-fail.txt"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_micro_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_micro_build_validation_nue.tfvars
@@ -32,7 +32,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br1"
     hypervisor         = "suma-11.mgr.suse.de"
     additional_network = null
-    images             = ["sles15sp7o", "opensuse156o", "slmicro61o"]
+    images             = ["sles15sp7o", "opensuse156o", "opensuse160o", "slmicro61o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.1 Build Validation $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_micro_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_micro_build_validation_nue.tfvars
@@ -32,7 +32,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br1"
     hypervisor         = "suma-11.mgr.suse.de"
     additional_network = null
-    images             = ["sles15sp7o", "opensuse156o", "slmicro62o"]
+    images             = ["sles15sp7o", "opensuse156o", "opensuse160o", "slmicro62o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.2 Build Validation $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_slc.tfvars
@@ -255,7 +255,7 @@ ENVIRONMENT_CONFIGURATION = {
 
 BASE_CONFIGURATION = {
   base_core = {
-    images             = [ "sles15sp5o", "sles15sp7o", "opensuse156o" ]
+    images             = [ "sles15sp5o", "sles15sp7o", "opensuse156o", "opensuse160o" ]
     pool               = "ssd"
     bridge             = "br1"
     additional_network = null
@@ -283,7 +283,7 @@ BASE_CONFIGURATION = {
     hypervisor         = "florina.mgr.slc1.suse.org"
   }
   base_retail = {
-    images             = [ "sles15sp6o","sles15sp7o", "opensuse156o" ]
+    images             = [ "sles15sp6o","sles15sp7o", "opensuse156o", "opensuse160o" ]
     pool               = "ssd"
     bridge             = "br1"
     additional_network = "192.168.52.0/24"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_slc.tfvars
@@ -254,7 +254,7 @@ ENVIRONMENT_CONFIGURATION = {
 
 BASE_CONFIGURATIONS = {
   base_core = {
-    images             = [ "tumbleweedo", "opensuse156o", "sles15sp7o" ]
+    images             = [ "tumbleweedo", "opensuse156o", "opensuse160o", "sles15sp7o" ]
     pool               = "ssd"
     bridge             = "br1"
     additional_network = null
@@ -282,7 +282,7 @@ BASE_CONFIGURATIONS = {
     hypervisor         = "ginfizz.mgr.slc1.suse.org"
   }
   base_retail = {
-    images             = [ "sles15sp6o", "sles15sp7o", "opensuse156o", "leapmicro55o" ]
+    images             = [ "sles15sp6o", "sles15sp7o", "opensuse156o", "opensuse160o", "leapmicro55o" ]
     pool               = "ssd"
     bridge             = "br1"
     additional_network = "192.168.100.0/24"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_sles_hubtesting_prg.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_sles_hubtesting_prg.tfvars
@@ -55,7 +55,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br0"
     hypervisor         = "cthulhu.mgr.suse.de"
     additional_network = null
-    images             = ["sles15sp7o", "opensuse156o", "sles15sp5o"]
+    images             = ["sles15sp7o", "opensuse156o", "opensuse160o", "sles15sp5o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.2 Build Validation $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars
@@ -237,7 +237,7 @@ ENVIRONMENT_CONFIGURATION = {
 
 BASE_CONFIGURATIONS = {
   base_core = {
-    images             = [ "sles15sp4o", "opensuse156o", "sles15sp7o" ]
+    images             = [ "sles15sp4o", "opensuse156o", "opensuse160o", "sles15sp7o" ]
     pool               = "ssd"
     bridge             = "br1"
     additional_network = null

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_sles_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_sles_build_validation_nue.tfvars
@@ -32,7 +32,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br1"
     hypervisor         = "suma-11.mgr.suse.de"
     additional_network = null
-    images             = [ "sles15sp6o", "opensuse156o"]
+    images             = [ "sles15sp6o", "opensuse156o", "opensuse160o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.0 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm51_micro_sle_update_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm51_micro_sle_update_nue.tfvars
@@ -33,7 +33,7 @@ BASE_CONFIGURATIONS = {
     bridge              = "br1"
     hypervisor          = "suma-11.mgr.suse.de"
     additional_network  = null
-    images              = ["sles15sp7o", "opensuse156o", "slmicro61o"]
+    images              = ["sles15sp7o", "opensuse156o", "opensuse160o", "slmicro61o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.1 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm51_sles_sle_update_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm51_sles_sle_update_nue.tfvars
@@ -33,7 +33,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br1"
     hypervisor         = "suma-11.mgr.suse.de"
     additional_network = null
-    images              = ["sles15sp7o", "opensuse156o"]
+    images              = ["sles15sp7o", "opensuse156o", "opensuse160o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.1 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma43_sle_update_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma43_sle_update_nue.tfvars
@@ -35,7 +35,7 @@ BASE_CONFIGURATIONS = {
     bridge              = "br1"
     hypervisor          = "suma-11.mgr.suse.de"
     additional_network  = null
-    images              = ["sles15sp4o", "sles15sp6o", "opensuse156o"]
+    images              = ["sles15sp4o", "sles15sp6o", "opensuse156o", "opensuse160o"]
   }
 }
 MAIL_SUBJECT          = "Results 4.3 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma43_sle_update_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma43_sle_update_slc.tfvars
@@ -27,7 +27,7 @@ ENVIRONMENT_CONFIGURATION = {
 
 BASE_CONFIGURATIONS = {
   base_core = {
-    images             = [ "sles15sp4o", "opensuse156o" ]
+    images             = [ "sles15sp4o", "opensuse156o", "opensuse160o" ]
     pool               = "ssd"
     bridge             = "br0"
     hypervisor         = "riverworld.mgr.slc1.suse.org"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma50_micro_sle_update_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma50_micro_sle_update_nue.tfvars
@@ -33,7 +33,7 @@ BASE_CONFIGURATIONS = {
     bridge              = "br1"
     hypervisor          = "suma-11.mgr.suse.de"
     additional_network  = null
-    images              = ["sles15sp6o", "opensuse156o", "slemicro55o"]
+    images              = ["sles15sp6o", "opensuse156o", "opensuse160o", "slemicro55o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.0 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma50_micro_sle_update_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma50_micro_sle_update_slc.tfvars
@@ -34,7 +34,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br0"
     hypervisor         = "riverworld.mgr.slc1.suse.org"
     additional_network = null
-    images             = [ "sles15sp6o", "opensuse156o", "slemicro55o" ]
+    images             = [ "sles15sp6o", "opensuse156o", "opensuse160o", "slemicro55o" ]
   }
 }
 MAIL_SUBJECT          = "Results 5.0 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma50_sles_sle_update_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/suma50_sles_sle_update_nue.tfvars
@@ -33,7 +33,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br1"
     hypervisor         = "suma-11.mgr.suse.de"
     additional_network = null
-    images             = [ "sles15sp6o", "opensuse156o"]
+    images             = [ "sles15sp6o", "opensuse156o", "opensuse160o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.0 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"


### PR DESCRIPTION
## What does this PR change?

Moves the test-suite **controller** to openSUSE Leap 16.0 (from Leap 15.6, EOL since April 2026), across all environments.

The controller host OS is defined centrally in sumaform (`modules/controller/main.tf`, hardcoded image), so the migration is global — driven by the companion sumaform PR. This PR handles the susemanager-ci side:

1. **Add `opensuse160o` to every environment's image download list** (48 `images = [...]` lists + the 2 uppercase `IMAGES = [...]` lists in `PR-tfvars/PR-testing-{uyuni,manager43}.tfvars`). The controller's base image must be present in each environment's download list, otherwise its base volume won't exist on libvirt. `opensuse156o` is **kept** (the openSUSE Leap 15.6 minion clients still use it) — `opensuse160o` is added alongside it.
2. **`Uyuni-Master-AWS.tf`** — this environment *explicitly overrides* the controller image; flipped `opensuse156o` → `opensuse160o` (it would otherwise stay pinned to 15.6).
3. **`README.md`** — image matrix: all Controller rows → Leap 16.0.

Not touched:
- `opensuse156o` stays wherever it's used for minion clients / dhcp_dns / mirrors.
- **salt-shaker** environments (their `opensuse156o` is the system-under-test, and their controller comes from the separate `salt_testenv` module — not part of this migration).
- Mirror-only configs (no controller).

Companion PRs:
- sumaform: https://github.com/uyuni-project/sumaform/pull/2230 (controller VM image → Leap 16.0)
- uyuni: https://github.com/uyuni-project/uyuni/pull/12313 (controller-dev container → Leap 16.0)

Links: https://github.com/SUSE/spacewalk/issues/31270
