### PR TITLE
Stop deploying the PXE boot minion in the 4.3 test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For details have a look at [terracumber_config/README.md](terracumber_config/REA
 | Deb-like    | Ubuntu 24.04  | Ubuntu 24.04  | Ubuntu 24.04 | Ubuntu 24.04 | Ubuntu 24.04 | Ubuntu 24.04  | Ubuntu 22.04 |
 | Virthost    | -             | -             | -            | -            | -            | SLES 15 SP7   | SLES 15 SP4  |
 | Buildhost   | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
-| Terminal    | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | SLES 15 SP4  |
+| Terminal    | Leap 15.6     | SLES 15 SP7   | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7  | SLES 15 SP7   | -            |
 | DHCP-DNS    | Leap 15.6     | Leap 15.6     | Leap 15.6    | Leap 15.6    | Leap 15.6    | Leap 15.6     | -            |
 | Controller  | Leap 16.0     | Leap 16.0     | Leap 16.0    | Leap 16.0    | Leap 16.0    | Leap 16.0     | Leap 16.0    |
 | Server      | Tumbleweed    | Tumbleweed    | SL Micro 6.1 | SL Micro 6.2 | SL Micro 6.1 | SLE Micro 5.5 | SLES 15 SP4  |

--- a/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-NUE.tf
@@ -198,13 +198,15 @@ module "cucumber_testsuite" {
     #     memory = 8192
     #   }
     # }
-    pxeboot_minion = {
-      image = "sles15sp4o"
-      provider_settings = {
-        vcpu = 2
-        memory = 2048
-      }
-    }
+    ## The Cobbler PXE boot and Retail mass import features cannot pass on 4.3 anymore,
+    ## dropping the PXE boot minion makes all @pxeboot_minion scenarios skip
+    # pxeboot_minion = {
+    #   image = "sles15sp4o"
+    #   provider_settings = {
+    #     vcpu = 2
+    #     memory = 2048
+    #   }
+    # }
     kvm_host = {
       image = "sles15sp4o"
       provider_settings = {

--- a/terracumber_config/tf_files/SUSEManager-4.3-SLC.tf
+++ b/terracumber_config/tf_files/SUSEManager-4.3-SLC.tf
@@ -196,12 +196,14 @@ module "cucumber_testsuite" {
     #     memory = 8192
     #   }
     # }
-    pxeboot_minion = {
-      image = "sles15sp4o"
-      provider_settings = {
-        memory = 2048
-      }
-    }
+    ## The Cobbler PXE boot and Retail mass import features cannot pass on 4.3 anymore,
+    ## dropping the PXE boot minion makes all @pxeboot_minion scenarios skip
+    # pxeboot_minion = {
+    #   image = "sles15sp4o"
+    #   provider_settings = {
+    #     memory = 2048
+    #   }
+    # }
     kvm_host = {
       image = "sles15sp4o"
       provider_settings = {


### PR DESCRIPTION
Stops deploying the PXE boot minion in the 4.3 acceptance test suites (NUE and SLC), so the Cobbler PXE boot and Retail mass import features are skipped instead of failing on every run.

Both features can no longer pass on 4.3. The Manager-4.3 testsuite only maps `sles15sp6o` and `sles15sp7o` to a Kiwi profile, while the 4.3 environments provide a SLES 15 SP4 terminal, and the Cobbler scenario writes the PXE menu entry on the server while the terminal boots from the traditional proxy. They are also the only consumers of the PXE boot minion here: `@skip_if_containerized_server` keeps them out of every other product line, and the Retail PXE boot feature has been skipped since the 4.3 build host was commented out. With no `pxeboot_minion` host, `PXEBOOT_MAC` stays unset and every `@pxeboot_minion` scenario is skipped.

```
Is sles15sp4o a supported image version? (RuntimeError)
./features/support/retail.rb:62:in 'Object#compute_kiwi_profile_name'
```
