### PR TITLE
Switch the Head and Uyuni master reference environments to Rocky 10

### DIFF
--- a/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
+++ b/terracumber_config/tf_files/MLM-Head-refenv-NUE.tf
@@ -120,7 +120,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky10o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ref-head-"
@@ -190,7 +190,7 @@ module "cucumber_testsuite" {
       }
     }
     rhlike_minion = {
-      image = "rocky8o"
+      image = "rocky10o"
       provider_settings = {
         mac = "aa:b2:93:01:00:c9"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM

--- a/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-refenv-NUE.tf
@@ -106,7 +106,7 @@ module "cucumber_testsuite" {
   cc_username = var.SCC_USER
   cc_password = var.SCC_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
+  images = ["rocky10o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "tumbleweedo"]
 
   use_avahi    = false
   name_prefix  = "uyuni-ref-master-"
@@ -177,7 +177,7 @@ module "cucumber_testsuite" {
       }
     }
     rhlike_minion = {
-      image = "rocky8o"
+      image = "rocky10o"
       provider_settings = {
         mac = "aa:b2:93:01:00:e9"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM


### PR DESCRIPTION
## What does this PR change?

Switches the RH-like client of the Head and Uyuni master reference environments
from Rocky 8 to Rocky 10, in both the `images` list and `rhlike_minion`:

- `MLM-Head-refenv-NUE.tf`
- `Uyuni-Master-refenv-NUE.tf`

## Why?

Reference environments move to Rocky 10 from now on. The 5.2 reference
environment was switched in #2153 after `manager-5.2-infra-reference` build #2
failed with `context deadline exceeded` while creating the `rocky8o` libvirt
volume: reference environments deliberately do not use the internal mirror, and
the Rocky 8 generic cloud image is 2.0 GB against 545 MB for Rocky 10.

These two environments run the testsuite from `master`, so they move together
with the testsuite change that makes the reference run sync the Rocky Linux 10
product instead of Rocky Linux 8.

## Notes

- No mirror is introduced; the images still come from `download.rockylinux.org`.
- The 5.1, 5.0 and 4.3 reference environments are not touched: they run their
  own testsuite branches, which keep syncing Rocky 8 (4.3 uses CentOS 7).
- Build validation is untouched and keeps the full Rocky 8 / 9 / 10 client
  matrix.
- CI (acceptance test) environments are not touched; whether they follow is the
  open question tracked in the follow-up card.

## Must merge together with

Without the matching testsuite change the servers would only sync Rocky 8
channels, no EL10 bootstrap repository would be created, and
`features/init_clients/min_rhlike_salt.feature` would fail to bootstrap the
minion.

- master testsuite: https://github.com/uyuni-project/uyuni/pull/12352

## The full set of changes

- susemanager-ci:
  - master (5.1 reference environment): https://github.com/SUSE/susemanager-ci/pull/2158
  - master (5.2 reference environment): https://github.com/SUSE/susemanager-ci/pull/2153
  - master (Head and Uyuni master reference environments): this PR
- testsuite:
  - master: https://github.com/uyuni-project/uyuni/pull/12352
  - Manager-5.2: https://github.com/SUSE/spacewalk/pull/31451
  - Manager-5.1: https://github.com/SUSE/spacewalk/pull/31462

## Test coverage

- [x] No functional changes to the test suite; validated by the next
      `manager-Head-infra-reference-NUE` and `uyuni-master-infra-reference-NUE`
      runs deploying the RH-like minion.

## Links

- Follow-up card for the CI environments: https://github.com/SUSE/spacewalk/issues/31449
