### PR TITLE
Switch the 5.2 reference environment to Rocky 10

### DIFF
--- a/terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf
+++ b/terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf
@@ -135,7 +135,7 @@ module "cucumber_testsuite" {
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
 
-  images = ["rocky8o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky10o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ref-52-"
@@ -205,7 +205,7 @@ module "cucumber_testsuite" {
       }
     }
     rhlike_minion = {
-      image = "rocky8o"
+      image = "rocky10o"
       provider_settings = {
         mac = "aa:b2:93:01:02:f9"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM


### PR DESCRIPTION
## What does this PR change?

Switches the RH-like client of the 5.2 reference environment from Rocky 8 to
Rocky 10, in both the `images` list and `rhlike_minion` of
`MLM-5.2-refenv-PRG.tf`.

## Why?

`manager-5.2-infra-reference` build #2 failed with:

```
Error: context deadline exceeded
  with module.cucumber_testsuite.module.base.module.base_backend.libvirt_volume.volumes["rocky8o"]
```

after 23 minutes of "Still creating". The other four volumes were created in
5-47 seconds. Reference environments deliberately do not use the internal
mirror, so base images are downloaded from their upstream location: the Rocky 8
generic cloud image is 2.0 GB, while Rocky 10 is 545 MB.

The 5.2 personal environment already uses `rocky10o` (#2137), so this also makes
the two 5.2 environments consistent. Reference environments use Rocky 10 from
now on.

## Notes

- No mirror is introduced; the image still comes from `download.rockylinux.org`.
- `rocky10o` is defined in sumaform for the libvirt backend, is in the
  `x86_64_v2_images` list, and is already deployed by the build validation jobs
  in NUE, PRG and SLC.
- Build validation is untouched and keeps the full Rocky 8 / 9 / 10 client
  matrix.
- CI (acceptance test) environments are not touched; whether they follow is the
  open question tracked in the follow-up card.

## Must merge together with

The reference run syncs the RH-like product in
`features/reposync/reference_srv_sync_products_extra.feature`. Without the
matching testsuite change the server would only sync Rocky 8 channels, no EL10
bootstrap repository would be created by
`mgr-create-bootstrap-repo --auto --with-custom-channels`, and
`features/init_clients/min_rhlike_salt.feature` would fail to bootstrap the
minion.

- Manager-5.2 testsuite: https://github.com/SUSE/spacewalk/pull/31451

## The full set of changes

- susemanager-ci:
  - master (5.1 reference environment): https://github.com/SUSE/susemanager-ci/pull/2158
  - master (5.2 reference environment): this PR
  - master (Head and Uyuni master reference environments): https://github.com/SUSE/susemanager-ci/pull/2154
- testsuite:
  - master: https://github.com/uyuni-project/uyuni/pull/12352
  - Manager-5.2: https://github.com/SUSE/spacewalk/pull/31451
  - Manager-5.1: https://github.com/SUSE/spacewalk/pull/31462

## Test coverage

- [x] No functional changes to the test suite; validated by the next
      `manager-5.2-infra-reference` run deploying the RH-like minion.

## Links

- Failing build: https://jenkins.mgr.suse.de/view/By%20Functionality/view/Reference/job/manager-5.2-infra-reference/2/console
- Follow-up card for the CI environments: https://github.com/SUSE/spacewalk/issues/31449
