### PR TITLE
Fix bug with active choice when run in schedule

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -194,7 +194,6 @@ def run(params) {
                 }
                 stage('Secondary features') {
                     if (runSecondary) {
-                        println "DEBUG functional_scopes raw value: '${params.functional_scopes}'"
                         def tags_list = ""
                         if (params.functional_scopes) {
                             // Re-add the @ prefix stripped from the job parameters
@@ -206,10 +205,6 @@ def run(params) {
                                     .join(' or ')
                             tags_list = "export TAGS=\"${transformed_scopes}\"; "
                         }
-
-                        println "DEBUG tags_list value: '${tags_list}'"
-                        def cmd1 = "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'"
-                        println "DEBUG cmd1: ${cmd1}"
                         def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true
                         def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true
                         def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -2,8 +2,8 @@ def run(params) {
     timestamps {
         // Null-safe defaults for optional stage-control parameters (backward compat with env files that don't declare them)
         def runDeploy    = params.deploy    == null ? true : params.deploy
-        def runCore      = params.core      == null ? true : params.core
-        def runSecondary = params.secondary == null ? true : params.secondary
+        def runCore      = params.run_core      == null ? true : params.run_core
+        def runSecondary = params.run_secondary == null ? true : params.run_secondary
 
         // Init path env variables
         GString resultdir = "${env.WORKSPACE}/results"
@@ -194,6 +194,7 @@ def run(params) {
                 }
                 stage('Secondary features') {
                     if (runSecondary) {
+                        println "DEBUG functional_scopes raw value: '${params.functional_scopes}'"
                         def tags_list = ""
                         if (params.functional_scopes) {
                             // Re-add the @ prefix stripped from the job parameters
@@ -203,9 +204,12 @@ def run(params) {
                                     .collect { it.trim() }
                                     .collect { it.startsWith('@') ? it : "@${it}" }
                                     .join(' or ')
-                            tags_list = "export TAGS='${transformed_scopes}'; "
+                            tags_list = "export TAGS=\"${transformed_scopes}\"; "
                         }
 
+                        println "DEBUG tags_list value: '${tags_list}'"
+                        def cmd1 = "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'"
+                        println "DEBUG cmd1: ${cmd1}"
                         def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true
                         def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true
                         def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true

--- a/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-5.2-dev-acceptance-tests
@@ -25,7 +25,7 @@ node('sumaform-cucumber') {
             booleanParam(name: 'run_core', defaultValue: true, description: 'Run core testsuite'),
             booleanParam(name: 'run_secondary', defaultValue: true, description: 'Run secondary testsuite'),
             choice(name: 'rake_namespace', choices: ['cucumber', 'parallel'], description: 'Choose [parallel] (Clients and some features will run in parallel) or [cucumber] (all sequential)'),
-            activeChoice(name: 'functional_scopes', description: 'Choose the functional scopes that you want to test', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
+            activeChoice(name: 'functional_scopes', description: 'Choose the functional scopes that you want to test', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: false, script: """
                 return [
                     'scope_smdba', 'scope_spacecmd', 'scope_spacewalk_utils', 'scope_visualization',
                     'scope_notification_message', 'scope_virtual_host_manager', 'scope_subscription_matching',


### PR DESCRIPTION
## What does this PR ?

 - Fix parameter declaration for run secondary and core
 - change active choice sandbox from true to false for the bug https://github.com/jenkinsci/active-choices-plugin/issues/901
 
Root cause: Active Choices PT_CHECKBOX with sandbox: true doesn't run its JavaScript on cron builds (no browser), so the plugin falls back to the first list item (scope_smdba) as the parameter value