### PR TITLE
Require an explicit version in the maintenance JSON generator

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-4.3-qe-build-validation
@@ -65,6 +65,7 @@ node('sumaform-cucumber') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "4.3-released"
+    mutableParams.json_generator_version = "43"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_nue.tfvars'
 

--- a/jenkins_pipelines/environments/build-validation/manager-4.3-qe-build-validation-BACKUP
+++ b/jenkins_pipelines/environments/build-validation/manager-4.3-qe-build-validation-BACKUP
@@ -65,6 +65,7 @@ node('sumaform-cucumber-slc1') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "4.3-released"
+    mutableParams.json_generator_version = "43"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars'
 

--- a/jenkins_pipelines/environments/build-validation/manager-5.0-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.0-micro-qe-build-validation
@@ -69,6 +69,7 @@ node('sumaform-cucumber') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "5.0-released"
+    mutableParams.json_generator_version = "50-micro"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_micro_build_validation_nue.tfvars'
 

--- a/jenkins_pipelines/environments/build-validation/manager-5.1-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/build-validation/manager-5.1-qe-build-validation-AWS
@@ -62,6 +62,7 @@ node('sumaform-cucumber') {
     }
     def mutableParams = [:] + params
     mutableParams.product_version_display = "5.1-released"
+    mutableParams.json_generator_version = "51-micro"
     mutableParams.non_MU_channels_tasks_file = "susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_51.json"
     mutableParams.tf_file = "MLM-5.1-build-validation-paygo-AWS.tf"
     mutableParams.deployment_tfvars = "susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_paygo_build_validation_aws.tfvars"

--- a/jenkins_pipelines/environments/build-validation/manager-5.1-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.1-sles-qe-build-validation
@@ -71,6 +71,7 @@ node('sumaform-cucumber') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "5.1-released"
+    mutableParams.json_generator_version = "51-sles"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_51.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_sles_build_validation_nue.tfvars'
 

--- a/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
@@ -61,6 +61,7 @@ node('sumaform-cucumber') {
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
             booleanParam(name: 'push_new_custom_repositories', defaultValue: false, description: 'Force push new custom repositories for client tools if pipeline rerun after deployment'),
             text(name: 'mi_ids', defaultValue: '', description: 'MI Identifiers separated by comma or whitespaces (Option A)'),
+            choice(name: 'json_generator_version', choices: ['51-micro', '51-sles', '52-micro', '52-sles', '50-micro', '50-sles', '43'], description: 'Version the MI Identifiers above are resolved for. Has to match product_version and base_os: a SL Micro base_os is a -micro version, a SLES one a -sles version'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'MU Repositories in json format (Option B)')
             ])
     ])

