### PR TITLE
Revert "Add Tumbleweed devel repo for Podman 6.0 testing"

### DIFF
--- a/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
+++ b/terracumber_config/tf_files/Uyuni-Master-podman-NUE.tf
@@ -157,9 +157,6 @@ module "cucumber_testsuite" {
       database_disk_size    = 60
       login_timeout         = 28800
       large_deployment      = true
-      additional_repos = {
-        podman6_repo = "https://download.opensuse.org/repositories/devel:/microos/openSUSE_Tumbleweed/"
-      }
     }
     proxy_containerized = {
       provider_settings = {
@@ -168,9 +165,6 @@ module "cucumber_testsuite" {
       runtime              = "podman"
       container_registry   = "registry.opensuse.org/systemsmanagement/uyuni/master/containerfile"
       container_tag        = "latest"
-      additional_repos = {
-        podman6_repo = "https://download.opensuse.org/repositories/devel:/microos/openSUSE_Tumbleweed/"
-      }
     }
     suse_minion = {
       image             = "tumbleweedo"


### PR DESCRIPTION
Reverts SUSE/susemanager-ci#2099. Marvin reported that Podman 6 is now officially available in Tumbleweed.