### PR TITLE
Partial revert of "Remove tests on PRs" (b715a5b7).

### DIFF
--- a/jenkins_pipelines/README.md
+++ b/jenkins_pipelines/README.md
@@ -5,6 +5,8 @@ This directory contains the Jenkins pipeline definitions used to deploy and test
 ## Contents
 
 - [environments](environments/): Job definitions for all testsuite including CI, Build Validation, personal, and reference environment pipelines
+- [manager_prs](manager_prs/): Manager PR checks
+- [uyuni_prs](uyuni_prs/): Uyuni PR checks
 - [scripts](scripts/): Helper scripts used by the pipelines
 
 ## Directory structure
@@ -19,13 +21,15 @@ jenkins_pipelines/
 │   ├── salt-shaker/             # One job file per Salt-shaker job (parameter files)
 │   ├── sle-maintenance-update/  # One job file per SLE Maintenance environment (parameter files)
 │   └── manager* | uyuni*        # One job file per other environment (parameter files) mainly CIs
-└── scripts/
-    ├── edit_bci_project/        # Edit BCI project to build container images (SLE Mi BCI 5.1 and 5.0 pipeline)
-    ├── json_generator/          # JSON generation scripts
-    ├── test_review_summary/     # Test review summary script 
-    ├── tests/                   # Unit tests for the scripts
-    └── tf_vars_generator/
-        └── prepare_tfvars.py    # tfvars assembly script (see below)
+├── manager_prs/                 # Manager automated tests on PRs
+├── scripts/
+│   ├── edit_bci_project/        # Edit BCI project to build container images (SLE MI BCI 5.1 and 5.0 pipeline)
+│   ├── json_generator/          # JSON generation scripts
+│   ├── test_review_summary/     # Test review summary script
+│   ├── tests/                   # Unit tests for the scripts
+│   └── tf_vars_generator/
+│       └── prepare_tfvars.py    # tfvars assembly script (see below)
+└── uyuni_prs/                   # Uyuni automated tests on PRs
 ```
 
 ### `environments/build-validation/`

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -1,0 +1,86 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        // CONF To edit
+        repository = "SUSE/spacewalk"
+        context = "backend_unittests_pgsql"
+        description = "python backend pgsql unit test"
+        git_fs = "${env.WORKSPACE}"
+        filter = 'python/'
+        // the actual test is the git repo (inside spacewalk)
+        test = "susemanager-utils/testing/automation/backend-unittest-pgsql.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+    }
+
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Run tests against PR') {
+            steps {
+                echo 'Run tests!'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                            commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e;export PRODUCT=SUSE-Manager; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/python/spacewalk/reports/*_tests.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_changelog_test
@@ -1,0 +1,92 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        repository = "SUSE/spacewalk"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        gitarro_changelog_test = "-r ${repository}" +
+                " -c changelog_test -d \"test if changelog was updated\" " +
+                " -t /var/lib/jenkins/bin/changelog.rb " +
+                " -u ${env.BUILD_URL}" +
+                " -g \"${env.WORKSPACE}\" "
+
+        gitarro_enable_merging = "-r ${repository}" +
+                " --force_test -c merge_enabled -d \"Merging enabled (requires changelog_test passing)\" " +
+                " -u ${env.BUILD_URL}" +
+                " -g \"${env.WORKSPACE}\" "
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+
+        stage('Run changelog test') {
+            steps {
+                echo 'Run changelog tests'
+                script {
+                    gitarro_changelog_test_cmd = "${gitarro_cmd} ${gitarro_changelog_test}"
+                    gitarro_enable_merging_cmd = "${gitarro_cmd} ${gitarro_enable_merging}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                            gitarro_changelog_test_cmd = "${gitarro_local} ${gitarro_changelog_test}"
+                            gitarro_enable_merging_cmd = "${gitarro_local} ${gitarro_enable_merging}"
+                    }                    
+                    if (params.PR_NUMBER != '') {
+                        gitarro_changelog_test_cmd = "${gitarro_changelog_test_cmd} -P ${params.PR_NUMBER}"
+                        gitarro_enable_merging_cmd = "${gitarro_enable_merging_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; export PRODUCT=SUSE-Manager; ${gitarro_changelog_test_cmd}; CLRET=\${?}; " +
+                   "if [ \$CLRET -eq 0 ]; then " +
+                   "${gitarro_enable_merging_cmd} -t /usr/bin/true; " +
+                   "else ${gitarro_enable_merging_cmd} -t /usr/bin/false; " +
+                   "fi; exit \$CLRET"
+            }
+        }
+    }
+    // postactions
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -1,0 +1,101 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+    }
+
+    environment {
+      repository = 'SUSE/spacewalk'
+      gitarro_cmd = 'gitarro.ruby2.5'
+      gitarro_local = 'ruby gitarro.rb'
+      check = " -r ${repository} -t placeholder --check --changed_since 172800"
+    }
+
+    agent { label 'suse-manager-unit-tests' }
+
+    triggers {
+        cron('H/10 * * * *')
+    }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Trigger pending tests') {
+            steps {
+                echo "Trigger pending tests"
+                script {
+                    contexts = [
+                            'changelog_test' : 'notype',
+                            'java_lint_checkstyle' : 'java/',
+                            'java_pgsql_tests' : 'java/',
+                            'spacecmd_unittests': 'spacecmd/',
+                            'ruby_rubocop' : 'testsuite/',
+                            'backend_unittests_pgsql' : 'python/',
+                            'frontend_checks' : 'web/',
+                            'schema_migration_test_pgsql' : 'schema/spacewalk',
+                            'susemanager_unittests' : 'susemanager/'
+                    ]
+                    contexts.each { context, filter ->
+                        commands = "${gitarro_cmd} ${check} -c ${context} -f ${filter}"
+                        if (params.GITARRO_PR_NUMBER != '') {
+                            commands = "${gitarro_local} ${check} -c ${context} -f ${filter}"
+                        }
+                        PENDING = sh(
+                            script: "${commands}",
+                            returnStdout: true
+                            ).trim()
+                        echo PENDING
+                        if (PENDING.contains('TESTREQUIRED=true')) {
+                            PR_NUMBER = sh(script: "grep 'PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2", returnStdout: true).trim()
+                            build(
+                                job: "manager-prs-${context}-pipeline",
+                                parameters: [
+                                             [$class: 'StringParameterValue', name: 'GITARRO_PR_NUMBER', value: params.GITARRO_PR_NUMBER], 
+                                             [$class: 'StringParameterValue', name: 'PR_NUMBER', value: PR_NUMBER]
+                                            ],
+                                wait: false
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        success{
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_frontend_checks
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_frontend_checks
@@ -1,0 +1,77 @@
+#!/usr/bin/env groovy
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        frontend_checks = "-r SUSE/spacewalk" +
+                " -c frontend_checks -d \"frontend-checks\" " +
+                " -f \"web/\" " +
+                " -t susemanager-utils/testing/automation/frontend-checks.sh" +
+                " -u ${env.BUILD_URL} " +
+                " -g ${env.WORKSPACE} "
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Run all frontend checks') {
+            steps {
+                echo 'Run all frontend checks'
+                script {
+                    frontend_checks_cmd = "${gitarro_cmd} ${frontend_checks}"
+                    if (params.GITARRO_PR_NUMBER != "") {
+                        frontend_checks_cmd = "${gitarro_local} ${frontend_checks}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        frontend_checks_cmd = "${frontend_checks_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "export PRODUCT=SUSE-Manager && ${frontend_checks_cmd}"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_lint_checkstyle
@@ -1,0 +1,78 @@
+#!/usr/bin/env groovy
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        javacheckstyle_test = "-r SUSE/spacewalk" +
+                " -c java_lint_checkstyle -d \"java-checkstyle\" " +
+                " -f \"java/\" " +
+                " -t susemanager-utils/testing/automation/java-checkstyle.sh" +
+                " -u ${env.BUILD_URL} " +
+                " -g ${env.WORKSPACE} "
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+
+        stage('Run Javacheckstyle test') {
+            steps {
+                echo 'Run javacheckstyle tests'
+                script {
+                    javacheckstyle_test_cmd = "${gitarro_cmd} ${javacheckstyle_test}"
+                    if (params.GITARRO_PR_NUMBER != "") {
+                        javacheckstyle_test_cmd = "${gitarro_local} ${javacheckstyle_test}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        javacheckstyle_test_cmd = "${javacheckstyle_test_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "export PRODUCT=SUSE-Manager && ${javacheckstyle_test_cmd}"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -1,0 +1,87 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+
+        // specific psql conf
+        repository = "SUSE/spacewalk"
+        context = "java_pgsql_tests"
+        description = "java pgsql unit test"
+        filter = "java/"
+        git_fs = "${env.WORKSPACE}"
+        // the actual test is the git repo
+        test = "susemanager-utils/testing/automation/java-unittests-pgsql.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'sumadocker-nue' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Run Java psql unit test') {
+            steps {
+                echo 'Run psql unit tests'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                            commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; export PRODUCT=SUSE-Manager; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/java/test-results/*.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_ruby_rubocop
@@ -1,0 +1,101 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        repository = "SUSE/spacewalk"
+        context = "ruby_rubocop"
+        description = "rubocop checkstyle"
+        git_fs = "${env.WORKSPACE}"
+        filter = 'testsuite/'
+        test = "${env.WORKSPACE}/jenkins_pipelines/manager_prs/tests_files/rubocop.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro/gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+    }
+
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            when {
+                anyOf {
+                    changeset "**/*.rb"
+                    changeset ".github/workflows/rubocop.yml"
+                    changeset "testsuite/.rubocop.yml"
+                    changeset "testsuite/.rubocop_todo.yml"
+                    changeset "testsuite/Gemfile"
+                    changeset "testsuite/Rakefile"
+                }
+            }
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        dir('gitarro') {
+                            checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                      extensions       : [[$class: 'LocalBranch']],
+                                      userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                        }
+                    }
+                }
+            }
+        }
+        stage('Run tests against PR') {
+            when {
+                anyOf {
+                    changeset "**/*.rb"
+                    changeset ".github/workflows/rubocop.yml"
+                    changeset "testsuite/.rubocop.yml"
+                    changeset "testsuite/.rubocop_todo.yml"
+                    changeset "testsuite/Gemfile"
+                    changeset "testsuite/Rakefile"
+                }
+            }
+            steps {
+                echo 'Run tests!'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "export PRODUCT=SUSE-Manager && ${commands}"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -1,0 +1,89 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+    
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        // specific psql conf
+        repository = "SUSE/spacewalk"
+        context = "schema_migration_test_pgsql"
+        description = "schema migration test"
+        filter = "schema/spacewalk"
+        git_fs = "${env.WORKSPACE}"
+        test = "susemanager-utils/testing/automation/schema-migration-test-pgsql.sh" 
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+    // postgresql
+        runtest_pg = "-r ${repository}" +
+                " -c ${context} -d ${description} " +
+                " -f ${filter} " +
+                " -g ${git_fs} " +
+                " -u \"${env.BUILD_URL}\"" +
+                " -t ${test} "
+    }
+
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+
+        stage('Run schema tests postgresql') {
+            steps {
+                echo 'Run tests'
+                script {
+                    runtest_pg_cmd = "${gitarro_cmd} ${runtest_pg}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                            runtest_pg_cmd = "${gitarro_local} ${runtest_pg}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        runtest_pg_cmd = "${runtest_pg_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }     
+                }
+                sh "export PRODUCT=SUSE-Manager && ${runtest_pg_cmd}"
+            }
+        }
+
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -1,0 +1,88 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+
+        // CONF To edit
+        repository = 'SUSE/spacewalk'
+        context = 'spacecmd_unittests'
+        description = 'python unit test for spacecmd'
+        git_fs = "${env.WORKSPACE}"
+        filter = 'spacecmd/'
+        // the actual test is the git repo (inside spacewalk)
+        test = 'susemanager-utils/testing/automation/spacecmd-unittest.sh'
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+
+        stage('Run tests against PR') {
+            steps {
+                echo 'Run spacecmd unit tests!'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e;export PRODUCT=SUSE-Manager ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/spacecmd/reports/junit_tests.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_susemanager_unittests
@@ -1,0 +1,86 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        // specific psql conf
+        repository = "SUSE/spacewalk"
+        context = "susemanager_unittests"
+        description = "susemanager unit test"
+        filter = "susemanager/"
+        git_fs = "${env.WORKSPACE}"
+        // the actual test is the git repo
+        test = "susemanager-utils/testing/automation/susemanager-unittest.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Run tests') {
+            steps {
+                echo 'Run tests'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; export PRODUCT=SUSE-Manager; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/susemanager/src/reports/tests.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
+++ b/jenkins_pipelines/manager_prs/tests_files/rubocop.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+echo "running rubocop on step files"
+rubocop_file="testsuite/.rubocop.yml"
+if [[ -f "$rubocop_file" ]]; then
+  # Extract the Ruby version from the file
+  ruby_version=$(grep "TargetRubyVersion:" "$rubocop_file" | awk '{print $2}')
+  if [[ -n "$ruby_version" ]]; then
+    cd testsuite
+    docker run --rm --volume "$PWD:/app" docker.io/srbarrios/rubocop:ruby-$ruby_version
+  else
+    echo "No TargetRubyVersion found in $rubocop_file."
+  fi
+else
+  echo "File $rubocop_file does not exist."
+fi

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_backend_unittests_pgsql
@@ -1,0 +1,88 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+
+        // CONF To edit
+        repository = "uyuni-project/uyuni"
+        context = "backend_unittests_pgsql"
+        description = "python backend pgsql unit test"
+        git_fs = "${env.WORKSPACE}"
+        filter = 'python/'
+        // the actual test is the git repo (inside spacewalk)
+        test = "susemanager-utils/testing/automation/backend-unittest-pgsql.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+
+        stage('Run tests against PR') {
+            steps {
+                echo 'Run tests!'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/python/spacewalk/reports/*_tests.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_check
@@ -1,0 +1,95 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+    }
+
+    environment {
+      repository = "uyuni-project/uyuni"
+      gitarro_cmd = 'gitarro.ruby2.5'
+      gitarro_local = 'ruby gitarro.rb'
+      check = " -r ${repository} -t placeholder --check --changed_since 172800"
+    }
+
+    agent { label 'suse-manager-unit-tests' }
+
+    triggers {
+        cron('H/10 * * * *')
+    }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Trigger pending tests') {
+            steps {
+                script {
+                    contexts = [
+                            'java_pgsql_tests' : 'java/',
+                            'spacecmd_unittests': 'spacecmd/',
+                            'backend_unittests_pgsql' : 'python/',
+                            'schema_migration_test_pgsql' : 'schema/spacewalk',
+                            'susemanager_unittests' : 'susemanager/'
+                    ]
+                    contexts.each { context, filter ->
+                        commands = "${gitarro_cmd} ${check} -c ${context} -f ${filter}"
+                        if (params.GITARRO_PR_NUMBER != '') {
+                            commands = "${gitarro_local} ${check} -c ${context} -f ${filter}"
+                        }
+                        PENDING = sh(
+                            script: "${commands}",
+                            returnStdout: true
+                            ).trim()
+                        echo PENDING
+                        if (PENDING.contains('TESTREQUIRED=true')) {
+                            PR_NUMBER = sh(script: "grep 'PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2", returnStdout: true).trim()
+                            build(
+                                job: "uyuni-prs-${context}-pipeline",
+                                parameters: [
+                                             [$class: 'StringParameterValue', name: 'GITARRO_PR_NUMBER', value: params.GITARRO_PR_NUMBER], 
+                                             [$class: 'StringParameterValue', name: 'PR_NUMBER', value: PR_NUMBER]
+                                            ],
+                                wait: false
+                            )                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        success{
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_java_pgsql_tests
@@ -1,0 +1,83 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        ansiColor('xterm')
+    }
+    
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+
+        // specific psql conf
+        repository = "uyuni-project/uyuni"
+        context = "java_pgsql_tests"
+        description = "java pgsql unit test"
+        filter = "java/"
+        git_fs = "${env.WORKSPACE}"
+        // the actual test is the git repo
+        test = "susemanager-utils/testing/automation/java-unittests-pgsql.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'sumadocker-nue' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Run Java psql unit test') {
+            steps {
+                echo 'Run psql unit tests'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                            commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/java/test-results/*.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+
+    post {
+        success {
+            cleanWs()
+        }
+    }
+}

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_schema_migration_test_pgsql
@@ -1,0 +1,88 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+    
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        // specific psql conf
+        repository = "uyuni-project/uyuni"
+        context = "schema_migration_test_pgsql"
+        description = "schema migration test"
+        filter = "schema/spacewalk"
+        git_fs = "${env.WORKSPACE}"
+        test = "susemanager-utils/testing/automation/schema-migration-test-pgsql.sh"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+    // postgresql
+        runtest_pg = "-r ${repository}" +
+                " -c ${context} -d ${description} " +
+                " -f ${filter} " +
+                " -g ${git_fs} " +
+                " -u \"${env.BUILD_URL}\"" +
+                " -t ${test} "
+    }
+
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Run schema tests postgresql') {
+            steps {
+                echo 'Run tests'
+                script {
+                    runtest_pg_cmd = "${gitarro_cmd} ${runtest_pg}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        runtest_pg_cmd = "${gitarro_local} ${runtest_pg}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        runtest_pg_cmd = "${runtest_pg_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "${runtest_pg_cmd}"
+            }
+        }
+
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_spacecmd_unittests
@@ -1,0 +1,88 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+    
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+
+        // CONF To edit
+        repository = "uyuni-project/uyuni"
+        context = "spacecmd_unittests"
+        description = "python unit test for spacecmd"
+        git_fs = "${env.WORKSPACE}"
+        filter = 'spacecmd/'
+        // the actual test is the git repo (inside spacewalk)
+        test = "susemanager-utils/testing/automation/spacecmd-unittest.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+
+        stage('Run tests against PR') {
+            steps {
+                echo 'Run spacecmd unit tests!'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/spacecmd/reports/junit_tests.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
+++ b/jenkins_pipelines/uyuni_prs/Jenkinsfile_prs_susemanager_unittests
@@ -1,0 +1,86 @@
+#!/usr/bin/env groovy
+
+// Configure the build properties
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '500'))
+])
+
+pipeline {
+
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+        ansiColor('xterm')
+    }
+
+    parameters {
+        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
+        string(defaultValue: '', description: 'Uyuni PR', name: 'PR_NUMBER')
+        booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
+    }
+
+    environment {
+        // specific psql conf
+        repository = "uyuni-project/uyuni"
+        context = "susemanager_unittests"
+        description = "susemanager unit test"
+        filter = "susemanager/"
+        git_fs = "${env.WORKSPACE}"
+        // the actual test is the git repo
+        test = "susemanager-utils/testing/automation/susemanager-unittest.sh"
+        gitarro_common_params = "-r ${repository} -c ${context} -d ${description} -f ${filter} -t ${test} -g ${git_fs}"
+        gitarro_cmd = 'gitarro.ruby2.5'
+        gitarro_local = 'ruby gitarro.rb'
+        runtest = "${gitarro_common_params} -u ${env.BUILD_URL}"
+
+    }
+    // run only on specific hosts
+    agent { label 'suse-manager-unit-tests' }
+
+    stages {
+        stage('Clean Up Workspace') {
+            steps {
+                echo 'Clean up previous workspace'
+                cleanWs()
+                echo 'Check out SCM'
+                checkout scm
+                script {
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        echo 'Check out Gitarro PR'
+                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                                  extensions       : [[$class: 'LocalBranch']],
+                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
+                    }
+                }
+            }
+        }
+        stage('Run tests') {
+            steps {
+                echo 'Run tests'
+                script {
+                    commands = "${gitarro_cmd} ${runtest}"
+                    if (params.GITARRO_PR_NUMBER != '') {
+                        commands = "${gitarro_local} ${runtest}"
+                    }
+                    if (params.PR_NUMBER != '') {
+                        commands = "${commands} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                }
+                sh "set +e; ${commands}; TESTS_RESULT=\$?; set -e;"
+                echo 'Collecting JUnit Test reports'
+                junit allowEmptyResults: true, testResults: "**/susemanager/src/reports/tests.xml"
+                sh "exit \$TESTS_RESULT"
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                if (params.cleanWorkspace == true) {
+                    echo 'Clean up current workspace, when job success.'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Partial revert of "Remove tests on PRs" (b715a5b7).

The automatic PR check jobs (_manager-prs-*_, _uyuni-prs-*_) are still driven by gitarro and were not yet migrated to GitHub Actions, so their Jenkinsfiles must stay. Only the manual PR testing pipelines remain removed.