### PR TITLE
Fix the git log quoting in the Product changes stage

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline.groovy
+++ b/jenkins_pipelines/environments/common/pipeline.groovy
@@ -177,7 +177,7 @@ def run(params) {
                         # Note: This is a trade-off, we should be comparing the git revisions of all the packages composing our product
                         #       For that extra mile, we need a new tag in the repo metadata of each built, with the git revision of the related repository.
                     """
-                            sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/; git --no-pager log --pretty=format:\\\"%h %\\<(16,trunc)%cn  %s  %d\\\" ${previous_commit}..${product_commit}'", returnStatus: true
+                            sh script: "./terracumber-cli ${common_params} --logfile ${resultdirbuild}/testsuite.log --runstep cucumber --cucumber-cmd 'cd /root/spacewalk/; git --no-pager log --pretty=format:\"%h %<(16,trunc)%cn  %s  %d\" ${previous_commit}..${product_commit}'", returnStatus: true
                         } else {
                             println("Product changes disabled, checkbox 'show_product_changes' was not enabled'")
                         }


### PR DESCRIPTION
Fixes the quoting of the `git log` command in the `Product changes` stage, so the stage actually prints the product commits instead of dying on a shell syntax error.

The pretty format was escaped twice (`format:\\\"%h %\\<(16,trunc)...`), so the backslashes reached the remote shell literally. `\"` is then an escaped quote rather than a quoting delimiter, which leaves the parentheses of `%<(16,trunc)` unquoted and bash refuses the line:

```
bash: -c: line 1: syntax error near unexpected token `('
bash: -c: line 1: `cd /root/spacewalk/; git --no-pager log --pretty=format:\"%h %\<(16,trunc)%cn  %s  %d\" bd071d37...9bbad948...'
```

The stage runs with `returnStatus: true`, so the build stays green and the failure is easy to miss — it has produced no output on any build, including the ones with a real commit range. With a single level of escaping, matching what `pipeline-personal.groovy` already does, the remote shell parses the format string and the stage prints:

```
cda599d1 Konstantinos T..  Add RHEL 7, 8, 9 and 10 clients to the build validation environments   (HEAD -> ...)
37accc37 Cédric Bosdonnat  Check for helm charts test too   (origin/master, origin/HEAD)
```
