### PR TITLE
Point 5.2 build validation jobs at ToTest container registry

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
@@ -18,8 +18,12 @@ node('sumaform-cucumber') {
                     'sles15sp7_minion:selected'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Proxy container registry'),
+            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
+            // maintenance update (5.2.1) is published. Revert both registries below to
+            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
+            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),

--- a/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
@@ -37,8 +37,12 @@ node('sumaform-cucumber') {
                     'slmicro60_minion:selected', 'slmicro61_minion:selected', 'slmicro62_minion:selected'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Proxy container registry'),
+            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
+            // maintenance update (5.2.1) is published. Revert both registries below to
+            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
+            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP
@@ -37,8 +37,12 @@ node('sumaform-cucumber-slc1') {
                     'slmicro60_minion:selected', 'slmicro61_minion:selected', 'slmicro62_minion:selected'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Proxy container registry'),
+            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
+            // maintenance update (5.2.1) is published. Revert both registries below to
+            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
+            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation
@@ -21,8 +21,12 @@ node('sumaform-cucumber') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Proxy container registry'),
+            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
+            // maintenance update (5.2.1) is published. Revert both registries below to
+            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
+            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
@@ -39,8 +39,12 @@ node('sumaform-cucumber') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile', description: 'Proxy container registry'),
+            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
+            // maintenance update (5.2.1) is published. Revert both registries below to
+            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
+            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),


### PR DESCRIPTION
## Problem

The 5.2 build validation pipelines pull the server and proxy containers from the released-product `:Update` repository:

```
registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
```

That repository does not exist for 5.2, so `mgradm install podman` fails with `reading manifest latest ...: name unknown` — the same failure the 5.2 MI validation jobs hit in SUSE/susemanager-ci#2142.

## Why

The `:Update` repo is only created with the **first maintenance update after GA**, not at GA itself. Verified against `registry.suse.de` today:

| Repository | Tags |
|---|---|
| 5.2 `:ToTest` | `5.2.0`, `5.2.0.9.15`, `latest` |
| 5.2 `:Update` | `NAME_UNKNOWN` |

5.1 starts at `5.1.1` and 5.0 at `5.0.1` — neither ever published an `x.y.0` under `:Update`.

## Change

Switch `server_container_registry` and `proxy_container_registry` defaults from `.../multilinuxmanager52/update/containerfile` to `.../multilinuxmanager52/totest/containerfile` in all five 5.2 build validation pipelines. Ten lines, five files, no other changes:

- `jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation` — prg2, `mlm52_sles_build_validation_prg.tfvars`
- `jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP` — slc1, `mlm52_sles_build_validation_slc.tfvars`
- `jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation`
- `jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation`
- `jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation`

An inline `// WORKAROUND:` comment above the two parameters in each file records the `:Update` path to restore and links the tracking issue, matching what SUSE/susemanager-ci#2142 did for the MI validation jobs.

The ToTest repository carries the complete image set these environments need, all at `5.2.0` / `latest`:

| Image | Tags |
|---|---|
| `server` | `5.2.0`, `5.2.0.9.15`, `latest` |
| `server-postgresql` | `5.2.0`, `5.2.0.9.6`, `latest` |
| `proxy-httpd` | `5.2.0`, `5.2.0.7.10`, `latest` |
| `proxy-salt-broker` | `5.2.0`, `5.2.0.7.8`, `latest` |
| `proxy-squid` | `5.2.0`, `5.2.0.7.7`, `latest` |
| `proxy-ssh` | `5.2.0`, `5.2.0.7.7`, `latest` |
| `proxy-tftpd` | `5.2.0`, `5.2.0.7.7`, `latest` |

## Scope and caveats

These are pipeline parameter defaults only — a manually triggered build can still override either registry from the Jenkins UI.

**This is temporary and must be reverted.** Once 5.2.1 is published, `:Update` becomes the correct target and the ToTest repo may be removed entirely — 5.0's ToTest repo is already gone (`NAME_UNKNOWN`), so leaving this in place indefinitely would break the jobs a second time.

Revert tracked in SUSE/spacewalk#31401, which lists all seven affected files (these five plus the two MI validation pipelines).

## Related

- SUSE/susemanager-ci#2142 — the same switch for the two 5.2 MI validation jobs
- SUSE/spacewalk#31401 — the revert card
