### PR TITLE
Add the 5.2 reference environment job on the new Jenkins

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
@@ -9,58 +9,94 @@ def run(params) {
             env.common_params = "${env.common_params} --parallelism ${params.deploy_parallelism}"
         }
 
-        try {
-            stage('Clone terracumber, susemanager-ci and sumaform') {
-                // Create a directory for  to place the directory with the build results (if it does not exist)
-                sh "mkdir -p ${resultdir}"
-                git url: params.terracumber_gitrepo, branch: params.terracumber_ref
-                dir("susemanager-ci") {
-                    checkout scm
-                }
-                // Clone sumaform
-                sh "set +x; source /home/jenkins/.credentials set -x; ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync"
-
-                // Restore Terraform states from artifacts
-                if (params.use_previous_terraform_state) {
-                    copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
-                }
+        // The new Jenkins has no /home/jenkins/.credentials on its agents: the same content
+        // is provided by the sumaform-secrets credential and sourced from a temporary file.
+        def isNewJenkins = env.JENKINS_URL?.contains('jenkins.mgr.suse.de')
+        def credInit = isNewJenkins
+                ? 'set +x; credFile=$(mktemp); echo "$SECRET_CONTENT" > "${credFile}"; chmod 600 "${credFile}"; . "${credFile}"; rm -f "${credFile}"; set -x'
+                : 'set +x; . /home/jenkins/.credentials; set -x'
+        def withCreds = { Closure body ->
+            if (isNewJenkins) {
+                withCredentials([string(credentialsId: 'sumaform-secrets', variable: 'SECRET_CONTENT')]) { body() }
+            } else {
+                body()
             }
-            stage('Deploy') {
-                // Provision the environment
-                if (params.terraform_init) {
-                    env.TERRAFORM_INIT = '--init'
-                } else {
-                    env.TERRAFORM_INIT = ''
-                }
-                env.TERRAFORM_TAINT = ''
-                if (params.terraform_taint) {
-                    switch(params.sumaform_backend) {
-                        case "libvirt":
-                            env.TERRAFORM_TAINT = " --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
-                            break;
-                        case "aws":
-                            env.TERRAFORM_TAINT = " --taint '.*(host).*'";
-                            break;
-                        default:
-                            println("ERROR: Unknown backend ${params.sumaform_backend}");
-                            sh "exit 1";
-                            break;
+        }
+
+        try {
+            withCreds {
+                stage('Clone terracumber, susemanager-ci and sumaform') {
+                    // Create a directory for  to place the directory with the build results (if it does not exist)
+                    sh "mkdir -p ${resultdir}"
+                    git url: params.terracumber_gitrepo, branch: params.terracumber_ref
+                    dir("susemanager-ci") {
+                        checkout scm
+                    }
+                    // Clone sumaform
+                    sh """
+                        #!/bin/bash
+                        ${credInit}
+                        ./terracumber-cli ${common_params} --gitrepo ${params.sumaform_gitrepo} --gitref ${params.sumaform_ref} --runstep gitsync
+                    """
+
+                    // Restore Terraform states from artifacts
+                    if (params.use_previous_terraform_state) {
+                        copyArtifacts projectName: currentBuild.projectName, selector: specific("${currentBuild.previousBuild.number}")
                     }
                 }
-                sh "set +x; source /home/jenkins/.credentials set -x; export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}; export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}; export TERRAFORM=${params.bin_path}; export TERRAFORM_PLUGINS=${params.bin_plugins_path}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} ${env.TERRAFORM_TAINT} --sumaform-backend ${params.sumaform_backend} --runstep provision"
-                deployed = true
-            }
-            stage('Core - Setup') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:core'"
-            }
-            stage('Core - Reposync') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reference_reposync'"
-            }
-            stage('Core - Proxy') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:proxy'"
-            }
-            stage('Core - Initialize clients') {
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:reference_init_clients'"
+                stage('Deploy') {
+                    // Provision the environment
+                    if (params.terraform_init) {
+                        env.TERRAFORM_INIT = '--init'
+                    } else {
+                        env.TERRAFORM_INIT = ''
+                    }
+                    env.TERRAFORM_TAINT = ''
+                    if (params.terraform_taint) {
+                        switch(params.sumaform_backend) {
+                            case "libvirt":
+                                env.TERRAFORM_TAINT = " --taint '.*(domain|combustion_disk|cloudinit_disk|ignition_disk|main_disk|data_disk|database_disk|standalone_provisioning).*'";
+                                break;
+                            case "aws":
+                                env.TERRAFORM_TAINT = " --taint '.*(host).*'";
+                                break;
+                            default:
+                                println("ERROR: Unknown backend ${params.sumaform_backend}");
+                                sh "exit 1";
+                                break;
+                        }
+                    }
+                    if (isNewJenkins) {
+                        sh """
+                            sed -i '/HYPERVISOR_PRIVATE_SSH_KEY_PATH/d' ${resultdir}/sumaform/terraform.tfvars 2>/dev/null || true
+                            sed -i '/CONTROLLER_PUBLIC_SSH_KEY_PATH/d' ${resultdir}/sumaform/terraform.tfvars 2>/dev/null || true
+                            echo 'HYPERVISOR_PRIVATE_SSH_KEY_PATH="/home/jenkins/.ssh/id_ed25519.worker"' >> ${resultdir}/sumaform/terraform.tfvars
+                            echo 'CONTROLLER_PUBLIC_SSH_KEY_PATH="/home/jenkins/.ssh/id_ed25519.pub.controller"' >> ${resultdir}/sumaform/terraform.tfvars
+                        """
+                    }
+                    sh """
+                        #!/bin/bash
+                        ${credInit}
+                        export TF_VAR_CUCUMBER_GITREPO=${params.cucumber_gitrepo}
+                        export TF_VAR_CUCUMBER_BRANCH=${params.cucumber_ref}
+                        export TERRAFORM=${params.bin_path}
+                        export TERRAFORM_PLUGINS=${params.bin_plugins_path}
+                        ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/sumaform.log ${env.TERRAFORM_INIT} ${env.TERRAFORM_TAINT} --sumaform-backend ${params.sumaform_backend} --runstep provision
+                    """
+                    deployed = true
+                }
+                stage('Core - Setup') {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:core'"
+                }
+                stage('Core - Reposync') {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reference_reposync'"
+                }
+                stage('Core - Proxy') {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:proxy'"
+                }
+                stage('Core - Initialize clients') {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:reference_init_clients'"
+                }
             }
         }
         finally {

--- a/jenkins_pipelines/environments/manager-5.2-infra-reference
+++ b/jenkins_pipelines/environments/manager-5.2-infra-reference
@@ -1,0 +1,34 @@
+#!/usr/bin/env groovy
+
+node('sumaform-cucumber') {
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3')),
+        disableConcurrentBuilds(),
+        pipelineTriggers([cron('H 3 * * *')]),
+        parameters([
+            string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/SUSE/spacewalk.git', description: 'Testsuite Git Repository'),
+            string(name: 'cucumber_ref', defaultValue: 'Manager-5.2', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf', description: 'Path to the tf file to be used'),
+            string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
+            string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),
+            choice(name: 'sumaform_backend', choices: ['libvirt'], description: 'Sumaform backend to be used (see https://github.com/uyuni-project/sumaform#backend-choice)'),
+            choice(name: 'bin_path', choices: ['/usr/bin/tofu'], description: 'Binary path'),
+            choice(name: 'bin_plugins_path', choices: ['/usr/bin'], description: 'Plugins path'),
+            string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
+            string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
+            string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
+            booleanParam(name: 'terraform_init', defaultValue: true, description: 'Call terraform init (needed if modules are added or changes)'),
+            booleanParam(name: 'terraform_taint', defaultValue: true, description: 'Call terraform taint (so the resources, except volumes, are recreated)'),
+            booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
+            choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)')
+        ])
+    ])
+
+    stage('Checkout pipeline') {
+        checkout scm
+    }
+    timeout(activity: false, time: 14, unit: 'HOURS') {
+        def pipeline = load "jenkins_pipelines/environments/common/pipeline-reference-new.groovy"
+        pipeline.run(params)
+    }
+}

