### PR TITLE
Add the Leap 16.0 controller image to the 5.2 environments

### DIFF
--- a/terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf
+++ b/terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf
@@ -135,7 +135,7 @@ module "cucumber_testsuite" {
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
 
-  images = ["rocky10o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky10o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   use_avahi    = false
   name_prefix  = "mlm-ref-52-"

--- a/terracumber_config/tf_files/personal/main_52.tf
+++ b/terracumber_config/tf_files/personal/main_52.tf
@@ -35,7 +35,7 @@ module "cucumber_testsuite" {
   cc_ptf_username = var.SCC_PTF_USER
   cc_ptf_password = var.SCC_PTF_PASSWORD
 
-  images = ["rocky10o", "opensuse156o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
+  images = ["rocky10o", "opensuse156o", "opensuse160o", "ubuntu2404o", "sles15sp7o", "slmicro62o"]
 
   ssh_key_path = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
   use_avahi    = false

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm52_micro_sle_update_prg.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm52_micro_sle_update_prg.tfvars
@@ -33,7 +33,7 @@ BASE_CONFIGURATIONS = {
     bridge              = "br1"
     hypervisor          = "suma-11.mgr.suse.de"
     additional_network  = null
-    images              = ["sles15sp7o", "opensuse156o", "slmicro62o"]
+    images              = ["sles15sp7o", "opensuse156o", "opensuse160o", "slmicro62o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.2 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm52_sles_sle_update_prg.tfvars
+++ b/terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm52_sles_sle_update_prg.tfvars
@@ -33,7 +33,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br1"
     hypervisor         = "suma-11.mgr.suse.de"
     additional_network = null
-    images              = ["sles15sp7o", "opensuse156o"]
+    images              = ["sles15sp7o", "opensuse156o", "opensuse160o"]
   }
 }
 MAIL_SUBJECT          = "Results 5.2 SLE Update $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"


### PR DESCRIPTION
## What does this PR change?

Adds `opensuse160o` to the image download list of the four **5.2** environments that were missing it:

| File | Environment |
|---|---|
| `terracumber_config/tf_files/personal/main_52.tf` | 5.2 personal pipelines |
| `terracumber_config/tf_files/MLM-5.2-refenv-PRG.tf` | 5.2 reference environment (PRG) |
| `terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm52_micro_sle_update_prg.tfvars` | 5.2 SLE Update (Micro) |
| `terracumber_config/tf_files/tfvars/sle-update-tfvars/mlm52_sles_sle_update_prg.tfvars` | 5.2 SLE Update (SLES) |

`opensuse156o` is kept in every list — `dhcp_dns` and several minions still run on Leap 15.6.

## Why?

The test suite controller is hardcoded to openSUSE Leap 16.0 in sumaform
(`modules/controller/main.tf`: `image = "opensuse160o"`), and `cucumber_testsuite`
passes no image override, so the migration applies to every environment at once.

The libvirt base module only creates base volumes for the images listed in
`images` (`images_used = var.use_shared_resources ? [] : var.images`), and each
host builds its main disk from `<name_prefix><image>`. If `opensuse160o` is not
in an environment's list, the controller's base volume is never created and
deployment fails with:

```
Error: can't retrieve base volume with name '<prefix>-opensuse160o':
Storage volume not found: no storage vol with matching name '<prefix>-opensuse160o'
  with cucumber_testsuite.controller.main_disk[0],
  on backend_modules/libvirt/host/main.tf line 107, in resource "libvirt_volume" "main_disk"
```

The 5.2 environments were added after the Leap 16.0 migration swept `opensuse160o`
into all the other image lists, so they never received it. Every non-5.2
environment already has it.

## Test coverage

- **Manually tested**: reproduced on `ktsamis-personal-pipeline` build #25, which failed
  with the error above while deploying `main_52.tf`.
- Scanned every `images`/`IMAGES` list under `terracumber_config/` for the same gap.
  The remaining hits are all expected: `salt-shaker/*` (controller comes from the separate
  `salt_testenv` module), `local_mirror.tf` (mirror only), the `templates/*` files (values
  come from variables), and `MLM-Head-refenv-mcp-server.tf` / `SUSEManager-4.3-refenv-SLC.tf`
  (no controller module).
- No README image-matrix change needed — the Controller rows already read Leap 16.0.

## Links

Follow-up to the controller Leap 16.0 migration (#2131).
