### PR TITLE
Use the released 5.2 container registry in the 5.2 BV and MI jobs

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
@@ -18,13 +18,13 @@ node('sumaform-cucumber') {
                     'sles15sp7_minion:selected'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
-            // maintenance update (5.2.1) is published. Revert both registries below to
-            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
-            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
-            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
+            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
+            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
+            // current. Reset the default below to '' once releng re-points the server latest tag.
+            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
@@ -37,13 +37,13 @@ node('sumaform-cucumber') {
                     'slmicro60_minion:selected', 'slmicro61_minion:selected', 'slmicro62_minion:selected'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
-            // maintenance update (5.2.1) is published. Revert both registries below to
-            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
-            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
-            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
+            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
+            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
+            // current. Reset the default below to '' once releng re-points the server latest tag.
+            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),

--- a/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP
@@ -37,13 +37,13 @@ node('sumaform-cucumber-slc1') {
                     'slmicro60_minion:selected', 'slmicro61_minion:selected', 'slmicro62_minion:selected'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
-            // maintenance update (5.2.1) is published. Revert both registries below to
-            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
-            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
-            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
+            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
+            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
+            // current. Reset the default below to '' once releng re-points the server latest tag.
+            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -77,6 +77,11 @@ def run(params) {
                     custom_project_path = "registry.suse.de/${params.container_project.toLowerCase().replaceAll(':', '/')}/containerfile"
                     server_container_registry = custom_project_path
                     proxy_container_registry = custom_project_path
+                    // WORKAROUND: the 5.2 jobs pin the server image to the 5.2.0 tag, and that pin
+                    // would follow the registry override above into the container project, hiding
+                    // the server image rebuilt there. Remove this together with those pins.
+                    // Follow up card to remove both: https://github.com/SUSE/spacewalk/issues/31401
+                    server_container_image = ''
                 } else if (isNewJenkins) {
                     Utils.markStageSkippedForConditional(STAGE_NAME)
                 }

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation
@@ -21,13 +21,13 @@ node('sumaform-cucumber') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
-            // maintenance update (5.2.1) is published. Revert both registries below to
-            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
-            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
-            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
+            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
+            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
+            // current. Reset the default below to '' once releng re-points the server latest tag.
+            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
@@ -39,13 +39,13 @@ node('sumaform-cucumber') {
                     value: minionList,
                     defaultValue: minionList,
                     description: 'Node list to run during BV'),
-            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
-            // maintenance update (5.2.1) is published. Revert both registries below to
-            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
-            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
-            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
+            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
+            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
+            // current. Reset the default below to '' once releng re-points the server latest tag.
+            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
@@ -16,13 +16,13 @@ node('sumaform-cucumber') {
             activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [ 'sles15sp7_minion:selected' ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
-            // maintenance update (5.2.1) is published. Revert both registries below to
-            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
-            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
-            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
+            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
+            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
+            // current. Reset the default below to '' once releng re-points the server latest tag.
+            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
@@ -16,13 +16,13 @@ node('sumaform-cucumber') {
             activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [ 'sles15sp7_minion:selected' ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            // WORKAROUND: the 5.2 :Update container repository does not exist until the first
-            // maintenance update (5.2.1) is published. Revert both registries below to
-            // registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/update/containerfile
-            // once it does. Tracked in https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
-            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
+            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
+            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
+            // current. Reset the default below to '' once releng re-points the server latest tag.
+            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
+            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),


### PR DESCRIPTION
## What does this PR change

Points the seven 5.2 build validation and MI validation pipelines at the registry where officially released 5.2 content is published, and pins the server image to the GA tag while the `latest` tag there is wrong.

Registry, for both `server_container_registry` and `proxy_container_registry`:

```
registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile
  ->
registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers
```

Released content is pushed from [SUSE:Containers:SUSE-MultiLinuxManager:5.2](https://build.suse.de/project/show/SUSE:Containers:SUSE-MultiLinuxManager:5.2), which is this path on `registry.suse.de` (confirmed by releng). The previously used `:Update` codestream is where submissions happen, is not locked and rebuilds on SLE dependency changes, and in any case does not exist for 5.2 before 5.2.1. ToTest is the wrong place for a BV that must run against released content, and releng has confirmed it stops being used once a product enters the maintenance phase: 5.1's has been stuck at 5.1.0 since 2025-07-30, 5.0's is already gone. A ToTest project may come back later, but it would not be the one these pipelines were pointing at.

`server_container_image` is pinned to `suse/multi-linux-manager/5.2/x86_64/server:5.2.0` as a **workaround**, because `server:latest` in the released registry still resolves to a 2026-04-28 pre-GA build (5.2.7, beta2 era). Every other 5.2 image in that registry is current, so only the server needs the pin — `mgradm` honours a tag embedded in the image name and ignores the global tag, leaving the database, attestation, hub API, saline and all proxy images on `latest`.

Verified against `registry.suse.de` before the change:

| image | released registry, `latest` | ToTest, `latest` |
| --- | --- | --- |
| **server** | **5.2.7, 2026-04-28** | **5.2.14, 2026-07-07** |
| proxy-httpd | 5.2.9, 2026-07-06 | identical |
| proxy-salt-broker / squid / ssh / tftpd | 5.2.8, 2026-07-01 | identical |
| server-attestation | 5.2.10, 2026-07-06 | identical |
| server-saline | 5.2.10, 2026-07-01 | identical |
| server-postgresql | 5.2.12, 2026-07-06 | identical |
| server-hub-xmlrpc-api | 5.2.0.7.7 | identical |

The released `server:5.2.0` tag is `sha256:0b01d1397aa9...`, the same manifest ToTest's `latest` resolves to today, so the deployed server image does not change with this PR — only where it comes from and how it is addressed.

When a container project override is in use (`container_project` + `mi_project`, the `bci` MI job), the common pipeline rewrites both registries to that project. It now also clears `server_container_image` there, so the pin cannot hide the server image rebuilt by the MI project.

## Affected pipelines

Build validation:

- `jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation`
- `jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP`
- `jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation`
- `jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation`
- `jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation`

MI validation:

- `jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools`
- `jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci`

Common:

- `jenkins_pipelines/environments/common/pipeline-build-validation.groovy` — clear the image pin when a container project override is in use

## Follow up

The tag pin is tracked in SUSE/spacewalk#31401, which has been reworked from "revert to `:Update` when 5.2.1 ships" to "drop the pin when releng re-points `server:latest`". Ready check:

```bash
curl -s -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
  https://registry.suse.de/v2/suse/containers/suse-multilinuxmanager/5.2/containers/suse/multi-linux-manager/5.2/x86_64/server/manifests/latest \
  | sha256sum
# must match the same call for tag 5.2.0
```

Not addressed here: the 5.0 and 5.1 BV and MI jobs still use their `:Update` codestream registries. Both work today, but if `SUSE:Containers` is the canonical released path they should probably follow.

## Related

- SUSE/spacewalk#31401 — workaround follow up card
- #2142, #2150 — the earlier switch to ToTest that this replaces
