### PR TITLE
Abort cucumber runs that stop producing console output

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -13,6 +13,25 @@ def run(params) {
             def build_validation = true
             env.exports = "export BUILD_NUMBER=${BUILD_NUMBER}; export BUILD_VALIDATION=true; export CUCUMBER_PUBLISH_QUIET=true;"
 
+            // Inactivity timeout: kills a cucumber run that has stopped producing output entirely.
+            // Measured on full runs, the worst legitimate silence outside the product sync stays
+            // under 5 minutes, while the sync itself went silent for 62 minutes in
+            // manager-4.3-qe-build-validation #43, so it gets a timeout of its own.
+            // Anything that is not a positive number of minutes falls back to the default.
+            // No 'def': both values are read from clientTestingStages() and clientMigrationStages().
+            def idleTimeoutMinutesOr = { value, int fallback ->
+                def raw = value?.toString()?.trim()
+                raw?.isInteger() && raw.toInteger() > 0 ? raw.toInteger() : fallback
+            }
+            cucumberIdleTimeoutMinutes = idleTimeoutMinutesOr(params.cucumber_idle_timeout, 60)
+            productSyncIdleTimeoutMinutes = idleTimeoutMinutesOr(params.product_sync_idle_timeout, 180)
+            withIdleTimeoutOf = { int minutes, Closure body ->
+                timeout(activity: true, time: minutes, unit: 'MINUTES') { body() }
+            }
+            withIdleTimeout = { Closure body ->
+                withIdleTimeoutOf(cucumberIdleTimeoutMinutes, body)
+            }
+
             def ssh_option = '-o StrictHostKeyChecking=no -o ConnectTimeout=7200 -o ServerAliveInterval=60'
             String server_ami = params.server_ami ?: ""
             String proxy_ami = params.proxy_ami ?: ""
@@ -212,7 +231,9 @@ def run(params) {
 
                 stage('Run core features') {
                     if (params.must_run_core && (deployed || !params.must_deploy)) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_core'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_core'"
+                        }
                     }
                 }
 
@@ -220,7 +241,10 @@ def run(params) {
                     if (params.must_sync && (deployed || !params.must_deploy)) {
                         // Get minion list from terraform state list command
                         def nodesHandler = getNodesHandler()
-                        def res_sync_products = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_reposync'", returnStatus: true)
+                        def res_sync_products = 1
+                        withIdleTimeoutOf(productSyncIdleTimeoutMinutes) {
+                            res_sync_products = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_reposync'", returnStatus: true)
+                        }
                         echo "Custom channels and MU repositories synchronization status code: ${res_sync_products}"
                         sh "exit ${res_sync_products}"
                     }
@@ -234,7 +258,10 @@ def run(params) {
                             input 'Press any key to start adding Maintenance Update repositories'
                         }
                         echo 'Add custom channels and MU repositories'
-                        def res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_proxy'", returnStatus: true)
+                        def res_mu_repos = 1
+                        withIdleTimeout {
+                            res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_proxy'", returnStatus: true)
+                        }
                         echo "Custom channels and MU repositories status code: ${res_mu_repos}"
                         sh "exit ${res_mu_repos}"
                     }
@@ -245,7 +272,10 @@ def run(params) {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start adding activation keys'
                         }
-                        def res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_proxy'", returnStatus: true)
+                        def res_add_keys = 1
+                        withIdleTimeout {
+                            res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_proxy'", returnStatus: true)
+                        }
                         echo "Add Proxy Activation Key status code: ${res_add_keys}"
                         sh "exit ${res_add_keys}"
                     }
@@ -256,7 +286,10 @@ def run(params) {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start creating the proxy bootstrap repository'
                         }
-                        def res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_proxy'", returnStatus: true)
+                        def res_create_bootstrap_repos = 1
+                        withIdleTimeout {
+                            res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_proxy'", returnStatus: true)
+                        }
                         echo "Create Proxy bootstrap repository status code: ${res_create_bootstrap_repos}"
                         sh "exit ${res_create_bootstrap_repos}"
                     }
@@ -266,7 +299,10 @@ def run(params) {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start bootstraping the Proxy'
                         }
