### PR TITLE
Give the client bootstrap stage its own timeout

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-personal.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-personal.groovy
@@ -8,6 +8,7 @@ def run(params) {
             // The junit plugin doesn't affect full paths
             GString junit_resultdir = "results/${BUILD_NUMBER}/results_junit"
             GString exports = "export BUILD_NUMBER=${env.BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${params.capybara_timeout}; export DEFAULT_TIMEOUT=${params.default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
+            def bootstrap_timeout = 300
             String tfvariables_file = 'susemanager-ci/terracumber_config/tf_files/personal/variables.tf'
             String tfvars_infra_description = "susemanager-ci/terracumber_config/tf_files/personal/environment.tfvars"
             GString common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --tf_variables_description_file ${tfvariables_file}  --gitfolder ${resultdir}/sumaform --terraform-bin ${params.bin_path}"
@@ -146,7 +147,7 @@ def run(params) {
                 stage('Core - Initialize clients') {
                     if (params.run_core) {
                         withIdleTimeout {
-                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} export DEFAULT_TIMEOUT=${bootstrap_timeout}; rake parallel:init_clients'"
                         }
                     }
                 }

--- a/jenkins_pipelines/environments/common/pipeline-rke2.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-rke2.groovy
@@ -8,6 +8,7 @@ def run(params) {
             // The junit plugin doesn't affect full paths
             env.common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform --terraform-bin ${params.bin_path}"
             env.exports = "export BUILD_NUMBER=${BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
+            env.bootstrap_timeout = 300
 
             if (params.deploy_parallelism) {
                 env.common_params = "${env.common_params} --parallelism ${params.deploy_parallelism}"
@@ -105,7 +106,7 @@ def run(params) {
                 stage('Core - Initialize clients') {
                     if (runCore) {
                         withIdleTimeout {
-                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                            sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} export DEFAULT_TIMEOUT=${bootstrap_timeout}; rake parallel:init_clients'"
                         }
                     }
                 }

--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -14,6 +14,7 @@ def run(params) {
             GString junit_resultdir = "results/${env.BUILD_NUMBER}/results_junit"
             // Mutable: the AWS backend appends PUBLISH_CUCUMBER_REPORT below
             def exports = "export BUILD_NUMBER=${env.BUILD_NUMBER}; export CAPYBARA_TIMEOUT=${capybara_timeout}; export DEFAULT_TIMEOUT=${default_timeout}; export CUCUMBER_PUBLISH_QUIET=true;"
+            def bootstrap_timeout = 300
             GString common_params = "--outputdir ${resultdir} --tf ${params.tf_file} --gitfolder ${resultdir}/sumaform --terraform-bin ${params.bin_path}"
 
 
@@ -205,7 +206,7 @@ def run(params) {
                     stage('Core - Initialize clients') {
                         if (runCore) {
                             withIdleTimeout {
-                                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} rake parallel:init_clients'"
+                                sh "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/testsuite; ${exports} export DEFAULT_TIMEOUT=${bootstrap_timeout}; rake parallel:init_clients'"
                             }
                         }
                     }


### PR DESCRIPTION
Runs the `Core - Initialize clients` stage with `DEFAULT_TIMEOUT=300` instead of the 250 the rest of the run uses.

Six cucumber workers onboard their clients at the same time, and the server regularly takes longer than 250 seconds to finish `Apply states` under that load. The stage then fails on a timeout that has nothing to do with the change under test, and passes on a retry with no other difference. `pipeline-build-validation.groovy` already overrides the timeout for its bootstrap stage; this applies the same pattern to `pipeline.groovy`, `pipeline-rke2.groovy` and `pipeline-personal.groovy`.

The override only takes full effect together with https://github.com/uyuni-project/uyuni/pull/12521, which stops the wait for an event to appear in the system history from ignoring the caller's timeout.
