### PR TITLE
Fix secondary features stage in the personal pipeline

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -149,17 +149,9 @@ def run(params) {
                             tags_list = "export TAGS='${transformed_scopes}'; "
                         }
 
-                        def cucumberCmd1 = "${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary"
-                        def cucumberCmd2 = "${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable"
-                        def cucumberCmd3 = "${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing"
-
-                        def encoded1 = cucumberCmd1.bytes.encodeBase64().toString()
-                        def encoded2 = cucumberCmd2.bytes.encodeBase64().toString()
-                        def encoded3 = cucumberCmd3.bytes.encodeBase64().toString()
-
-                        def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'echo ${encoded1} | base64 -d | bash'", returnStatus: true
-                        def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'echo ${encoded2} | base64 -d | bash'", returnStatus: true
-                        def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'echo ${encoded3} | base64 -d | bash'", returnStatus: true
+                        def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true
+                        def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true
+                        def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true
                         sh "exit \$(( ${statusCode1}|${statusCode2}|${statusCode3} ))"
                     }
                 }


### PR DESCRIPTION
## What

`pipeline-personal.groovy` base64-encodes each secondary rake command before handing it to `--cucumber-cmd`:

```groovy
def encoded1 = cucumberCmd1.bytes.encodeBase64().toString()
...
--cucumber-cmd 'echo ${encoded1} | base64 -d | bash'
```

The Groovy sandbox on ci.suse.de rejects that:

```
Scripts not permitted to use method groovy.lang.GString getBytes.
Administrators can decide whether to approve or reject this signature.
```

The stage throws before the first `sh` step, so **no secondary test runs at all**.

This PR drops the encoding and interpolates the command into `--cucumber-cmd` directly, which is what `common/pipeline.groovy` already does.

## Why it is only broken here

`pipeline.groovy` hit the same wall and was fixed in [ad8124aa](https://github.com/SUSE/susemanager-ci/commit/ad8124aaa20a8240b863d9b69ad740ed78c39583) ("Fix pipeline groovy limitation", #2124, 2026-07-21). `pipeline-personal.groovy` was not part of that change and kept the broken form. It is also a slightly worse variant — `pipeline.groovy` at least had `.toString().bytes` from #2123, while the personal copy calls `.bytes` straight on a `GString`.

## Evidence

Failure — [ktsamis-personal-pipeline #27](https://ci.suse.de/view/Manager/view/Manager-qe/job/ktsamis-personal-pipeline/27/consoleFull). Deploy, Sanity Check and all three Core stages passed (38/38 scenarios in Initialize clients), then:

```
[Pipeline] { (Secondary features)
Scripts not permitted to use method groovy.lang.GString getBytes. ...
[Pipeline] }
```

Under a second, zero scenarios.

Fixed form — [manager-5.2-dev-acceptance-tests #142](https://jenkins.mgr.suse.de/view/By%20Functionality/view/CI/job/manager-5.2-dev-acceptance-tests/142/consoleFull), running the already-corrected `pipeline.groovy`. `Secondary features` spans ~32k console lines and completes all three rake steps (650, 672 and 28 scenarios). No sandbox error anywhere in the log.

## Scope

Only the base64 encoding. The `tags_list` quoting on the line above is untouched and is handled separately in #2147.

## Testing

Not yet run on the personal job — it needs this merged first, since the job checks out `master`.
