### PR TITLE
Fix the helm charts pipeline fileExists

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_helm_charts_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_helm_charts_tests
@@ -52,7 +52,7 @@ pipeline {
         stage('Run Helm charts test') {
             when {
                 expression {
-                    return fileExists (${test_script})
+                    return fileExists ("${test_script}")
                 }
             }
             steps {


### PR DESCRIPTION
fileExists needs a string as parameter and the variable needs to be within quotes.

Also harmonize the file name with its sibblings while at it.