### PR TITLE
Install the Uyuni server in the RKE2 benchmark environment

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-RKE2-benchmark-SLC.tf
@@ -96,10 +96,10 @@ module "cucumber_testsuite" {
   // Kubernetes variables
   kubernetes                     = true
   use_devel_oci                  = false
-  install_mlm_server             = false
+  install_mlm_server             = true
   install_mlm_proxy              = false
-  install_traefik                = false
-  install_local_path_provisioner = false
+  install_traefik                = true
+  install_local_path_provisioner = true
   deploy_coco_attestation        = false
   deploy_saline                  = false
   deploy_tftp                    = false


### PR DESCRIPTION
The RKE2 benchmark environment never installs a Uyuni server. The deploy stage passes, but the sanity check dies while loading `env.rb`:

```
FAIL: kubectl get pods -n uyuni -l app.kubernetes.io/component=server -o jsonpath='{.items[0].metadata.name}' returned status code = 1.
```

In sumaform the `helm upgrade --install uyuni` state is guarded by `install_mlm_server` ([install_kubernetes_server.sls#L204](https://github.com/uyuni-project/sumaform/blob/master/salt/server_kubernetes/install_kubernetes_server.sls#L204)). With the flag off, the RKE2 VM comes up with cert-manager and trust-manager, but the `uyuni` namespace stays empty. So there is nothing left to fail and the deploy reports `Succeeded: 89 / Failed: 0`.

Traefik is needed too. `uyuni-ingress.yaml` is copied in unconditionally, and the chart's ingress objects need the IngressRoute CRDs that `install_traefik` applies. The local path provisioner is set to match [Uyuni-Master-RKE2-NUE.tf](https://github.com/SUSE/susemanager-ci/blob/master/terracumber_config/tf_files/Uyuni-Master-RKE2-NUE.tf) and [MLM-Head-RKE2-NUE.tf](https://github.com/SUSE/susemanager-ci/blob/master/terracumber_config/tf_files/MLM-Head-RKE2-NUE.tf).

The flags were turned off in SUSE/susemanager-ci#2128, which also added the `server_kubernetes` host block with `runtime = "rke2"`. Builds [155](https://ci.suse.de/job/uyuni-master-dev-benchmark-tests-RKE2/155/), [157](https://ci.suse.de/job/uyuni-master-dev-benchmark-tests-RKE2/157/) and [158](https://ci.suse.de/job/uyuni-master-dev-benchmark-tests-RKE2/158/) all fail this way. Earlier builds failed at checkout for an unrelated reason, which is why it took until now to show up.
