### PR TITLE
Fix build container with new python3.13 version

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -72,7 +72,16 @@ def run(params) {
                 stage('Build containers') {
                     if (params.container_project && params.mi_project && params.must_deploy) {
                         def SCRIPT_DIR = "${WORKSPACE}/susemanager-ci/jenkins_pipelines/scripts/edit_bci_project"
-                        sh "python3 -m venv ${WORKSPACE}/venv"
+                        sh """
+                        set -e
+                        python3 -m venv ${WORKSPACE}/venv || true
+                        if [ ! -x ${WORKSPACE}/venv/bin/python3 ]; then
+                            echo "venv creation incomplete/failed (missing bin/python3) - likely no working ensurepip bundled with this image's python3-venv package. Recreating without pip and bootstrapping it manually."
+                            rm -rf ${WORKSPACE}/venv
+                            python3 -m venv --without-pip ${WORKSPACE}/venv
+                            curl -sS https://bootstrap.pypa.io/get-pip.py | ${WORKSPACE}/venv/bin/python3
+                        fi
+                    """
                         sh "${WORKSPACE}/venv/bin/pip install -r ${SCRIPT_DIR}/requirements.txt"
                         sh(script: "${WORKSPACE}/venv/bin/python ${SCRIPT_DIR}/edit.py --container-project ${params.container_project} --mi-project ${params.mi_project}", returnStdout: true)
                         custom_project_path = "registry.suse.de/${params.container_project.toLowerCase().replaceAll(':', '/')}/containerfile"


### PR DESCRIPTION
## Issue
After the Jenkins agent image bump (Python 3.6 → 3.13), the "Build containers" stage fails with:
`[Errno 2] No such file or directory: '.../venv/bin/python3'`. The new SUSE-based image's Python package doesn't bundle a working `ensurepip`/pip, so `python3 -m venv` creates an incomplete venv (no `bin/python3`).

## Solution
After creating the venv, check whether `bin/python3` exists. If not, recreate it with `--without-pip` and bootstrap pip manually via `get-pip.py`, so the stage no longer depends on the image shipping a fully working venv/pip package.

Tested here: https://jenkins.mgr.suse.de/job/manager-5.1-qe-mi-validation-bci/109/

## Follow-up
Root cause is the agent image itself missing the venv/pip subpackage — worth confirming with image maintainers so this workaround can eventually be removed.