### PR TITLE
Fix TAGS quoting so multi-scope secondary runs work

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -146,7 +146,9 @@ def run(params) {
                                     .collect { it.trim() }
                                     .collect { it.startsWith('@') ? it : "@${it}" }
                                     .join(' or ')
-                            tags_list = "export TAGS='${transformed_scopes}'; "
+                            // --cucumber-cmd below is single-quoted, and rake re-splits TAGS through a
+                            // shell, so the value carries its own quotes rather than nesting single ones.
+                            tags_list = "export TAGS=\"\\\"${transformed_scopes}\\\"\"; "
                         }
 
                         def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true

--- a/jenkins_pipelines/environments/common/pipeline-rke2.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-rke2.groovy
@@ -101,7 +101,9 @@ def run(params) {
                                     .collect { it.trim() }
                                     .collect { it.startsWith('@') ? it : "@${it}" }
                                     .join(' or ')
-                            tags_list = "export TAGS='${transformed_scopes}'; "
+                            // --cucumber-cmd below is single-quoted, and rake re-splits TAGS through a
+                            // shell, so the value carries its own quotes rather than nesting single ones.
+                            tags_list = "export TAGS=\"\\\"${transformed_scopes}\\\"\"; "
                         }
 
                         def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -208,7 +208,9 @@ def run(params) {
                                         .collect { it.trim() }
                                         .collect { it.startsWith('@') ? it : "@${it}" }
                                         .join(' or ')
-                                tags_list = "export TAGS=\"${transformed_scopes}\"; "
+                                // --cucumber-cmd below is single-quoted, and rake re-splits TAGS through a
+                                // shell, so the value carries its own quotes rather than nesting single ones.
+                                tags_list = "export TAGS=\"\\\"${transformed_scopes}\\\"\"; "
                             }
                             def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true
                             def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -121,7 +121,9 @@ node('sumaform-cucumber-slc1') {
                 def tags_list = ""
                 if (params.functional_scopes) {
                     def transformed_scopes = params.functional_scopes.replaceAll(',', ' or ')
-                    tags_list += "export TAGS=${transformed_scopes}; "
+                    // --cucumber-cmd below is single-quoted, and rake re-splits TAGS through a
+                    // shell, so the value carries its own quotes rather than nesting single ones.
+                    tags_list += "export TAGS=\"\\\"${transformed_scopes}\\\"\"; "
                 }
                 def statusCode1 = sh script:"./terracumber-cli ${common_params} ${cucumber_cmd} '${tags_list} cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
                 def statusCode2 = sh script:"./terracumber-cli ${common_params} ${cucumber_cmd} '${tags_list} cd /root/spacewalk/testsuite; rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus:true


### PR DESCRIPTION
## What

`tags_list` is interpolated into a `--cucumber-cmd` argument that is itself wrapped in single quotes, and the scopes are joined with `' or '` — so the value contains spaces:

```groovy
tags_list = "export TAGS='${transformed_scopes}'; "
...
sh script: "./terracumber-cli ... --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ... rake cucumber:secondary'"
```

Two shells then get a say in how that splits, and both need handling.

**Outer layer, on the Jenkins agent.** Single quotes do not nest. The shell closes the quote at `TAGS='`, and the rest word-splits into separate argv entries:

```
terracumber-cli: error: unrecognized arguments: or @scope_spacecmd or @scope_spacewalk_utils or ...
+ exit 2
```

**Inner layer, on the controller.** The testsuite Rakefile reads `TAGS` into the cucumber command line. The `cucumber:` namespace builds it as an array:

```ruby
tags = ENV.fetch('TAGS', nil)
include_tags = tags.nil? ? [] : ['--tags', tags]
```

but `Cucumber::Rake::Task`'s forked runner joins that array back into a single shell string — visible in any console log as one flat `bundle exec cucumber ... --tags @scope_x features/...` line. The `parallel:` namespace interpolates `"--tags #{tags}"` into a string directly. Either way a bare `@a or @b` splits a second time, so the value keeps an embedded pair of quotes and cucumber receives the tag expression as one argument.

## Precedent

`uyuni-prs-ci-tests` already builds `TAGS` in exactly this form:

```groovy
secondary_exports += "export TAGS=\"\\\"(${transformed_scopes}) and not @flaky\\\"\"; "
```

and feeds it into a single-quoted `--cucumber-cmd` in `pipeline-pull-request.groovy` — the same shape, and the only caller that has been running multi-scope without trouble. This brings the rest in line with it.

## Why it is rarely seen

`functional_scopes` has no `defaultValue`, so it is normally empty and no `export TAGS` is emitted at all. A single scope contains no spaces, so it cannot word-split either. Two or more always break.

Observed in [manager-5.2-dev-acceptance-tests #113](https://jenkins.mgr.suse.de/view/By%20Functionality/view/CI/job/manager-5.2-dev-acceptance-tests/113/consoleFull), the first run to select the full scope list — all three secondary rake calls died within a second of each other, zero tests run.

| build | functional_scopes | secondary |
|---|---|---|
| 110 | absent | ok |
| 111 | `scope_smdba` (single, no spaces) | ok |
| 112 | empty | ok |
| 113 | 39 scopes | **failed before any test** |

It is not 5.2-specific — 4.3, 5.0 and 5.1 load the same `common/pipeline.groovy` and have simply never run with more than one scope.

## Scope

Every file that builds a `TAGS` export:

- `common/pipeline.groovy` — used by 4.3 / 5.0 / 5.1 / 5.2 / Head / TEST-\* jobs. Its outer layer was fixed by c1ef3875; this adds the inner one.
- `common/pipeline-rke2.groovy` — nested single quotes.
- `common/pipeline-personal.groovy` — nested single quotes.
- `uyuni-master-dev-acceptance-tests-code-coverage` — no quoting at all.

`uyuni-prs-ci-tests` is already correct and is left alone. The ~35 files under `environments/` only declare the `functional_scopes` parameter and delegate to one of the above.

## Related

`pipeline-personal.groovy` had a second problem in the same stage, the Groovy sandbox rejecting its base64 command encoding; fixed in #2170, which is merged.

## Testing

Tested on [ktsamis-personal-pipeline #29](https://ci.suse.de/view/Manager/view/Manager-qe/job/ktsamis-personal-pipeline/29/consoleFull) with `@scope_visualization` and `@scope_salt` selected. All three secondary rake calls got `--tags "@scope_visualization or @scope_salt"` as one argument and ran 324 scenarios; the 31 features carrying either tag on `Manager-5.2` all ran, and nothing else did. Before the fix the same job died with `unrecognized arguments`.

`secondary_finishing` reports `0 scenarios` because none of the four `finishing/` features carry a `@scope_` tag - unrelated, tracked in https://github.com/SUSE/spacewalk/issues/31564.
