### PR TITLE
Partially revert "Fix pipeline for 5.2 acceptance tests"

### DIFF
--- a/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
@@ -25,7 +25,21 @@ node('sumaform-cucumber') {
             booleanParam(name: 'run_core', defaultValue: true, description: 'Run core testsuite'),
             booleanParam(name: 'run_secondary', defaultValue: true, description: 'Run secondary testsuite'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
-            extendedChoice(name: 'functional_scopes',  multiSelectDelimiter: ',', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_CHECKBOX', visibleItemCount: 30, value: '@scope_smdba,@scope_spacecmd,@scope_spacewalk_utils,@scope_visualization,@scope_notification_message,@scope_virtual_host_manager,@scope_subscription_matching,@scope_formulas,@scope_sp_migration,@scope_cve_audit,@scope_onboarding,@scope_content_lifecycle_management,@scope_res,@scope_recurring_actions,@scope_maintenance_windows,@scope_building_container_images,@scope_kubernetes_integration,@scope_openscap,@scope_deblike,@scope_rhlike,@scope_action_chains,@scope_salt_ssh,@scope_tomcat,@scope_changing_software_channels,@scope_monitoring,@scope_salt,@scope_cobbler,@scope_sumatoolbox,@scope_virtualization,@scope_hub,@scope_retail,@scope_configuration_channels,@scope_content_staging,@scope_proxy,@scope_traditional_client,@scope_api,@scope_power_management,@scope_retracted_patches,@scope_ansible,@scope_reportdb,@scope_containerized_proxy', description: 'Choose the functional scopes that you want to test')
+            activeChoice(name: 'functional_scopes', description: 'Choose the functional scopes that you want to test', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
+                return [
+                    'scope_smdba', 'scope_spacecmd', 'scope_spacewalk_utils', 'scope_visualization',
+                    'scope_notification_message', 'scope_virtual_host_manager', 'scope_subscription_matching',
+                    'scope_formulas', 'scope_sp_migration', 'scope_cve_audit', 'scope_onboarding',
+                    'scope_content_lifecycle_management', 'scope_res', 'scope_recurring_actions',
+                    'scope_maintenance_windows', 'scope_building_container_images', 'scope_kubernetes_integration',
+                    'scope_openscap', 'scope_deblike', 'scope_rhlike', 'scope_action_chains', 'scope_salt_ssh',
+                    'scope_tomcat', 'scope_changing_software_channels', 'scope_monitoring', 'scope_salt',
+                    'scope_cobbler', 'scope_sumatoolbox', 'scope_virtualization', 'scope_hub', 'scope_retail',
+                    'scope_configuration_channels', 'scope_content_staging', 'scope_proxy',
+                    'scope_traditional_client', 'scope_api', 'scope_power_management',
+                    'scope_retracted_patches', 'scope_ansible'
+                ]
+            """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_scopes']"]])
         ])
     ])
 

--- a/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
@@ -37,7 +37,7 @@ node('sumaform-cucumber') {
                     'scope_cobbler', 'scope_sumatoolbox', 'scope_virtualization', 'scope_hub', 'scope_retail',
                     'scope_configuration_channels', 'scope_content_staging', 'scope_proxy',
                     'scope_traditional_client', 'scope_api', 'scope_power_management',
-                    'scope_retracted_patches', 'scope_ansible'
+                    'scope_retracted_patches', 'scope_ansible', 'scope_reportdb', 'scope_containerized_proxy'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_scopes']"]])
         ])


### PR DESCRIPTION
This partially reverts commit de8e241d360a3c37fdf8b733606fa2835d09896a and ensure `scope_rhlike` is part of `activeChoice`.

The changes introduced by https://github.com/SUSE/susemanager-ci/pull/2127 were actually not correct, as this pipeline is expected to run on a different Jenkins instance that is not causing the previously reported error.