### PR TITLE
Drop the 5.2.0 server image tag pin from the 5.2 BV and MI jobs

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-micro-qe-build-validation
@@ -20,11 +20,7 @@ node('sumaform-cucumber') {
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
-            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
-            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
-            // current. Reset the default below to '' once releng re-points the server latest tag.
-            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
+            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation
@@ -39,11 +39,7 @@ node('sumaform-cucumber') {
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
-            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
-            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
-            // current. Reset the default below to '' once releng re-points the server latest tag.
-            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
+            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),

--- a/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP
+++ b/jenkins_pipelines/environments/build-validation/manager-5.2-sles-qe-build-validation-BACKUP
@@ -39,11 +39,7 @@ node('sumaform-cucumber-slc1') {
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
-            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
-            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
-            // current. Reset the default below to '' once releng re-points the server latest tag.
-            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
+            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),

--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -90,11 +90,6 @@ def run(params) {
                         custom_project_path = "registry.suse.de/${params.container_project.toLowerCase().replaceAll(':', '/')}/containerfile"
                         server_container_registry = custom_project_path
                         proxy_container_registry = custom_project_path
-                        // WORKAROUND: the 5.2 jobs pin the server image to the 5.2.0 tag, and that pin
-                        // would follow the registry override above into the container project, hiding
-                        // the server image rebuilt there. Remove this together with those pins.
-                        // Follow up card to remove both: https://github.com/SUSE/spacewalk/issues/31401
-                        server_container_image = ''
                     } else if (isNewJenkins) {
                         Utils.markStageSkippedForConditional(STAGE_NAME)
                     }

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-micro-qe-build-validation
@@ -23,11 +23,7 @@ node('sumaform-cucumber') {
                     description: 'Node list to run during BV'),
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
-            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
-            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
-            // current. Reset the default below to '' once releng re-points the server latest tag.
-            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
+            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: true, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
+++ b/jenkins_pipelines/environments/legacy/build-validation/manager-5.2-sles-qe-build-validation
@@ -41,11 +41,7 @@ node('sumaform-cucumber') {
                     description: 'Node list to run during BV'),
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
-            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
-            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
-            // current. Reset the default below to '' once releng re-points the server latest tag.
-            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
+            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
             booleanParam(name: 'must_run_core', defaultValue: true, description: 'Run Core features'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-bci
@@ -18,11 +18,7 @@ node('sumaform-cucumber') {
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
-            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
-            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
-            // current. Reset the default below to '' once releng re-points the server latest tag.
-            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
+            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),

--- a/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
+++ b/jenkins_pipelines/environments/sle-maintenance-update/manager-5.2-qe-mi-validation-mgrtools
@@ -18,11 +18,7 @@ node('sumaform-cucumber') {
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
             string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Server container registry'),
             string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/containers/suse-multilinuxmanager/5.2/containers', description: 'Proxy container registry'),
-            // WORKAROUND: the server image is pinned to the 5.2.0 tag because latest in the registry
-            // above still resolves to a 2026-04-28 pre-GA build, while every other 5.2 image there is
-            // current. Reset the default below to '' once releng re-points the server latest tag.
-            // Follow up card to remove this pin: https://github.com/SUSE/spacewalk/issues/31401
-            string(name: 'server_container_image', defaultValue: 'suse/multi-linux-manager/5.2/x86_64/server:5.2.0', description: 'Server container image'),
+            string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             // This is different than other pipelines to make it work with the simple proxy_traditional without refactoring all feature files
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),


### PR DESCRIPTION
The `server` `latest` tag in the released 5.2 registry is fixed. It now resolves to the same digest as the `5.2.0` tag, so the pin added in SUSE/susemanager-ci#2160 is no longer needed.

```bash
base=https://registry.suse.de/v2/suse/containers/suse-multilinuxmanager/5.2/containers/suse/multi-linux-manager/5.2/x86_64/server/manifests
acc="application/vnd.docker.distribution.manifest.list.v2+json"
curl -s -H "Accept: $acc" $base/latest | sha256sum   # d26cccc55024...
curl -s -H "Accept: $acc" $base/5.2.0  | sha256sum   # d26cccc55024...
```

Both point at `sha256:0b01d1397aa9...` — version 5.2.14, built 2026-07-07, `com.suse.release-stage: released`.

This resets `server_container_image` back to `''` in the five build validation jobs and the two MI validation jobs, and removes the `server_container_image = ''` override in the `Build containers` stage of `pipeline-build-validation.groovy`, which existed only to keep the pin out of the `bci` job.

Closes SUSE/spacewalk#31401