-                        def res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_proxy'", returnStatus: true)
+                        def res_init_proxy = 1
+                        withIdleTimeout {
+                            res_init_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_proxy'", returnStatus: true)
+                        }
                         echo "Init Proxy status code: ${res_init_proxy}"
                         sh "exit ${res_init_proxy}"
                     }
@@ -290,7 +326,10 @@ def run(params) {
                         if (params.confirm_before_continue) {
                             input 'Press any key to start paygo related tests'
                         }
-                        def res_paygo_testing = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_paygo_testing'", returnStatus: true)
+                        def res_paygo_testing = 1
+                        withIdleTimeout {
+                            res_paygo_testing = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_paygo_testing'", returnStatus: true)
+                        }
                         echo "PAYGO testing status code: ${res_paygo_testing}"
                     }
                 }
@@ -307,7 +346,10 @@ def run(params) {
                                     input 'Press any key to start adding Maintenance Update repositories'
                                 }
                                 echo 'Add custom channels and MU repositories'
-                                def res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_monitoring_server'", returnStatus: true)
+                                def res_mu_repos = 1
+                                withIdleTimeout {
+                                    res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_monitoring_server'", returnStatus: true)
+                                }
                                 echo "Custom channels and MU repositories status code: ${res_mu_repos}"
                                 sh "exit ${res_mu_repos}"
                             }
@@ -318,7 +360,10 @@ def run(params) {
                                 if (params.confirm_before_continue) {
                                     input 'Press any key to start adding activation keys'
                                 }
-                                def res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_monitoring_server'", returnStatus: true)
+                                def res_add_keys = 1
+                                withIdleTimeout {
+                                    res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_monitoring_server'", returnStatus: true)
+                                }
                                 echo "Add Server Monitoring Activation Key status code: ${res_add_keys}"
                                 sh "exit ${res_add_keys}"
                             }
@@ -329,7 +374,10 @@ def run(params) {
                                 if (params.confirm_before_continue) {
                                     input 'Press any key to start creating the Server Monitoring bootstrap repository'
                                 }
-                                def res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_monitoring_server'", returnStatus: true)
+                                def res_create_bootstrap_repos = 1
+                                withIdleTimeout {
+                                    res_create_bootstrap_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_monitoring_server'", returnStatus: true)
+                                }
                                 echo "Create Server Monitoring bootstrap repository status code: ${res_create_bootstrap_repos}"
                                 sh "exit ${res_create_bootstrap_repos}"
                             }
@@ -340,7 +388,10 @@ def run(params) {
                                     input 'Press any key to start bootstraping the Monitoring Server'
                                 }
                                 echo 'Register monitoring server as minion with gui'
-                                def res_init_monitoring = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_monitoring'", returnStatus: true)
+                                def res_init_monitoring = 1
+                                withIdleTimeout {
+                                    res_init_monitoring = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_monitoring'", returnStatus: true)
+                                }
                                 echo "Init Monitoring Server status code: ${res_init_monitoring}"
                                 sh "exit ${res_init_monitoring}"
                             }
@@ -388,16 +439,25 @@ def run(params) {
                                 input 'Press any key to start running the retail tests'
                             }
                             echo 'Prepare Proxy for Retail'
-                            def res_retail_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_retail_proxy'", returnStatus: true)
+                            def res_retail_proxy = 1
+                            withIdleTimeout {
+                                res_retail_proxy = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_retail_proxy'", returnStatus: true)
+                            }
                             echo "Retail proxy status code: ${res_retail_proxy}"
                             if (res_retail_proxy != 0) {
                                 error("Retail proxy failed")
                             }
                             echo 'SLE 12 Retail'
-                            def res_retail_sle12 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_retail_sle12'", returnStatus: true)
+                            def res_retail_sle12 = 1
+                            withIdleTimeout {
+                                res_retail_sle12 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_retail_sle12'", returnStatus: true)
+                            }
                             echo "SLE 12 Retail status code: ${res_retail_sle12}"
                             echo 'SLE 15 Retail'
