### PR TITLE
Do not abort the results stage when the email fails

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation-aws.groovy
@@ -504,7 +504,12 @@ def run(params) {
                         // junit allowEmptyResults: true, testResults: "${junit_resultdir}/*.xml", skipPublishingChecks: true
                     }
                     // Send email
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                    } catch (Exception ex) {
+                        println("ERROR: sending the results email failed.\\nException: ${ex}")
+                        result_error = 1
+                    }
                     // Clean up old results
                     sh "./clean-old-results -r ${resultdir}"
                     // Fail pipeline if paygo client stages failed

--- a/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-pull-request.groovy
@@ -401,7 +401,12 @@ def run(params) {
                                 archiveArtifacts artifacts: "results/${BUILD_NUMBER}/**/*"
                             }
                             if (email_to != '') {
-                                sh " export TF_VAR_MAIL_TO=${email_to};export TF_VAR_URL_PREFIX=${url_prefix}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --tf_variables_product_file ${tfvars_product_version} --runstep mail"
+                                try {
+                                    sh " export TF_VAR_MAIL_TO=${email_to};export TF_VAR_URL_PREFIX=${url_prefix}; ./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --tf_variables_product_file ${tfvars_product_version} --runstep mail"
+                                } catch(Exception ex) {
+                                    println("ERROR: sending the results email failed: ${ex}")
+                                    error = 1
+                                }
                             }
                             // Clean up old results
                             sh "./clean-old-results -r ${resultdir} -s 10"

--- a/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference-new.groovy
@@ -107,7 +107,11 @@ def run(params) {
                 stage('Get results') {
                     if (!deployed) {
                         // Send email
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                        try {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                        } catch (err) {
+                            println("ERROR: sending the results email failed: ${err}")
+                        }
                     }
                     // Clean up old results
                     sh "./clean-old-results -r ${resultdir}"

--- a/jenkins_pipelines/environments/common/pipeline-reference.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-reference.groovy
@@ -59,7 +59,11 @@ def run(params) {
                 stage('Get results') {
                     if (!deployed) {
                         // Send email
-                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                        try {
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                        } catch (err) {
+                            println("ERROR: sending the results email failed: ${err}")
+                        }
                     }
                     // Clean up old results
                     sh "./clean-old-results -r ${resultdir}"

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -303,7 +303,12 @@ def run(params) {
                         }
                     }
                     // Send email
-                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                    try {
+                        sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                    } catch (err) {
+                        println("ERROR: sending the results email failed: ${err}")
+                        error = 1
+                    }
 
                     if (rrtg_version) {
                         withCreds {

--- a/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
+++ b/jenkins_pipelines/environments/uyuni-master-dev-acceptance-tests-code-coverage
@@ -158,7 +158,12 @@ node('sumaform-cucumber-slc1') {
             stage('Get results') {
                 def error = 0
                 // Send email
-                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                try {
+                    sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/mail.log --runstep mail"
+                } catch (err) {
+                    println("ERROR: sending the results email failed: ${err}")
+                    error = 1
+                }
                 // Clean up old results
                 sh "./clean-old-results -r ${resultdir}"
                 sh "exit ${error}"


### PR DESCRIPTION
Wraps the `Send email` step of every results stage in a try/catch, so a failure to send the email no longer aborts the stage.

That `sh` call was the only unguarded step in the results stages. When `terracumber-cli` exits non-zero the stage aborts on the spot and the steps after it never run — the RRTG ingest, `clean-old-results`, and the `sh "exit ${error}"` line that reports the real test result. Where the stage already tracks an exit code the catch sets it, so a failed email still turns the build red. In the two reference pipelines the email is only sent when the deploy failed and the build is red already, so there the catch only logs.

```
ERROR: sending the results email failed: hudson.AbortException: script returned exit code 1
```
