### PR TITLE
Switch the 5.1 reference environment to Rocky 10

### DIFF
--- a/terracumber_config/tf_files/MLM-5.1-refenv-NUE.tf
+++ b/terracumber_config/tf_files/MLM-5.1-refenv-NUE.tf
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky8o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
+  images = ["rocky10o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro61o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ref-51-"
@@ -191,7 +191,7 @@ module "cucumber_testsuite" {
       }
     }
     rhlike_minion = {
-      image = "rocky8o"
+      image = "rocky10o"
       provider_settings = {
         mac = "aa:b2:93:01:01:29"
         // Since start of May we have problems with the instance not booting after a restart if there is only a CPU and only 1024Mb for RAM


### PR DESCRIPTION
## What does this PR change?

Switches the RH-like client of the 5.1 reference environment from Rocky 8 to
Rocky 10, in both the `images` list and `rhlike_minion` of
`MLM-5.1-refenv-NUE.tf`.

## Why?

QE agreed to move the CI and reference environments of 5.1 and 5.2 to Rocky 10,
so that the RH-like client is the same version everywhere on both supported
versions. This is the 5.1 reference environment part.

The switch started with `manager-5.2-infra-reference` build #2, which failed
with `context deadline exceeded` while creating the `rocky8o` libvirt volume.
Reference environments deliberately do not use the internal mirror, so base
images are downloaded from their upstream location, and the Rocky 8 generic
cloud image is 2.0 GB against 545 MB for Rocky 10.

## Notes

- No mirror is introduced; the image still comes from `download.rockylinux.org`.
- 5.1 supports Rocky 10 as a client: `Manager-5.1` already has the
  `rocky10_minion` and `rocky10_sshminion` build validation features, the
  `rockylinux-10 for x86_64` base channel and the `managertools-el10-*-rocky`
  client tools channels in `features/support/constants.rb`.
- `rocky10o` is defined in sumaform master, which is what this job deploys, and
  is in the `x86_64_v2_images` list so the host gets `cpu_model = "host-model"`.
- Build validation is untouched and keeps the full Rocky 8 / 9 / 10 client
  matrix.

## Must merge together with

The reference run syncs the RH-like product in
`features/reposync/reference_srv_sync_products_extra.feature`. Without the
matching testsuite change the server would only sync Rocky 8 channels, no EL10
bootstrap repository would be created by
`mgr-create-bootstrap-repo --auto --force --with-custom-channels`, and
`features/init_clients/min_rhlike_salt.feature` would fail to bootstrap the
minion.

- Manager-5.1 testsuite: https://github.com/SUSE/spacewalk/pull/31462

## The full set of changes

- susemanager-ci:
  - master (5.1 reference environment): this PR
  - master (5.2 reference environment): https://github.com/SUSE/susemanager-ci/pull/2153
  - master (Head and Uyuni master reference environments): https://github.com/SUSE/susemanager-ci/pull/2154
- testsuite:
  - master: https://github.com/uyuni-project/uyuni/pull/12352
  - Manager-5.2: https://github.com/SUSE/spacewalk/pull/31451
  - Manager-5.1: https://github.com/SUSE/spacewalk/pull/31462

## Test coverage

- [x] No functional changes to the test suite; validated by the next
      `manager-5.1-infra-reference-NUE` run deploying the RH-like minion.

## Links

- Card: https://github.com/SUSE/spacewalk/issues/31449