-                            def res_retail_sle15 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_retail_sle15'", returnStatus: true)
+                            def res_retail_sle15 = 1
+                            withIdleTimeout {
+                                res_retail_sle15 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_retail_sle15'", returnStatus: true)
+                            }
                             echo "SLE 15 Retail status code: ${res_retail_sle15}"
                             if (res_retail_sle15 != 0 || res_retail_sle12 != 0) {
                                 error("Run retail failed")
@@ -419,7 +479,9 @@ def run(params) {
                     def result_error = 0
                     if (deployed || !params.must_deploy) {
                         try {
-                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
+                            withIdleTimeout {
+                                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_finishing'"
+                            }
                         } catch (Exception ex) {
                             println("ERROR: rake cucumber:build_validation_finishing failed.\\nException: ${ex}")
                             result_error = 1
@@ -514,7 +576,10 @@ def clientTestingStages(params, capybara_timeout, default_timeout, minion_type =
                             input 'Press any key to start adding Maintenance Update repositories'
                         }
                         echo 'Add custom channels and MU repositories'
-                        def res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${node}'", returnStatus: true)
+                        def res_mu_repos = 1
+                        withIdleTimeout {
+                            res_mu_repos = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_${node}'", returnStatus: true)
+                        }
                         if (res_mu_repos != 0) {
                             mu_sync_status[node] = 'FAIL'
                             error("Add custom channels and MU repositories failed with status code: ${res_mu_repos}")
@@ -535,7 +600,10 @@ def clientTestingStages(params, capybara_timeout, default_timeout, minion_type =
                             input 'Press any key to start adding common channels'
                         }
                         echo 'Add non MU Repositories'
-                        def res_non_MU_repositories = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:${build_validation_non_MU_script}'", returnStatus: true)
+                        def res_non_MU_repositories = 1
+                        withIdleTimeout {
+                            res_non_MU_repositories = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:${build_validation_non_MU_script}'", returnStatus: true)
+                        }
                         echo "Non MU Repositories status code: ${res_non_MU_repositories}"
                         if (res_non_MU_repositories != 0) {
                             error("Add common channels failed with status code: ${res_non_MU_repositories}")
@@ -550,7 +618,10 @@ def clientTestingStages(params, capybara_timeout, default_timeout, minion_type =
                         input 'Press any key to start adding activation keys'
                     }
                     echo 'Add Activation Keys'
-                    def res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_${node}'", returnStatus: true)
+                    def res_add_keys = 1
+                    withIdleTimeout {
+                        res_add_keys = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_${node}'", returnStatus: true)
+                    }
                     echo "Add Activation Keys status code: ${res_add_keys}"
                     if (res_add_keys != 0) {
                         error("Add Activation Keys failed with status code: ${res_add_keys}")
@@ -568,7 +639,10 @@ def clientTestingStages(params, capybara_timeout, default_timeout, minion_type =
                         lock(resource: mgrCreateBootstrapRepo, timeout: 320) {
                             try {
                                 echo 'Create bootstrap repository'
-                                def res_create_bootstrap_repository = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_${node}'", returnStatus: true)
+                                def res_create_bootstrap_repository = 1
+                                withIdleTimeout {
+                                    res_create_bootstrap_repository = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_create_bootstrap_repository_${node}'", returnStatus: true)
+                                }
                                 echo "Create bootstrap repository status code: ${res_create_bootstrap_repository}"
                                 if (res_create_bootstrap_repository != 0) {
                                     error("Create bootstrap repository failed with status code: ${res_create_bootstrap_repository}")
@@ -587,7 +661,10 @@ def clientTestingStages(params, capybara_timeout, default_timeout, minion_type =
                     }
                     randomWait()
                     echo 'Bootstrap clients'
-                    def res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
+                    def res_init_clients = 1
+                    withIdleTimeout {
+                        res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${node}'", returnStatus: true)
+                    }
                     echo "Init clients status code: ${res_init_clients}"
                     if (res_init_clients != 0) {
                         error("Bootstrap clients failed with status code: ${res_init_clients}")
@@ -601,7 +678,10 @@ def clientTestingStages(params, capybara_timeout, default_timeout, minion_type =
                     }
                     randomWait()
                     echo 'Run Smoke tests'
-                    def res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_smoke_tests_${node}'", returnStatus: true)
+                    def res_smoke_tests = 1
+                    withIdleTimeout {
+                        res_smoke_tests = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_smoke_tests_${node}'", returnStatus: true)
+                    }
                     echo "Smoke tests status code: ${res_smoke_tests}"
                     if (res_smoke_tests != 0) {
                         error("Run Smoke tests failed with status code: ${res_smoke_tests}")
@@ -672,7 +752,10 @@ def clientMigrationStages() {
                 input "Press any key to start testing the migration of ${minion}"
             }
             stage("${minion} migration") {
-                def res_minion_migration = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_${minion}_migration'", returnStatus: true)
+                def res_minion_migration = 1
+                withIdleTimeout {
+                    res_minion_migration = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_${minion}_migration'", returnStatus: true)
+                }
                 echo "${minion} migration status code: ${res_minion_migration}"
                 if (res_minion_migration != 0) {
                     error("Migration test for ${minion} failed with status code: ${res_minion_migration}")

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -59,6 +59,24 @@ def run(params) {
             if (params.deploy_parallelism) {
                 env.common_params = "${env.common_params} --parallelism ${params.deploy_parallelism}"
             }
+            // Inactivity timeout: kills a cucumber run that has stopped producing output entirely.
+            // Measured on full runs, the worst legitimate silence outside the product sync stays
+            // under 5 minutes, while the sync itself went silent for 62 minutes in
+            // manager-4.3-qe-build-validation #43, so it gets a timeout of its own.
+            // Anything that is not a positive number of minutes falls back to the default.
+            // No 'def': both values are read from runCucumberRakeTarget() and clientTestingStages().
+            def idleTimeoutMinutesOr = { value, int fallback ->
+                def raw = value?.toString()?.trim()
+                raw?.isInteger() && raw.toInteger() > 0 ? raw.toInteger() : fallback
+            }
+            cucumberIdleTimeoutMinutes = idleTimeoutMinutesOr(params.cucumber_idle_timeout, 60)
+            productSyncIdleTimeoutMinutes = idleTimeoutMinutesOr(params.product_sync_idle_timeout, 180)
+            withIdleTimeoutOf = { int minutes, Closure body ->
+                timeout(activity: true, time: minutes, unit: 'MINUTES') { body() }
+            }
+            withIdleTimeout = { Closure body ->
+                withIdleTimeoutOf(cucumberIdleTimeoutMinutes, body)
+            }
             try {
                 stage('Clone terracumber, susemanager-ci') {
                     // Create a directory for  to place the directory with the build results (if it does not exist)
@@ -286,7 +304,7 @@ def run(params) {
                     if (params.must_sync && (deployed || !params.must_deploy)) {
                         // Get minion list from tofu state list command
                         def nodesHandler = getNodesHandler(params)
-                        def res_products = runCucumberRakeTarget('cucumber:build_validation_reposync', true, nodesHandler.envVariableListToDisable)
+                        def res_products = runCucumberRakeTarget('cucumber:build_validation_reposync', true, nodesHandler.envVariableListToDisable, productSyncIdleTimeoutMinutes)
                         echo "Custom channels and MU repositories status code: ${res_products}"
                         sh "exit ${res_products}"
                     } else if (isNewJenkins) {
@@ -621,10 +639,11 @@ def run(params) {
 /**
  * Executes a rake command inside the terracumber cucumber step.
  * @param rake_target The full rake target string (e.g., 'cucumber:build_validation_core').
- * @param disableMinions Optional list of environment variables to unset (for parallel client stages).
  * @param return_status Boolean to decide if the command should return the exit status.
+ * @param disableMinions Optional list of environment variables to unset (for parallel client stages).
+ * @param idleTimeoutMinutes Optional inactivity timeout, for the few targets that stay silent longer than the default.
  */
-def runCucumberRakeTarget(String rake_target, boolean return_status = false, disableMinions = null) {
+def runCucumberRakeTarget(String rake_target, boolean return_status = false, disableMinions = null, Integer idleTimeoutMinutes = null) {
     // Note: The disableMinions is provided as a space-separated string in the code (e.g., in getNodesHandler(params)),
     // For compatibility with the original structure where getNodesHandler(params).envVariableListToDisable is a string.
     def unset_vars = ""
@@ -644,10 +663,18 @@ def runCucumberRakeTarget(String rake_target, boolean return_status = false, dis
     // Remove leading/trailing whitespace and execute
     def final_script = script.stripIndent().trim()
 
+    // Inactivity timeout: kills a cucumber run that has stopped producing output entirely.
+    def idleMinutes = idleTimeoutMinutes ?: cucumberIdleTimeoutMinutes
     if (return_status) {
-        return sh(script: final_script, returnStatus: true)
+        def status = 1
+        withIdleTimeoutOf(idleMinutes) {
+            status = sh(script: final_script, returnStatus: true)
+        }
+        return status
     } else {
-        sh final_script
+        withIdleTimeoutOf(idleMinutes) {
+            sh final_script
+        }
     }
 }
 
@@ -819,7 +846,10 @@ def clientTestingStages(params, muLockSlots, smokeTestSlots, bootstrapRepoSlots)
                     // Temporarily modify env.exports to include the bootstrap timeout
                     def custom_exports = "${env.exports} export DEFAULT_TIMEOUT=${env.bootstrap_timeout};"
                     // The helper doesn't easily allow overriding env.exports. For this unique case, we'll keep the logic inline to modify the environment variable within the script block for the special DEFAULT_TIMEOUT.
-                    def res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${custom_exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${nodeTag}'", returnStatus: true)
+                    def res_init_clients = 1
+                    withIdleTimeout {
+                        res_init_clients = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${temporaryList.join(' ')}; ${custom_exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_init_client_${nodeTag}'", returnStatus: true)
+                    }
                     echoHtmlReportPath( "build_validation_init_client_${nodeTag}")
                     echo "Init clients status code: ${res_init_clients}"
                     if (res_init_clients != 0) {

--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -32,6 +32,13 @@ def run(params) {
                     body()
                 }
             }
+            // Inactivity timeout: kills a cucumber run that has stopped producing output entirely.
+            // Anything that is not a positive number of minutes falls back to the default.
+            def rawIdleTimeout = params.cucumber_idle_timeout?.toString()?.trim()
+            def cucumberIdleTimeoutMinutes = rawIdleTimeout?.isInteger() && rawIdleTimeout.toInteger() > 0 ? rawIdleTimeout.toInteger() : 60
+            def withIdleTimeout = { Closure body ->
+                timeout(activity: true, time: cucumberIdleTimeoutMinutes, unit: 'MINUTES') { body() }
+            }
             try {
                 withCreds {
                     stage('Clone terracumber, susemanager-ci and sumaform') {
@@ -117,22 +124,30 @@ def run(params) {
                     }
                 }
                 stage('Sanity Check') {
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:sanity_check'"
+                    withIdleTimeout {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:sanity_check'"
+                    }
                 }
                 stage('Core - Setup') {
                     if (params.run_core) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:core'"
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:reposync'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:core'"
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:reposync'"
+                        }
                     }
                 }
                 stage('Core - Proxy') {
                     if (params.run_core) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:proxy'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:proxy'"
+                        }
                     }
                 }
                 stage('Core - Initialize clients') {
                     if (params.run_core) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                        }
                     }
                 }
                 stage('Secondary features') {
@@ -151,9 +166,12 @@ def run(params) {
                             tags_list = "export TAGS=\"\\\"${transformed_scopes}\\\"\"; "
                         }
 
-                        def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true
-                        def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true
-                        def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true
+                        def statusCode1 = 1
+                        def statusCode2 = 1
+                        def statusCode3 = 1
+                        withIdleTimeout { statusCode1 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true) }
+                        withIdleTimeout { statusCode2 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true) }
+                        withIdleTimeout { statusCode3 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true) }
                         sh "exit \$(( ${statusCode1}|${statusCode2}|${statusCode3} ))"
                     }
                 }

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -21,6 +21,13 @@ def run(params) {
         tfvars_product_version = "susemanager-ci/terracumber_config/tf_files/tfvars/PR-tfvars/PR-testing-${product_version}.tfvars"
         tfvars_platform_localisation = "susemanager-ci/terracumber_config/tf_files/tfvars/PR-tfvars/PR-testing-${platform_localisation}-environments.tfvars"
         tf_local_variables = 'susemanager-ci/terracumber_config/tf_files/tfvars/PR-tfvars/PR-testing-additionnal-repos.tf'
+        // Inactivity timeout: kills a cucumber run that has stopped producing output entirely.
+        // Anything that is not a positive number of minutes falls back to the default.
+        def rawIdleTimeout = params.cucumber_idle_timeout?.toString()?.trim()
+        def cucumberIdleTimeoutMinutes = rawIdleTimeout?.isInteger() && rawIdleTimeout.toInteger() > 0 ? rawIdleTimeout.toInteger() : 60
+        def withIdleTimeout = { Closure body ->
+            timeout(activity: true, time: cucumberIdleTimeoutMinutes, unit: 'MINUTES') { body() }
+        }
         try {
             stage('Get environment') {
                   checkout scm
@@ -284,37 +291,47 @@ def run(params) {
             stage('Sanity Check') {
                 ws(environment_workspace){
                     if(must_test) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:sanity_check'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:sanity_check'"
+                        }
                     }
                 }
             }
             stage('Core - Setup') {
                 ws(environment_workspace){
                     if(must_test) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:core'"
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reposync'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:core'"
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:reposync'"
+                        }
                     }
                 }
             }
             stage('Core - Proxy') {
                 ws(environment_workspace){
                     if(must_test) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:proxy'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake cucumber:proxy'"
+                        }
                     }
                 }
             }
             stage('Core - Initialize clients') {
                 ws(environment_workspace){
                     if(must_test) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${rake_namespace}:init_clients'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; rake ${rake_namespace}:init_clients'"
+                        }
                     }
                 }
             }
             stage('Secondary features') {
                 ws(environment_workspace){
                     if(must_test && ( params.functional_scopes || run_all_scopes) ) {
-                        def statusCode1 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${secondary_exports} cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus:true
-                        def statusCode2 = sh script:"./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${secondary_exports} cd /root/spacewalk/testsuite; rake ${rake_namespace}:secondary_parallelizable'", returnStatus:true
+                        def statusCode1 = 1
+                        def statusCode2 = 1
+                        withIdleTimeout { statusCode1 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${secondary_exports} cd /root/spacewalk/testsuite; rake cucumber:secondary'", returnStatus: true) }
+                        withIdleTimeout { statusCode2 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${secondary_exports} cd /root/spacewalk/testsuite; rake ${rake_namespace}:secondary_parallelizable'", returnStatus: true) }
                         sh "exit \$(( ${statusCode1}|${statusCode2} ))"
                     }
                 }

--- a/jenkins_pipelines/environments/common/pipeline-rke2.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-rke2.groovy
@@ -17,6 +17,13 @@ def run(params) {
             def product_commit = null
             def mirror_scope = env.JOB_BASE_NAME.split('-acceptance-tests')[0]
             mirror_scope = mirror_scope.replaceAll("-dev", "")
+            // Inactivity timeout: kills a cucumber run that has stopped producing output entirely.
+            // Anything that is not a positive number of minutes falls back to the default.
+            def rawIdleTimeout = params.cucumber_idle_timeout?.toString()?.trim()
+            def cucumberIdleTimeoutMinutes = rawIdleTimeout?.isInteger() && rawIdleTimeout.toInteger() > 0 ? rawIdleTimeout.toInteger() : 60
+            def withIdleTimeout = { Closure body ->
+                timeout(activity: true, time: cucumberIdleTimeoutMinutes, unit: 'MINUTES') { body() }
+            }
             // Start pipeline
             def deployed = false
             try {
@@ -66,28 +73,40 @@ def run(params) {
                     def statusCode = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake utils:collect_and_tag_flaky_tests'", returnStatus: true
                 }
                 stage('Sanity Check') {
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:sanity_check'"
+                    withIdleTimeout {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${env.exports} rake cucumber:sanity_check'"
+                    }
                 }
                 stage('Kubernetes sanity checks') {
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:kubernetes_sanity_checks'"
+                    withIdleTimeout {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:kubernetes_sanity_checks'"
+                    }
                 }
                 stage('Kubernetes tests') {
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:kubernetes_tests'"
+                    withIdleTimeout {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:kubernetes_tests'"
+                    }
                 }
                 stage('Core - Setup') {
                     if (runCore) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:core'"
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:reposync'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:core'"
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:reposync'"
+                        }
                     }
                 }
                 stage('Core - Proxy') {
                     if (runCore) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:proxy'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:proxy'"
+                        }
                     }
                 }
                 stage('Core - Initialize clients') {
                     if (runCore) {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                        }
                     }
                 }
                 stage('Secondary features') {
@@ -106,9 +125,12 @@ def run(params) {
                             tags_list = "export TAGS=\"\\\"${transformed_scopes}\\\"\"; "
                         }
 
-                        def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true
-                        def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true
-                        def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true
+                        def statusCode1 = 1
+                        def statusCode2 = 1
+                        def statusCode3 = 1
+                        withIdleTimeout { statusCode1 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true) }
+                        withIdleTimeout { statusCode2 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true) }
+                        withIdleTimeout { statusCode3 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true) }
                         sh "exit \$(( ${statusCode1}|${statusCode2}|${statusCode3} ))"
                     }
                 }

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -81,6 +81,13 @@ def run(params) {
                     body()
                 }
             }
+            // Inactivity timeout: kills a cucumber run that has stopped producing output entirely.
+            // Anything that is not a positive number of minutes falls back to the default.
+            def rawIdleTimeout = params.cucumber_idle_timeout?.toString()?.trim()
+            def cucumberIdleTimeoutMinutes = rawIdleTimeout?.isInteger() && rawIdleTimeout.toInteger() > 0 ? rawIdleTimeout.toInteger() : 60
+            def withIdleTimeout = { Closure body ->
+                timeout(activity: true, time: cucumberIdleTimeoutMinutes, unit: 'MINUTES') { body() }
+            }
             try {
                 withCreds {
                     stage('Clone terracumber, susemanager-ci and sumaform') {
@@ -176,22 +183,30 @@ def run(params) {
                         }
                     }
                     stage('Sanity Check') {
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:sanity_check'"
+                        withIdleTimeout {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:sanity_check'"
+                        }
                     }
                     stage('Core - Setup') {
                         if (runCore) {
-                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:core'"
-                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:reposync'"
+                            withIdleTimeout {
+                                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:core'"
+                                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:reposync'"
+                            }
                         }
                     }
                     stage('Core - Proxy') {
                         if (runCore) {
-                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:proxy'"
+                            withIdleTimeout {
+                                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake cucumber:proxy'"
+                            }
                         }
                     }
                     stage('Core - Initialize clients') {
                         if (runCore) {
-                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                            withIdleTimeout {
+                                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                            }
                         }
                     }
                     stage('Secondary features') {
@@ -213,9 +228,12 @@ def run(params) {
                                 // shell, so the value carries its own quotes rather than nesting single ones.
                                 tags_list = "export TAGS=\"\\\"${transformed_scopes}\\\"\"; "
                             }
-                            def statusCode1 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true
-                            def statusCode2 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true
-                            def statusCode3 = sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true
+                            def statusCode1 = 1
+                            def statusCode2 = 1
+                            def statusCode3 = 1
+                            withIdleTimeout { statusCode1 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake cucumber:secondary'", returnStatus: true) }
+                            withIdleTimeout { statusCode2 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_parallelizable'", returnStatus: true) }
+                            withIdleTimeout { statusCode3 = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd '${tags_list}cd /root/spacewalk/testsuite; ${exports} rake ${params.rake_namespace}:secondary_finishing'", returnStatus: true) }
                             sh "exit \$(( ${statusCode1}|${statusCode2}|${statusCode3} ))"
                         }
                     }


### PR DESCRIPTION
## What does this PR change?

A Playwright worker can wedge after a step timeout and never exit. The stage then produces no further output but keeps the build alive until the job-level wall-clock timeout: build [4176](https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-dev-acceptance-tests-podman/4176/) sat in `Core - Initialize clients` for 11h37m before being aborted by hand.

Every cucumber run now sits inside an inactivity timeout, which resets on every console line, so a long stage is unaffected and only a silent one is killed. It covers `pipeline.groovy`, `pipeline-personal.groovy`, `pipeline-rke2.groovy`, `pipeline-pull-request.groovy` and both build validation pipelines, all through the same `withIdleTimeout` helper.

## The numbers

The default is **60 minutes everywhere**. The build validation product sync gets **180**, because it is the one stage measured going silent for longer. Both are overridable per job, with `cucumber_idle_timeout` and `product_sync_idle_timeout`; anything that is not a positive number of minutes falls back to the default.

Longest silence between two console lines, per stage, measured over full runs:

| run | length | worst silence | where |
|---|---|---|---|
| [manager-4.3-qe-build-validation #43](https://jenkins.mgr.suse.de/job/manager-4.3-qe-build-validation/43/) | 11.6h | **62.4 min** | Sync. products and channels |
| [manager-5.1-sles-qe-build-validation #9](https://jenkins.mgr.suse.de/job/manager-5.1-sles-qe-build-validation/9/) | 9.0h, SUCCESS | **31.1 min** | Sync. products and channels |
| [uyuni-master-dev-acceptance-tests-podman #4174](https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-dev-acceptance-tests-podman/4174/) | 7.9h | 26 min | a retrying Capybara step |
| [manager-4.3-dev-acceptance-tests #3584](https://ci.suse.de/view/Manager-qe/job/manager-4.3-dev-acceptance-tests/3584/) | 10.2h | 26 min | a retrying Capybara step |

Every build validation stage other than the product sync stayed under 5 minutes. Output arrives from terracumber in buffered bursts, so those gaps are what the timeout actually sees, whatever the test was doing underneath.

Two limits of the approach, both visible in the data. During the parallel client stages the branches interleave in one console, so a single branch's silence cannot be separated out — the per-stage numbers there are lower bounds. And an idle timeout only catches silence: [manager-5.2-sles-qe-build-validation #34](https://jenkins.mgr.suse.de/job/manager-5.2-sles-qe-build-validation/34/) ran for 67 hours without ever going quiet for more than 5.5 minutes, retrying `Add Activation Keys` in a loop. Catching that needs a wall-clock stage timeout, which is a separate change.

## Scope

Only the cucumber call itself is wrapped: waiting on a `lock`, on `randomWait()` or on a `confirm_before_continue` input happens outside the block, so a stage queued behind another one is never at risk. On trigger the stage is marked aborted, and `Save TF state` and `Get results` still run.

In `Secondary features` the `sh` calls sit inside the timeout closure rather than in their `def statusCode… =` initialisers. Those variables default to `1`, so a run that never gets to assign one cannot be read as a success.

The Jenkins layer is a deliberate first step, not the final home. A killer has to live outside the wedged process: the testsuite's own Ruby watchdog can never fire, because the main thread holds the GVL inside a native Playwright call. Whether this belongs in terracumber or in the Rakefile instead is tracked in SUSE/spacewalk#31590, with the options and their trade-offs.

## How was this tested?

[ktsamis-personal-pipeline #31](https://ci.suse.de/view/Manager/view/Manager-qe/job/ktsamis-personal-pipeline/31/console), on a throwaway branch that is not part of this PR. To keep the run short it lowered the timeout to 2 minutes and replaced `Sanity Check` with 4 minutes of output followed by silence. **The 2 minutes below is that test rig only.**

The noisy phase ran to completion at twice the timeout, because every line resets the clock:

```
[16:07:14.350Z] Timeout set to expire after 2 min 0 sec without activity
[16:07:14.678Z] noisy phase, line 1 of 8
...
[16:10:47.597Z] noisy phase, line 8 of 8
```

The silent phase was killed 2m12s in, and the `finally` block still ran:

```
[16:11:19.863Z] going silent now
[16:13:31.862Z] Cancelling nested steps due to timeout
[16:13:31.863Z] Sending interrupt signal to process
[16:13:41.213Z] script returned exit code 143
[16:13:41.344Z] Archiving artifacts
```

