### PR TITLE
Add 5.2 environment for personal pipelines

### DIFF
--- a/terracumber_config/tf_files/personal/main_52.tf
+++ b/terracumber_config/tf_files/personal/main_52.tf
@@ -1,0 +1,170 @@
+variable "CONTAINER_REGISTRY" {
+  type = string
+  description = "Container repository for server and proxy"
+  default = "registry.suse.de"
+}
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://${var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].hypervisor}/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "5.2-nightly"
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  cc_ptf_username = var.SCC_PTF_USER
+  cc_ptf_password = var.SCC_PTF_PASSWORD
+
+  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+
+  ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
+  use_avahi    = false
+  name_prefix   = "${var.ENVIRONMENT}-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  no_auth_registry       = "registry.mgr.suse.de"
+  auth_registry          = "registry.mgr.suse.de:5000/cucutest"
+  auth_registry_username = "cucutest"
+  auth_registry_password = "cucusecret"
+  git_profiles_repo      = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/temporary"
+
+  container_server = true
+  container_proxy  = true
+
+  mirror                   = "minima-mirror-ci-bv.mgr.suse.de"
+  use_mirror_images        = true
+
+  server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
+
+  ## Add extra containers
+  deploy_tftp              = true
+  deploy_saline            = true
+  deploy_coco_attestation  = true
+  deploy_hub_api           = true
+
+  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  host_settings = {
+    controller = {
+      provider_settings = {
+        mac       = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["controller"]
+        vcpu = 4
+        memory = 4096
+      }
+    }
+    server_containerized = {
+      image = "slmicro62o"
+      provider_settings = {
+        mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["server"]
+        vcpu = 8
+        memory = 32768
+      }
+      main_disk_size       = 500
+      login_timeout        = 28800
+      large_deployment     = true
+      runtime              = "podman"
+      container_registry   = var.CONTAINER_REGISTRY
+      container_tag        = "latest"
+
+    }
+    proxy_containerized = {
+      image = "slmicro62o"
+      provider_settings = {
+        mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["proxy"]
+        vcpu = 2
+        memory = 2048
+      }
+      main_disk_size = 200
+      runtime = "podman"
+      container_registry = var.CONTAINER_REGISTRY
+      container_tag = "latest"
+    }
+    suse_minion = {
+      image = "sles15sp7o"
+      provider_settings = {
+        mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["suse-minion"]
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    suse_sshminion = {
+      image = "sles15sp7o"
+      provider_settings = {
+        mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["suse-sshminion"]
+        vcpu = 2
+        memory = 2048
+      }
+      additional_packages = [ "iptables" ]
+    }
+    rhlike_minion = {
+      image = "rocky8o"
+      provider_settings = {
+        mac    = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["rhlike-minion"]
+        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+        // Also, openscap cannot run with less than 1.25 GB of RAM
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    deblike_minion = {
+      image = "ubuntu2404o"
+      provider_settings = {
+        mac = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["deblike-minion"]
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    build_host = {
+      image = "sles15sp7o"
+      provider_settings = {
+        mac    = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["build-host"]
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    pxeboot_minion = {
+      image = "sles15sp7o"
+    }
+    dhcp_dns = {
+      name = "dhcp-dns"
+      image = "opensuse156o"
+      hypervisor = {
+        host        = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].hypervisor
+        user        = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].dhcp_user
+        private_key = file(pathexpand(var.HYPERVISOR_PRIVATE_SSH_KEY_PATH))
+      }
+    }
+  }
+
+  provider_settings = {
+    pool               = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].pool
+    network_name       = null
+    bridge             = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].bridge
+    additional_network = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].additional_network
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}

--- a/terracumber_config/tf_files/personal/main_52.tf
+++ b/terracumber_config/tf_files/personal/main_52.tf
@@ -35,7 +35,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky10o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false
@@ -117,7 +117,7 @@ module "cucumber_testsuite" {
       additional_packages = [ "iptables" ]
     }
     rhlike_minion = {
-      image = "rocky8o"
+      image = "rocky10o"
       provider_settings = {
         mac    = var.ENVIRONMENT_CONFIGURATION[var.ENVIRONMENT].mac["rhlike-minion"]
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM

--- a/terracumber_config/tf_files/personal/main_52.tf
+++ b/terracumber_config/tf_files/personal/main_52.tf
@@ -64,7 +64,6 @@ module "cucumber_testsuite" {
   deploy_coco_attestation  = true
   deploy_hub_api           = true
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
   host_settings = {
     controller = {
       provider_settings = {


### PR DESCRIPTION
Adds `terracumber_config/tf_files/personal/main_52.tf` so personal CI pipelines can deploy a Multi-Linux Manager 5.2 environment, alongside the existing 4.3 / 5.0 / 5.1 / head / uyuni-master options.

The file is a copy of `main_51.tf` with these deltas:

| Setting | main_51.tf | main_52.tf |
| --- | --- | --- |
| `product_version` | `5.1-nightly` | `5.2-nightly` |
| `images`, `server_containerized.image`, `proxy_containerized.image` | `slmicro61o` | `slmicro62o` |
| `images`, `rhlike_minion.image` | `rocky8o` | `rocky10o` |
| `# ... adjust the image matrix at the end of the README` comment | present | dropped |

**Rocky 10:** following review feedback, the rhlike minion runs the newest available RHEL-like client. Note this makes the personal 5.2 environment differ from `MLM-5.2-PRG.tf` and every other acceptance environment, which still pin `rocky8o`.

**Ubuntu stays on 24.04:** sumaform has no `ubuntu2604o` image — its image list tops out at `ubuntu2404o` (noble) in `modules/base/variables.tf` and the libvirt image URL map — so 26.04 is not deployable yet.

**Dropped comment:** no README in this repo (nor in sumaform, current or historical) documents an image matrix, so the note pointed at documentation that does not exist. The same stale line still exists in 20+ sibling `.tf` files including `main_51.tf`; cleaning those up is out of scope here.

Everything else is unchanged: `CONTAINER_REGISTRY = registry.suse.de`, the `deploy_tftp` / `deploy_saline` / `deploy_coco_attestation` / `deploy_hub_api` flags, the cucumber fixture registries, host sizing and the `ENVIRONMENT_CONFIGURATION` lookups. So it works for every personal environment already in `environment.tfvars`, with no new MACs, pools or networks.

No job files change. The personal jobs declare `tf_file` as a free-text parameter, so 5.2 is selected at build time:

- `tf_file` = `susemanager-ci/terracumber_config/tf_files/personal/main_52.tf`
- `cucumber_ref` = `Manager-5.2`

Job defaults stay on 5.1.

Note on the registry: for podman deployments sumaform only passes the registry host into `mgradm.yaml`; the image namespace comes from mgradm itself, and which mgradm gets installed is decided by `product_version` (the `Devel:/Galaxy:/Manager:/5.2:/MLM-Products` repos). That matches how `MLM-5.2-PRG.tf` does it — bare `registry.suse.de`. Per-build overrides remain available via the `container_registry` job parameter.

### Testing

`tofu validate` against a sumaform checkout passes, re-run after each commit including the Rocky 10 bump. A full `tofu plan` needs libvirt and credentials, so the first real check is a personal job run pointed at the new file.