--- a/terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf
+++ b/terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf
@@ -1,0 +1,243 @@
+// Mandatory variables for terracumber
+variable "URL_PREFIX" {
+  type = string
+  default = "https://jenkins.mgr.suse.de/job/manager-5.2-infra-reference"
+}
+
+// Not really used as this is for --runall parameter, and we run cucumber step by step
+variable "CUCUMBER_COMMAND" {
+  type = string
+  default = "export PRODUCT='SUSE-Manager' && run-testsuite"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_GITREPO" {
+  type = string
+  default = "https://github.com/SUSE/spacewalk.git"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_BRANCH" {
+  type = string
+  default = "Manager-5.2"
+}
+
+// Not really used in this pipeline, as we do not run cucumber
+variable "CUCUMBER_RESULTS" {
+  type = string
+  default = "/root/spacewalk/testsuite"
+}
+
+// Not really used in this pipeline, as we do not send emails on success (no cucumber results)
+variable "MAIL_SUBJECT" {
+  type = string
+  default = "Results REF5.2-PRG $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"
+}
+
+variable "MAIL_TEMPLATE" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins.txt"
+}
+
+variable "MAIL_SUBJECT_ENV_FAIL" {
+  type = string
+  default = "Results REF5.2-PRG: Environment setup failed"
+}
+
+variable "MAIL_TEMPLATE_ENV_FAIL" {
+  type = string
+  default = "../mail_templates/mail-template-jenkins-refenv-fail.txt"
+}
+
+variable "MAIL_FROM" {
+  type = string
+  default = "jenkins@suse.de"
+}
+
+variable "MAIL_TO" {
+  type = string
+  default = "galaxy-ci@suse.de"
+}
+
+// sumaform specific variables
+variable "SCC_USER" {
+  type = string
+}
+
+variable "SCC_PASSWORD" {
+  type = string
+}
+
+variable "SCC_PTF_USER" {
+  type = string
+  default = null
+  // Not needed for master, as PTFs are only build for SUSE Manager / MLM
+}
+
+variable "SCC_PTF_PASSWORD" {
+  type = string
+  default = null
+  // Not needed for master, as PTFs are only build for SUSE Manager / MLM
+}
+
+variable "GIT_USER" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+variable "GIT_PASSWORD" {
+  type = string
+  default = null // Not needed for master, as it is public
+}
+
+// Both paths are written to terraform.tfvars by the pipeline when running on
+// jenkins.mgr.suse.de, where the keys live in the agent home instead of sumaform
+variable "CONTROLLER_PUBLIC_SSH_KEY_PATH" {
+  type = string
+  default = "./salt/controller/id_ed25519.pub"
+}
+
+variable "HYPERVISOR_PRIVATE_SSH_KEY_PATH" {
+  type = string
+  default = "~/.ssh/id_ed25519"
+}
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.3"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+tcp://suma-02.mgr.suse.de/system"
+}
+
+module "cucumber_testsuite" {
+  source = "./modules/cucumber_testsuite"
+
+  product_version = "5.2-nightly"
+
+  // Cucumber repository configuration for the controller
+  git_username = var.GIT_USER
+  git_password = var.GIT_PASSWORD
+  git_repo     = var.CUCUMBER_GITREPO
+  branch       = var.CUCUMBER_BRANCH
+
+  cc_username = var.SCC_USER
+  cc_password = var.SCC_PASSWORD
+
+  cc_ptf_username = var.SCC_PTF_USER
+  cc_ptf_password = var.SCC_PTF_PASSWORD
+
+  ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
+
+  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+
+  use_avahi    = false
+  name_prefix  = "mlm-ref-52-"
+  domain       = "mgr.suse.de"
+  from_email   = "root@suse.de"
+
+  no_auth_registry       = "registry.mgr.suse.de"
+  auth_registry          = "registry.mgr.suse.de:5000/cucutest"
+  auth_registry_username = "cucutest"
+  auth_registry_password = "cucusecret"
+  git_profiles_repo      = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/temporary"
+
+  container_server = true
+  container_proxy  = true
+
+  # server_http_proxy        = "http-proxy.mgr.suse.de:3128"
+  custom_download_endpoint = "ftp://minima-mirror-ci-bv.mgr.suse.de:445"
+
+  # when changing images, please also keep in mind to adjust the image matrix in the "Used image versions" section of the README.
+  host_settings = {
+    controller = {
+      provider_settings = {
+        mac = "aa:b2:93:01:02:f0"
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    server_containerized = {
+      image = "slmicro62o"
+      provider_settings = {
+        mac = "aa:b2:93:01:02:f1"
+        vcpu = 4
+        memory = 16384
+      }
+      main_disk_size = 500
+      login_timeout = 28800
+      runtime = "podman"
+      container_registry = "registry.suse.de"
+      container_tag = "latest"
+    }
+    proxy_containerized = {
+      image = "slmicro62o"
+      provider_settings = {
+        mac = "aa:b2:93:01:02:f2"
+        vcpu = 2
+        memory = 2048
+      }
+      main_disk_size = 200
+      runtime = "podman"
+      container_registry = "registry.suse.de"
+      container_tag = "latest"
+    }
+    suse_minion = {
+      image = "sles15sp7o"
+      provider_settings = {
+        mac = "aa:b2:93:01:02:f6"
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    suse_sshminion = {
+      image = "sles15sp7o"
+      provider_settings = {
+        mac = "aa:b2:93:01:02:f8"
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    rhlike_minion = {
+      image = "rocky8o"
+      provider_settings = {
+        mac = "aa:b2:93:01:02:f9"
+        // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM
+        // Also, openscap cannot run with less than 1.25 GB of RAM
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    deblike_minion = {
+      image = "ubuntu2404o"
+      provider_settings = {
+        mac = "aa:b2:93:01:02:fb"
+        vcpu = 2
+        memory = 2048
+      }
+    }
+    build_host = {
+      image = "sles15sp7o"
+      provider_settings = {
+        mac = "aa:b2:93:01:02:fd"
+        vcpu = 2
+        memory = 2048
+      }
+    }
+  }
+  provider_settings = {
+    pool = "ssd"
+    network_name = null
+    bridge = "br1"
+  }
+}
+
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}


### PR DESCRIPTION
## What

Adds a 5.2 reference environment job that runs on the new Jenkins
(`jenkins.mgr.suse.de`), equivalent to `manager-5.1-infra-reference-NUE` on
ci.suse.de.

## Changes

- **`terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf`** (new) — copy of
  `MLM-5.1-refenv-NUE.tf` adapted to 5.2: `product_version = "5.2-nightly"`,
  `slmicro62o` for server and proxy, `name_prefix = "mlm-ref-52-"`, the already
  reserved `aa:b2:93:01:02:f0`–`fd` MACs on vlan2509 (`bridge = "br1"`), and
  `CONTROLLER_PUBLIC_SSH_KEY_PATH` / `HYPERVISOR_PRIVATE_SSH_KEY_PATH`
  variables so the new Jenkins can point at the keys in the agent home.
- **`jenkins_pipelines/environments/manager-5.2-infra-reference`** (new) —
  the job definition, testsuite branch `Manager-5.2`, backend `libvirt`,
  `/usr/bin/tofu`, nightly `H 3 * * *` trigger.
- **`jenkins_pipelines/environments/common/pipeline-reference-new.groovy`** —
  the new Jenkins has no `/home/jenkins/.credentials` on its agents, so this
  ports the mechanism already used by `common/pipeline.groovy` (commit
  71900b44): detect `JENKINS_URL`, source the `sumaform-secrets` credential
  from a temporary file and write the ssh key paths into `terraform.tfvars`.
  The ci.suse.de path is unchanged, so the 4.3 / 5.0 / 5.1 / Head / Uyuni
  reference jobs are not affected.

## Notes

- DHCP and DNS entries for `mlm-ref-52-*` already exist, so no infrastructure
  change is required.
- The registry stays plain `registry.suse.de`: the ToTest registry workaround
  applies to `-released` maintenance update deployments, while this is a
  nightly environment.

## Testing

- `tofu validate` passes against the sumaform modules.
- The tf file was diffed against `MLM-5.1-refenv-NUE.tf` to confirm only the
  intended differences.
- The job still has to be created on jenkins.mgr.suse.de and added to the
  By Functionality → Reference view before the first run.