--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -32,6 +32,9 @@ def run(params) {
             def client_paygo_stage_result_fail = false
             def products_and_salt_migration_stage_result_fail = false
             def retail_stage_result_fail = false
+            // Version passed to maintenance_json_generator.py: it has no default anymore,
+            // so every environment offering mi_ids has to name the version explicitly.
+            def json_generator_version = params.json_generator_version ?: ''
 
             local_mirror_params = "--outputdir ${resultdir} --tf susemanager-ci/terracumber_config/tf_files/local_mirror.tf --gitfolder ${local_mirror_dir} --terraform-bin ${params.bin_path}"
             aws_mirror_params = "--outputdir ${resultdir} --tf susemanager-ci/terracumber_config/tf_files/aws_mirror.tf --gitfolder ${aws_mirror_dir} --terraform-bin ${params.bin_path}"
@@ -74,11 +77,14 @@ def run(params) {
                                         }
                                         // Generate custom_repositories.json file in the workspace using a Python script - MI Identifiers passed by parameter
                                         if (params.mi_ids?.trim()) {
+                                            if (!json_generator_version) {
+                                                error("json_generator_version is not set for this environment, cannot generate custom_repositories.json from mi_ids")
+                                            }
                                             node('manager-jenkins-node') {
                                                 checkout scm
-                                                res_python_script_ = sh(script: "python3 jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py --mi_ids ${params.mi_ids} --no_embargo", returnStatus: true)
-                                                echo "Build Validation JSON script return code:\n ${json_content}"
-                                                if (res_python_script != 0) {
+                                                res_python_script_ = sh(script: "python3 jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py --version ${json_generator_version} --mi_ids ${params.mi_ids} --no_embargo", returnStatus: true)
+                                                echo "Build Validation JSON script return code:\n ${res_python_script_}"
+                                                if (res_python_script_ != 0) {
                                                     error("MI IDs (${params.mi_ids}) passed by parameter are wrong, already released or all under embargo")
                                                 }
                                             }

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -49,6 +49,9 @@ def run(params) {
             // Parameters used for sandbox pipeline
             def product_version = params.product_version ?: ''
             def base_os = params.base_os ?: ''
+            // Version passed to maintenance_json_generator.py: it has no default anymore,
+            // so every environment offering mi_ids has to name the version explicitly.
+            def json_generator_version = params.json_generator_version ?: ''
 
             env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform --tf_variables_description_file=${tfVariablesFile} --terraform-bin ${params.bin_path}"
 
@@ -123,9 +126,12 @@ def run(params) {
                             }
                             // Generate custom_repositories.json file in the workspace using a Python script - MI Identifiers passed by parameter
                             if (params.mi_ids?.trim()) {
+                                if (!json_generator_version) {
+                                    error("json_generator_version is not set for this environment, cannot generate custom_repositories.json from mi_ids")
+                                }
                                 node('manager-jenkins-node') {
                                     checkout scm
-                                    def res_python_script_ = sh(script: "python3 jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py --mi_ids ${params.mi_ids}", returnStatus: true)
+                                    def res_python_script_ = sh(script: "python3 jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py --version ${json_generator_version} --mi_ids ${params.mi_ids}", returnStatus: true)
                                     echo "Build Validation JSON script return code:\n ${res_python_script_}"
                                     if (res_python_script_ != 0) {
                                         error("MI IDs (${params.mi_ids}) passed by parameter are wrong (or already released)")
@@ -262,9 +268,12 @@ def run(params) {
 
                         // Generate custom_repositories.json file in the workspace using a Python script - MI Identifiers passed by parameter
                         if (params.mi_ids?.trim()) {
+                            if (!json_generator_version) {
+                                error("json_generator_version is not set for this environment, cannot generate custom_repositories.json from mi_ids")
+                            }
                             node('manager-jenkins-node') {
                                 checkout scm
-                                def res_python_script_ = sh(script: "python3 jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py --mi_ids ${params.mi_ids}", returnStatus: true)
+                                def res_python_script_ = sh(script: "python3 jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py --version ${json_generator_version} --mi_ids ${params.mi_ids}", returnStatus: true)
                                 echo "Build Validation JSON script return code:\n ${res_python_script_}"
                                 if (res_python_script_ != 0) {
                                     error("MI IDs (${params.mi_ids}) passed by parameter are wrong (or already released)")

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-4.3-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-4.3-qe-build-validation
@@ -66,6 +66,7 @@ node('sumaform-cucumber') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "4.3-released"
+    mutableParams.json_generator_version = "43"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_nue.tfvars'
 

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-4.3-qe-build-validation-BACKUP
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-4.3-qe-build-validation-BACKUP
@@ -66,6 +66,7 @@ node('sumaform-cucumber-slc1') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "4.3-released"
+    mutableParams.json_generator_version = "43"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_43.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars'
 

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.0-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.0-micro-qe-build-validation
@@ -70,6 +70,7 @@ node('sumaform-cucumber') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "5.0-released"
+    mutableParams.json_generator_version = "50-micro"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_micro_build_validation_nue.tfvars'
 

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.0-micro-qe-build-validation-BACKUP
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.0-micro-qe-build-validation-BACKUP
@@ -69,6 +69,7 @@ node('sumaform-cucumber-slc1') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "5.0-released"
+    mutableParams.json_generator_version = "50-micro"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma50_micro_build_validation_slc.tfvars'
 

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.1-qe-build-validation-AWS
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.1-qe-build-validation-AWS
@@ -62,6 +62,7 @@ node('sumaform-cucumber') {
     }
     def mutableParams = [:] + params
     mutableParams.product_version_display = "5.1-released"
+    mutableParams.json_generator_version = "51-micro"
     mutableParams.non_MU_channels_tasks_file = "susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_51.json"
     mutableParams.tf_file = "MLM-5.1-build-validation-paygo-AWS.tf"
     mutableParams.deployment_tfvars = "susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_paygo_build_validation_aws.tfvars"

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.1-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.1-sles-qe-build-validation
@@ -71,6 +71,7 @@ node('sumaform-cucumber') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = "5.1-released"
+    mutableParams.json_generator_version = "51-sles"
     mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_51.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm51_sles_build_validation_nue.tfvars'
 

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-sandbox-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-sandbox-qe-build-validation
@@ -60,6 +60,7 @@ node('sumaform-cucumber') {
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
             booleanParam(name: 'push_new_custom_repositories', defaultValue: false, description: 'Force push new custom repositories for client tools if pipeline rerun after deployment'),
             text(name: 'mi_ids', defaultValue: '', description: 'MI Identifiers separated by comma or whitespaces (Option A)'),
+            choice(name: 'json_generator_version', choices: ['51-micro', '51-sles', '52-micro', '52-sles', '50-micro', '50-sles', '43'], description: 'Version the MI Identifiers above are resolved for. Has to match product_version and base_os: a SL Micro base_os is a -micro version, a SLES one a -sles version'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'MU Repositories in json format (Option B)')
             ])
     ])

--- a/jenkins_pipelines/environments/personal/maxime-personal-bv
+++ b/jenkins_pipelines/environments/personal/maxime-personal-bv
@@ -65,6 +65,7 @@ node('sumaform-cucumber') {
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
             booleanParam(name: 'push_new_custom_repositories', defaultValue: false, description: 'Force push new custom repositories for client tools if pipeline rerun after deployment'),
             text(name: 'mi_ids', defaultValue: '', description: 'MI Identifiers separated by comma or whitespaces (Option A)'),
+            choice(name: 'json_generator_version', choices: ['51-micro', '51-sles', '52-micro', '52-sles', '50-micro', '50-sles', '43'], description: 'Version the MI Identifiers above are resolved for. Has to match product_version and base_os: a SL Micro base_os is a -micro version, a SLES one a -sles version'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'MU Repositories in json format (Option B)')
             ])
     ])

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator.py
@@ -5,6 +5,7 @@ import json
 import os
 import requests
 import logging
+import sys
 import threading
 
 from ibs_osc_client import IbsOscClient
@@ -30,25 +31,34 @@ def _slfo_pr_id(value: str) -> str:
         )
     return value
 
-def parse_cli_args() -> argparse.Namespace:
+def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="This script reads the open qam-manager requests and creates a json file that can be fed to the BV testsuite pipeline"
     )
-    parser.add_argument("-v", "--version", dest="version",
-                        help="Version of SUMA/MLM to run this script for. Default: 51-sles.",
-                        choices=list(nodes_by_version.keys()), default="51-sles", action='store')
+    parser.add_argument("-v", "--version", required=True, dest="version",
+                        help="Version of SUMA/MLM to run this script for",
+                        choices=list(nodes_by_version.keys()), action='store')
     parser.add_argument("-i", "--mi_ids", required=False, dest="mi_ids", help="Space separated list of MI IDs", nargs='*', action='store')
     parser.add_argument("-f", "--file", required=False, dest="file", help="Path to a file containing MI IDs separated by newline character", action='store')
     parser.add_argument("-e", "--no_embargo", dest="embargo_check", help="Reject MIs under embargo",  action='store_true')
     parser.add_argument(
-        "--slfo-pull-request",
+        "-s", "--slfo-pull-request",
         required=False,
         dest="slfo_pull_request",
         metavar="ID",
         type=_slfo_pr_id,
         help="SLFO PullRequest id for sles160_minion, slmicro62_minion (x86_64), and opensuse160arm_minion (aarch64) on stable 51-* / 52-* only; rejected for *-beta versions (beta uses :ToTest automatically)",
     )
-    args = parser.parse_args()
+
+    if argv is None:
+        argv = sys.argv[1:]
+    # No arguments at all is not a misuse, it is somebody looking for the usage:
+    # show the help instead of an error about the missing -v.
+    if not argv:
+        parser.print_help()
+        raise SystemExit(0)
+
+    args = parser.parse_args(argv)
     if args.slfo_pull_request is not None:
         if not supports_slfo_pull_request(args.version):
             parser.error("--slfo-pull-request is only supported for 51-* and 52-* versions")

--- a/jenkins_pipelines/scripts/json_generator/maintenance_json_generator_README.md
+++ b/jenkins_pipelines/scripts/json_generator/maintenance_json_generator_README.md
@@ -39,7 +39,7 @@ information for the SUSE Manager BV testsuite pipeline.
 - Embargo Checks: The script has an option to reject Maintenance Incidents (MIs)
 that are under embargo.
 - SLFO client tools for `sles160_minion` / `slmicro62_minion` (x86_64) and `opensuse160arm_minion` (aarch64):
-  - Stable `51-*` / `52-sles` / `52-micro`: use `--slfo-pull-request <id>` to
+  - Stable `51-*` / `52-sles` / `52-micro`: use `-s` / `--slfo-pull-request <id>` to
     inject a `:PullRequest:/<id>` client-tools URL (independent of MI IDs).
   - Beta `53-sles-beta` / `53-micro-beta`: a static `:ToTest` URL is baked in
     and applied automatically; `--slfo-pull-request` is rejected for beta
@@ -53,22 +53,28 @@ Command-Line Arguments
 The script accepts several command-line arguments to control its behavior.
 
 ```bash
-python3.11 maintenance_json_generator.py [options]
+python3 maintenance_json_generator.py [options]
 ```
+
+The script needs Python 3.10 or newer; do not call a pinned point release such
+as `python3.11`, it is not packaged on every host (Leap 16.0 ships 3.13 only).
+The Jenkins pipelines call plain `python3` for the same reason.
+
+Running the script with no arguments at all prints this help and exits.
 
 Options:
 
-`-v`, `--version`: Specifies the SUSE Manager version. Options are `43` for SUSE
-Manager 4.3, `50-micro` / `50-sles` for 5.0, `51-micro` / `51-sles` for 5.1, `52-micro` / `52-sles` for 5.2 (stable), and `53-micro-beta` / `53-sles-beta` for 5.3 beta placeholders. Default is `51-sles`.
+`-v`, `--version`: **Mandatory.** Specifies the SUSE Manager version. Options are `43` for SUSE
+Manager 4.3, `50-micro` / `50-sles` for 5.0, `51-micro` / `51-sles` for 5.1, `52-micro` / `52-sles` for 5.2 (stable), and `53-micro-beta` / `53-sles-beta` for 5.3 beta placeholders. There is no default: the version always has to be named, so that a JSON is never silently generated for the wrong product.
 `-i`, `--mi_ids`: A space-separated list of MI IDs.
 `-f`, `--file`: Path to a file containing MI IDs, each on a new line.
 `-e`, `--no_embargo`: Reject any MIs that are currently under embargo.
-`--slfo-pull-request`: SLFO PullRequest id for `sles160_minion`, `slmicro62_minion` (x86_64), and `opensuse160arm_minion` (aarch64 SLE-16 client-tools) on stable 5.1 / 5.2 only (independent of MI ids). Rejected for `-beta` versions, which receive a fixed `:ToTest` URL automatically. In `custom_repositories.json`, those entries use the inner key pattern `slfo_pr_{id}_{minion}_{arch}` (includes minion name and architecture) to ensure each repository has a unique name, preventing race conditions where minions could pick up the wrong-architecture repository.
+`-s`, `--slfo-pull-request`: SLFO PullRequest id for `sles160_minion`, `slmicro62_minion` (x86_64), and `opensuse160arm_minion` (aarch64 SLE-16 client-tools) on stable 5.1 / 5.2 only (independent of MI ids). Rejected for `-beta` versions, which receive a fixed `:ToTest` URL automatically. In `custom_repositories.json`, those entries use the inner key pattern `slfo_pr_{id}_{minion}_{arch}` (includes minion name and architecture) to ensure each repository has a unique name, preventing race conditions where minions could pick up the wrong-architecture repository.
 
 Example:
 
 ```bash
-python3.11 maintenance_json_generator.py --version 50-micro --mi_ids 1234 5678 --file mi_ids.txt --no_embargo
+python3 maintenance_json_generator.py --version 50-micro --mi_ids 1234 5678 --file mi_ids.txt --no_embargo
 ```
 
 This command will:
@@ -171,6 +177,9 @@ Repository definitions live under
 
 ## Error Handling
 
+- If `-v` / `--version` is missing, argparse halts with an error naming the
+required argument. Called with no arguments at all, the script prints its help
+and exits with 0 instead.
 - If no MI IDs are provided via CLI or file, the script will print an error
 message and halt execution.
 - Invalid MI IDs or missing files will result in appropriate error messages.

--- a/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
+++ b/jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py
@@ -1,5 +1,5 @@
 from argparse import Namespace
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 import io
 import json
 from os import path, remove
@@ -20,12 +20,30 @@ TESTDATA_DIR = Path(__file__).resolve().parent / 'testdata'
 class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
 
     def test_parse_cli_args_default_values(self):
-        sys.argv = ['maintenance_json_generator.py']
+        sys.argv = ['maintenance_json_generator.py', '-v', '51-sles']
         args = parse_cli_args()
         self.assertEqual(args.version, "51-sles")
         self.assertIsNone(args.mi_ids)
         self.assertFalse(args.embargo_check)
         self.assertIsNone(args.slfo_pull_request)
+
+    def test_parse_cli_args_without_arguments_shows_help(self):
+        sys.argv = ['maintenance_json_generator.py']
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            with self.assertRaises(SystemExit) as cm:
+                parse_cli_args()
+        self.assertEqual(cm.exception.code, 0)
+        self.assertIn("usage: maintenance_json_generator.py", stdout.getvalue())
+
+    def test_parse_cli_args_version_is_mandatory(self):
+        sys.argv = ['maintenance_json_generator.py', '-i', '1234']
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as cm:
+                parse_cli_args()
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("the following arguments are required: -v/--version", stderr.getvalue())
 
     def test_parse_cli_args_success(self):
         # shorthand flags
@@ -67,9 +85,14 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         args = parse_cli_args()
         self.assertEqual(args.version, '51-sles')
         self.assertEqual(args.slfo_pull_request, '9999')
+        # -s is the shorthand of --slfo-pull-request
+        sys.argv = ['maintenance_json_generator.py', '-v', '52-sles', '-s', '9999']
+        args = parse_cli_args()
+        self.assertEqual(args.version, '52-sles')
+        self.assertEqual(args.slfo_pull_request, '9999')
 
     def test_parse_cli_args_failure(self):
-        sys.argv = ['maintenance_json_generator.py',  '-x']
+        sys.argv = ['maintenance_json_generator.py',  '-v', '51-sles', '-x']
         stderr = io.StringIO()
         with redirect_stderr(stderr):
             with self.assertRaises(SystemExit) as cm:
@@ -94,6 +117,14 @@ class MaintenanceJsonGeneratorTestCase(unittest.TestCase):
         self.assertIn("--slfo-pull-request is only supported for 51-* and 52-* versions", stderr.getvalue())
 
         sys.argv = ['maintenance_json_generator.py', '--version', '50-micro', '--slfo-pull-request', '9999']
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as cm:
+                parse_cli_args()
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("--slfo-pull-request is only supported for 51-* and 52-* versions", stderr.getvalue())
+
+        sys.argv = ['maintenance_json_generator.py', '-v', '43', '-s', '9999']
         stderr = io.StringIO()
         with redirect_stderr(stderr):
             with self.assertRaises(SystemExit) as cm:


### PR DESCRIPTION
## What does this PR change?

`maintenance_json_generator.py` defaulted `-v` to `51-sles`, and all three Jenkins call sites invoked it without `-v`. The 4.3, 5.0-micro and 5.1 AWS PayG build validations were therefore silently resolving their MI ids against 5.1-on-SLES repositories.

CLI:

- `-v` / `--version` is mandatory and the `51-sles` default is gone, so a JSON is never generated for an unnamed product
- `-s` is the short form of `--slfo-pull-request`
- called with no arguments at all, the script prints its help and exits 0 instead of erroring out on the missing `-v`
- the README told the user to run `python3.11`, which is not packaged on Leap 16.0 (it ships 3.13 only); it now uses plain `python3`, as the pipelines already do, and states the minimum version instead

Pipelines: every environment that offers `mi_ids` names its version explicitly, matching the server and proxy base OS it deploys, because that is exactly what the generator's `micro` / `sles` variant selects (`micro` takes server and proxy tools from the SLFO ToTest product repos, `sles` from MI-based SLE-15-SP7 module repos).

| Environment | Server and proxy base OS | Version | Resolved as before |
|---|---|---|---|
| `manager-4.3-qe-build-validation` | sles15sp4o, 4.3 has no variant | `43` | `51-sles` |
| `manager-5.0-micro-qe-build-validation` | slemicro55o | `50-micro` | `51-sles` |
| `manager-5.1-sles-qe-build-validation` | sles15sp7o | `51-sles` | `51-sles` |
| `manager-5.1-qe-build-validation-AWS` | PayG AMI, SL Micro based | `51-micro` | `51-sles` |
| `manager-sandbox-qe-build-validation` | selectable via `base_os` | parameter, default `51-micro` | `51-sles` |
| `maxime-personal-bv` | selectable via `base_os` | parameter, default `51-micro` | `51-sles` |

The legacy and BACKUP copies of these jobs load the same shared pipelines and got the same values, 13 environment files in total. The two sandbox style jobs pick their base OS at run time, so no single hardcoded value is correct for them and they get a `json_generator_version` choice parameter instead; its default matches their own default `base_os` of `slmicro62o`. Both shared pipelines abort with a clear message if an environment ever passes `mi_ids` without a version.

While touching the AWS block: it echoed the undefined `json_content` and tested `res_python_script` instead of `res_python_script_`, so a generator failure there never actually raised. Both fixed.

## Test coverage

- Unit tests: `jenkins_pipelines/scripts/tests/test_maintenance_json_generator.py` covers the mandatory `-v`, the help on no arguments, and `-s` (accepted on `52-sles`, rejected on `43`)

```
cd jenkins_pipelines/scripts && python3 -m unittest discover -s tests -t .
Ran 50 tests - OK
```

`python-hcl2` has to be installed for the full discovery run, it is listed in `jenkins_pipelines/scripts/tf_vars_generator/requirements.txt`.

## Links

- Fixes https://github.com/SUSE/spacewalk/issues/31521
