### PR TITLE
helm chart: cannot check for the tests script presence

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_helm_charts_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_helm_charts_tests
@@ -53,19 +53,15 @@ pipeline {
             steps {
                 echo 'Run helm charts tests'
                 script {
-                    if (fileExists("${test_script}")) {
-                        helmcharts_test_cmd = "${gitarro_cmd} ${helmcharts_test}"
-                        if (params.GITARRO_PR_NUMBER != "") {
-                            helmcharts_test_cmd = "${gitarro_local} ${helmcharts_test}"
-                        }
-                        if (params.PR_NUMBER != '') {
-                            helmcharts_test_cmd = "${helmcharts_test_cmd} -P ${params.PR_NUMBER}"
-                            currentBuild.displayName = "PR: ${params.PR_NUMBER}"
-                        }
-                        sh "export PRODUCT=SUSE-Manager && ${helmcharts_test_cmd}"
-                    } else {
-                        echo "Skipping stage: ${test_script} not found in the PR."
+                    helmcharts_test_cmd = "${gitarro_cmd} ${helmcharts_test}"
+                    if (params.GITARRO_PR_NUMBER != "") {
+                        helmcharts_test_cmd = "${gitarro_local} ${helmcharts_test}"
                     }
+                    if (params.PR_NUMBER != '') {
+                        helmcharts_test_cmd = "${helmcharts_test_cmd} -P ${params.PR_NUMBER}"
+                        currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                    }
+                    sh "export PRODUCT=SUSE-Manager && ${helmcharts_test_cmd}"
                 }
             }
         }


### PR DESCRIPTION
The test script is in the PR to check and the pipeline checks out the CI repo. Such a check would be in Gitarro… if we ever want it.