### PR TITLE
Fix image matrix reference in tf files and add 5.2 to the matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,20 @@ image for testing Pull Requests built with the open build service. This needs to
 
 ### In the CI test suite
 
-|             | GitHub PR test| Uyuni         | Head         | 5.1          | 5.0           | 4.3          |
-|-------------|---------------|---------------|--------------|--------------|---------------|--------------|
-| Minion      | Tumbleweed    | Tumbleweed    | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
-| SSH minion  | Tumbleweed    | Tumbleweed    | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
-| Client      | -             | -             | -            | -            | -             | SLES 15 SP4  |
-| RH-like     | Rocky 8       | Rocky 8       | Rocky 8      | Rocky 8      | Rocky 8       | Rocky 8      |
-| Deb-like    | Ubuntu 24.04  | Ubuntu 24.04  | Ubuntu 24.04 | Ubuntu 24.04 | Ubuntu 24.04  | Ubuntu 22.04 |
-| Virthost    | -             | -             | -            | -            | SLES 15 SP7   | SLES 15 SP4  |
-| Buildhost   | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
-| Terminal    | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
-| DHCP-DNS    | Leap 15.6     | Leap 15.6     | Leap 15.6    | Leap 15.6    | Leap 15.6     | -            |
-| Controller  | Leap 15.6     | Leap 15.6     | Leap 15.6    | Leap 15.6    | Leap 15.6     | Leap 15.6    |
-| Server      | Tumbleweed    | Tumbleweed    | SL Micro 6.1 | SL Micro 6.1 | SLE Micro 5.5 | SLES 15 SP4  |
-| Proxy       | Tumbleweed    | Tumbleweed    | SL Micro 6.1 | SL Micro 6.1 | SLE Micro 5.5 | SLES 15 SP4  |
+|             | GitHub PR test| Uyuni         | Head         | 5.2          | 5.1          | 5.0           | 4.3          |
+|-------------|---------------|---------------|--------------|--------------|--------------|---------------|--------------|
+| Minion      | Tumbleweed    | Tumbleweed    | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
+| SSH minion  | Tumbleweed    | Tumbleweed    | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
+| Client      | -             | -             | -            | -            | -            | -             | SLES 15 SP4  |
+| RH-like     | Rocky 8       | Rocky 8       | Rocky 8      | Rocky 8      | Rocky 8      | Rocky 8       | Rocky 8      |
+| Deb-like    | Ubuntu 24.04  | Ubuntu 24.04  | Ubuntu 24.04 | Ubuntu 24.04 | Ubuntu 24.04 | Ubuntu 24.04  | Ubuntu 22.04 |
+| Virthost    | -             | -             | -            | -            | -            | SLES 15 SP7   | SLES 15 SP4  |
+| Buildhost   | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
+| Terminal    | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
+| DHCP-DNS    | Leap 15.6     | Leap 15.6     | Leap 15.6    | Leap 15.6    | Leap 15.6    | Leap 15.6     | -            |
+| Controller  | Leap 15.6     | Leap 15.6     | Leap 15.6    | Leap 15.6    | Leap 15.6    | Leap 15.6     | Leap 15.6    |
+| Server      | Tumbleweed    | Tumbleweed    | SL Micro 6.1 | SL Micro 6.2 | SL Micro 6.1 | SLE Micro 5.5 | SLES 15 SP4  |
+| Proxy       | Tumbleweed    | Tumbleweed    | SL Micro 6.1 | SL Micro 6.2 | SL Micro 6.1 | SLE Micro 5.5 | SLES 15 SP4  |
 
 ### In the full BV test suites
 

