### PR TITLE
Drop the undefined res_products echo from the AWS build validation

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -221,7 +221,6 @@ def run(params) {
                         // Get minion list from terraform state list command
                         def nodesHandler = getNodesHandler()
                         res_sync_products = sh(script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'unset ${nodesHandler.envVariableListToDisable.join(' ')}; ${env.exports} cd /root/spacewalk/testsuite; rake cucumber:build_validation_reposync'", returnStatus: true)
-                        echo "Custom channels and MU repositories status code: ${res_products}"
                         echo "Custom channels and MU repositories synchronization status code: ${res_sync_products}"
                         sh "exit ${res_sync_products}"
                     }


### PR DESCRIPTION
## What does this PR change?

The `Sync. products and channels` stage of the AWS build validation pipeline echoes `${res_products}`:

```groovy
res_sync_products = sh(script: "./terracumber-cli ... rake cucumber:build_validation_reposync", returnStatus: true)
echo "Custom channels and MU repositories status code: ${res_products}"
echo "Custom channels and MU repositories synchronization status code: ${res_sync_products}"
```

`res_products` is never assigned anywhere in `pipeline-build-validation-aws.groovy`, so the stage throws `MissingPropertyException` as soon as it runs with `must_sync` set. It only reads as harmless today because the AWS build validation jobs have been failing earlier than this stage.

The status it meant to report is already on the next line, from `res_sync_products`, the variable the stage actually sets, so the line just goes.

The name comes from `pipeline-build-validation.groovy`, where `res_products` does exist; it was copied over in 4c7c9631 and has been dead ever since.

## How was this tested?

Not run: the AWS build validation environment does not currently get as far as this stage. The change removes a reference to an undefined variable and prints nothing that was not already printed on the following line.
