### PR TITLE
Point 5.2 MI validation jobs at ToTest container registry

### DIFF
--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
@@ -16,6 +16,10 @@ node('sumaform-cucumber') {
             activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [ 'sles15sp7_minion:selected' ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
+            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
+            // maintenance update (5.2.1) is published. Revert both registries below to
+            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
+            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
@@ -16,8 +16,8 @@ node('sumaform-cucumber') {
             activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [ 'sles15sp7_minion:selected' ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Proxy container registry'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
@@ -16,6 +16,10 @@ node('sumaform-cucumber') {
             activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [ 'sles15sp7_minion:selected' ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
+            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
+            // maintenance update (5.2.1) is published. Revert both registries below to
+            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
+            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
@@ -16,8 +16,8 @@ node('sumaform-cucumber') {
             activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [ 'sles15sp7_minion:selected' ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Proxy container registry'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),


### PR DESCRIPTION
## Problem

Both 5.2 MI validation jobs failed on their first run in Jenkins:

- [manager-5.2-qe-mi-validation-mgrtools #1](https://jenkins.mgr.suse.de/view/By%20Functionality/view/SLEMu/job/manager-5.2-qe-mi-validation-mgrtools/1/console)
- [manager-5.2-qe-mi-validation-bci #1](https://jenkins.mgr.suse.de/view/By%20Functionality/view/SLEMu/job/manager-5.2-qe-mi-validation-bci/1/console)

Identical cause in both — `mgradm install podman` could not pull the server image:

```
Error: initializing source docker://registry.suse.de/suse/sle-15-sp7/update/products/
  multilinuxmanager52/update/containerfile/suse/multi-linux-manager/5.2/x86_64/server:latest
  ... reading manifest latest ...: name unknown
```

Everything downstream (`uyuni container is not accessible with one of podman, podman-remote or kubectl`, the `mgrctl cp` failures) is fallout — the container was never created.

## Why

The defaults were copied from the 5.1 jobs, which point at the released-product `:Update` container repository. That repository does not exist for 5.2 yet.

The `:Update` repo is only created with the **first maintenance update after GA**, not at GA itself. Verified against `registry.suse.de`:

| Repository | Tags |
|---|---|
| 5.2 `:ToTest` | `5.2.0`, `5.2.0.9.15`, `latest` |
| 5.2 `:Update` | `NAME_UNKNOWN` |
| 5.1 `:ToTest` | `5.1.0`, `5.1.0.6.40`, `latest` — frozen at GM |
| 5.1 `:Update` | `5.1.1` … `5.1.4`, `latest` — starts at `.1` |
| 5.0 `:Update` | `5.0.1` … `5.0.5` — starts at `.1` |

Neither 5.1 nor 5.0 ever published an `x.y.0` under `:Update`.

## Change

Switch `server_container_registry` and `proxy_container_registry` defaults in both jobs from `.../multilinuxmanager52/update/containerfile` to `.../multilinuxmanager52/totest/containerfile`. Four lines, two files, no other changes.

An inline `// WORKAROUND:` comment above the two parameters in each file records the `:Update` path to restore and links the tracking issue, so the temporary switch is visible in the source and not only here.

The ToTest repository carries the complete image set required by these environments, all at `5.2.0` / `latest`:

`server`, `server-postgresql`, `proxy-httpd`, `proxy-salt-broker`, `proxy-squid`, `proxy-ssh`, `proxy-tftpd`

## Scope and caveats

This makes the jobs runnable so the environment plumbing — tfvars, MACs, DHCP reservations, hostnames, `prg2` location, minion bootstrap — can be validated. It is **not** real maintenance-update validation: ToTest carries the 5.2.0 GM candidate, and no 5.2 maintenance updates exist yet to validate against.

**This is temporary and must be reverted.** Once 5.2.1 is published, `:Update` becomes the correct target and the ToTest repo may be removed entirely — 5.0's ToTest repo is already gone (`NAME_UNKNOWN`), so leaving this in place indefinitely would break the jobs a second time.

The `bci` job's `container_project` / `mi_project` override path is unaffected: when both are set, `pipeline-build-validation.groovy` replaces the registry with the `Devel:Galaxy:Manager:MUTesting:5.2` path regardless of these defaults. That project does not exist yet either — tracked in SUSE/spacewalk#31400.

Revert tracked in SUSE/spacewalk#31401.