--- a/terracumber_config/tf_files/MLM-5.1-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-NUE.tf
@@ -150,7 +150,7 @@ module "cucumber_testsuite" {
   deploy_coco_attestation  = true
   deploy_hub_api           = true
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/MLM-5.1-SLC.tf
+++ b/terracumber_config/tf_files/MLM-5.1-SLC.tf
@@ -144,7 +144,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.slc1.suse.org:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.slc1.suse.org:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/MLM-5.1-refenv-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-refenv-NUE.tf
@@ -140,7 +140,7 @@ module "cucumber_testsuite" {
   # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/MLM-5.2-PRG.tf
+++ b/terracumber_config/tf_files/MLM-5.2-PRG.tf
@@ -156,7 +156,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/MLM-Head-RKE2-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-RKE2-NUE.tf
@@ -158,7 +158,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/MLM-Head-podman-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-podman-NUE.tf
@@ -145,7 +145,7 @@ module "cucumber_testsuite" {
   deploy_coco_attestation  = true
   deploy_hub_api           = true
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
@@ -142,7 +142,7 @@ module "cucumber_testsuite" {
   //server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -120,7 +120,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLC.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLC.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.slc1.suse.org:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.slc1.suse.org:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-refenv-NUE.tf
@@ -122,7 +122,7 @@ module "cucumber_testsuite" {
   # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-NUE.tf
@@ -143,7 +143,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-SLC.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-SLC.tf
@@ -138,7 +138,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.slc1.suse.org:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.slc1.suse.org:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-NUE.tf
@@ -140,7 +140,7 @@ module "cucumber_testsuite" {
   # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-5.0-refenv-SLC.tf
+++ b/terracumber_config/tf_files/SUSEManager-5.0-refenv-SLC.tf
@@ -139,7 +139,7 @@ module "cucumber_testsuite" {
   # server_http_proxy        = "http-proxy.mgr.slc1.suse.org:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.slc1.suse.org:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Main-podman-NUE.tf
@@ -128,7 +128,7 @@ module "cucumber_testsuite" {
   server_http_proxy         = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint  = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-RKE2-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-RKE2-NUE.tf
@@ -138,7 +138,7 @@ module "cucumber_testsuite" {
   # server_http_proxy = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
@@ -131,7 +131,7 @@ module "cucumber_testsuite" {
   # server_http_proxy = "http-proxy.mgr.slc1.suse.org:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.slc1.suse.org:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
@@ -135,7 +135,7 @@ module "cucumber_testsuite" {
   deploy_hub_api           = true
 
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -125,7 +125,7 @@ module "cucumber_testsuite" {
   # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_43.tf
+++ b/terracumber_config/tf_files/personal/main_43.tf
@@ -47,7 +47,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_50.tf
+++ b/terracumber_config/tf_files/personal/main_50.tf
@@ -57,7 +57,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_51.tf
+++ b/terracumber_config/tf_files/personal/main_51.tf
@@ -64,7 +64,7 @@ module "cucumber_testsuite" {
   deploy_coco_attestation  = true
   deploy_hub_api           = true
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_52.tf
+++ b/terracumber_config/tf_files/personal/main_52.tf
@@ -64,6 +64,7 @@ module "cucumber_testsuite" {
   deploy_coco_attestation  = true
   deploy_hub_api           = true
 
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_head.tf
+++ b/terracumber_config/tf_files/personal/main_head.tf
@@ -64,7 +64,7 @@ module "cucumber_testsuite" {
   deploy_coco_attestation  = true
   deploy_hub_api           = true
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_head_staging.tf
+++ b/terracumber_config/tf_files/personal/main_head_staging.tf
@@ -58,7 +58,7 @@ module "cucumber_testsuite" {
   server_http_proxy        = "http-proxy.mgr.suse.de:3128"
   custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_rke2_head.tf
+++ b/terracumber_config/tf_files/personal/main_rke2_head.tf
@@ -71,7 +71,7 @@ module "cucumber_testsuite" {
   install_kubectl_helm           = false
   kubeconfig_path                = null
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_rke2_uyuni.tf
+++ b/terracumber_config/tf_files/personal/main_rke2_uyuni.tf
@@ -69,7 +69,7 @@ module "cucumber_testsuite" {
   install_kubectl_helm           = false
   kubeconfig_path                = null
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/personal/main_uyuni.tf
+++ b/terracumber_config/tf_files/personal/main_uyuni.tf
@@ -62,7 +62,7 @@ module "cucumber_testsuite" {
   deploy_coco_attestation  = true
   deploy_hub_api           = true
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {

--- a/terracumber_config/tf_files/templates/PR-testing.tf
+++ b/terracumber_config/tf_files/templates/PR-testing.tf
@@ -48,7 +48,7 @@ module "cucumber_testsuite" {
   # server_http_proxy = "http-proxy.${var.DOMAIN}:3128"
   custom_download_endpoint = "ftp://${var.DOWNLOAD_ENDPOINT}:445"
 
-  # when changing images, please also keep in mind to adjust the image matrix at the end of the README.
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   host_settings = {
     controller = {
       provider_settings = {


### PR DESCRIPTION
Follow-up to #2137.

## Why

Every `terracumber_config` tf file carries this comment above `host_settings`:

```
# when changing images, please also keep in mind to adjust the image matrix at the end of the README.
```

In #2137 I removed it from `personal/main_52.tf` as stale. **That was wrong** — the table is alive and maintained, and the removal should be reverted.

What actually happened:

- `ee617708` (2022-10-20) added the comment to 16 tf files, three weeks after `5df07d5d` added the table.
- Back then the table *was* the last section of the root README, titled "Used image versions in the CI test suite".
- It has since been retitled to `## Used image versions` + `### In the CI test suite`, and the mini-BV / MI-container / mgradm tables and the whole SLES MI chapter were appended after it.

So the table now sits at line 57 of 200. Only the locator "at the end of the README" is outdated — the instruction itself is not. Searching the README for the word "matrix" finds nothing, which is what makes the comment read as dangling.

## What this PR does

1. **Rewords the comment in all 29 tf files** to point at the section by name rather than by position:

   ```
   # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
   ```

2. **Restores the comment in `personal/main_52.tf`**, undoing the #2137 removal so the file matches the other 28.

3. **Adds the missing 5.2 column** to `### In the CI test suite`. The sections below it (mini BV, MI containers, mgradm/mgrpxy) already have 5.2 columns; this one did not.

## Source of the 5.2 column

The per-version columns describe the CI environment files, not the personal ones — `MLM-5.1-NUE.tf` maps 1:1 onto the existing 5.1 column. So the 5.2 column is taken from `MLM-5.2-PRG.tf`, which is identical to 5.1 except server and proxy:

| Role | 5.1 | 5.2 |
| --- | --- | --- |
| Server | SL Micro 6.1 | **SL Micro 6.2** |
| Proxy | SL Micro 6.1 | **SL Micro 6.2** |
| Minion / SSH minion / Buildhost / Terminal | SLES 15 SP7 | SLES 15 SP7 |
| RH-like | Rocky 8 | Rocky 8 |
| Deb-like | Ubuntu 24.04 | Ubuntu 24.04 |
| DHCP-DNS / Controller | Leap 15.6 | Leap 15.6 |

Note RH-like stays **Rocky 8** here. `personal/main_52.tf` uses Rocky 10, but that is the personal env only and this table tracks the CI envs.

## Testing

- Every `.tf` hunk is comment-only — verified by filtering the diff: nothing but `# when changing images` lines changes.
- `tofu validate` on `personal/main_52.tf` against a local sumaform checkout: `Success! The configuration is valid.`
- `tofu fmt -check` reports the same 29 pre-existing deviations before and after, so no new formatting drift.