### PR TITLE
Detect cron trigger and ignore functional_scopes on timer builds

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -196,11 +196,15 @@ def run(params) {
                     stage('Secondary features') {
                         if (runSecondary) {
                             def tags_list = ""
-                            if (params.functional_scopes) {
+                            // When triggered by cron the Active Choices plugin (JENKINS-42568) always returns
+                            // the first checkbox value instead of none, so ignore functional_scopes on timer builds.
+                            def isTimerTriggered = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause')
+                            def effectiveScopes = isTimerTriggered ? '' : params.functional_scopes
+                            if (effectiveScopes) {
                                 // Re-add the @ prefix stripped from the job parameters
                                 // (Jenkins' Safe HTML markup formatter escapes @ as &#64; in Active Choices labels).
                                 // startsWith guard keeps backward compatibility with jobs still passing @-prefixed scopes.
-                                def transformed_scopes = params.functional_scopes.split(',')
+                                def transformed_scopes = effectiveScopes.split(',')
                                         .collect { it.trim() }
                                         .collect { it.startsWith('@') ? it : "@${it}" }
                                         .join(' or ')


### PR DESCRIPTION
## What does this PR ?

Clean scope when pipeline is trigger by schedule task