### PR TITLE
Replace prs_checks and the helm_charts_tests with pr-checker

### DIFF
--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_check
@@ -13,14 +13,10 @@ pipeline {
     }
 
     parameters {
-        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
     }
 
     environment {
       repository = 'SUSE/spacewalk'
-      gitarro_cmd = 'gitarro.ruby2.5'
-      gitarro_local = 'ruby gitarro.rb'
-      check = " -r ${repository} -t placeholder --check --changed_since 172800"
     }
 
     agent { label 'suse-manager-unit-tests' }
@@ -36,49 +32,40 @@ pipeline {
                 cleanWs()
                 echo 'Check out SCM'
                 checkout scm
-                script {
-                    if (params.GITARRO_PR_NUMBER != '') {
-                        echo 'Check out Gitarro PR'
-                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
-                                  extensions       : [[$class: 'LocalBranch']],
-                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
-                    }
-                }
             }
         }
         stage('Trigger pending tests') {
             steps {
-                echo "Trigger pending tests"
+                echo "List needed tests"
                 script {
-                    contexts = [
-                            'changelog_test' : 'notype',
-                            'java_lint_checkstyle' : 'java/',
-                            'java_pgsql_tests' : 'java/',
-                            'helm_charts_tests': 'containers/.*-helm/.*',
-                            'spacecmd_unittests': 'spacecmd/',
-                            'ruby_rubocop' : 'testsuite/',
-                            'backend_unittests_pgsql' : 'python/',
-                            'frontend_checks' : 'web/',
-                            'schema_migration_test_pgsql' : 'schema/spacewalk',
-                            'susemanager_unittests' : 'susemanager/'
-                    ]
-                    contexts.each { context, filter ->
-                        commands = "${gitarro_cmd} ${check} -c ${context} -f ${filter}"
-                        if (params.GITARRO_PR_NUMBER != '') {
-                            commands = "${gitarro_local} ${check} -c ${context} -f ${filter}"
-                        }
-                        PENDING = sh(
-                            script: "${commands}",
-                            returnStdout: true
-                            ).trim()
-                        echo PENDING
-                        if (PENDING.contains('TESTREQUIRED=true')) {
-                            PR_NUMBER = sh(script: "grep 'PR_NUMBER:' ${env.WORKSPACE}/.gitarro_vars | cut -d ':' -f2", returnStdout: true).trim()
+                    writeFile(
+                        file: "${env.WORKSPACE}/pr-checker-config.json",
+                        encoding: "UTF-8",
+                        text: '''\
+                          |{
+                          |  "changelog_test" : [""],
+                          |  "java_lint_checkstyle" : ["java/"],
+                          |  "java_pgsql_tests" : ["java/"],
+                          |  "helm_charts_tests": ["containers/*-helm/*"],
+                          |  "spacecmd_unittests": ["spacecmd/"],
+                          |  "ruby_rubocop" : ["testsuite/"],
+                          |  "backend_unittests_pgsql" : ["python/"],
+                          |  "frontend_checks" : ["web/"],
+                          |  "schema_migration_test_pgsql" : ["schema/spacewalk"],
+                          |  "susemanager_unittests" : ["susemanager/"]
+                          |}
+                        '''.stripMargin(),
+                    )
+                    sh(
+                        "pr-checker --log-level debug --repo ${repository} list --config ${env.WORKSPACE}/pr-checker-config.json"
+                    )
+                    checks = readJSON(file: "${env.WORKSPACE}/checks.json")
+                    checks.each { pr, prData ->
+                        prData.checks_to_run.each { context ->
                             build(
                                 job: "manager-prs-${context}-pipeline",
                                 parameters: [
-                                             [$class: 'StringParameterValue', name: 'GITARRO_PR_NUMBER', value: params.GITARRO_PR_NUMBER], 
-                                             [$class: 'StringParameterValue', name: 'PR_NUMBER', value: PR_NUMBER]
+                                             [$class: 'StringParameterValue', name: 'PR_NUMBER', value: pr]
                                             ],
                                 wait: false
                             )

--- a/jenkins_pipelines/manager_prs/Jenkinsfile_prs_helm_charts_tests
+++ b/jenkins_pipelines/manager_prs/Jenkinsfile_prs_helm_charts_tests
@@ -7,26 +7,17 @@ properties([
 pipeline {
 
     options {
-        timeout(time: 30, unit: 'MINUTES') 
+        timeout(time: 30, unit: 'MINUTES')
         ansiColor('xterm')
     }
 
     parameters {
-        string(defaultValue: '', description: 'Gitarro PR', name: 'GITARRO_PR_NUMBER')
         string(defaultValue: '', description: 'SUSE Manager PR', name: 'PR_NUMBER')
         booleanParam(defaultValue: true, description: 'Clean up workspace after a successful execution.', name: 'cleanWorkspace')
     }
 
     environment {
-        gitarro_cmd = 'gitarro.ruby2.5'
-        gitarro_local = 'ruby gitarro.rb'
-        test_script = 'susemanager-utils/testing/automation/helm-charts-tests.sh'
-        helmcharts_test = "-r SUSE/spacewalk" +
-                " -c helm_charts_tests -d \"Helm charts tests\" " +
-                " -f \"containers/.*-helm/.*\" " +
-                " -t ${test_script} " +
-                " -u ${env.BUILD_URL} " +
-                " -g ${env.WORKSPACE} "
+        repository = 'SUSE/spacewalk'
     }
     // run only on specific hosts
     agent { label 'suse-manager-unit-tests' }
@@ -38,14 +29,6 @@ pipeline {
                 cleanWs()
                 echo 'Check out SCM'
                 checkout scm
-                script {
-                    if (params.GITARRO_PR_NUMBER != '') {
-                        echo 'Check out Gitarro PR'
-                        checkout([$class           : 'GitSCM', branches: [[name: "FETCH_HEAD"]],
-                                  extensions       : [[$class: 'LocalBranch']],
-                                  userRemoteConfigs: [[refspec: "+refs/pull/${params.GITARRO_PR_NUMBER}/head:refs/remotes/origin/PR-${params.GITARRO_PR_NUMBER}", url: "https://git@github.com/openSUSE/gitarro"]]])
-                    }
-                }
             }
         }
 
@@ -53,15 +36,20 @@ pipeline {
             steps {
                 echo 'Run helm charts tests'
                 script {
-                    helmcharts_test_cmd = "${gitarro_cmd} ${helmcharts_test}"
-                    if (params.GITARRO_PR_NUMBER != "") {
-                        helmcharts_test_cmd = "${gitarro_local} ${helmcharts_test}"
-                    }
                     if (params.PR_NUMBER != '') {
-                        helmcharts_test_cmd = "${helmcharts_test_cmd} -P ${params.PR_NUMBER}"
                         currentBuild.displayName = "PR: ${params.PR_NUMBER}"
+                        sh(
+                            "export PRODUCT=SUSE-Manager && pr-checker" +
+                            " --log-level debug" +
+                            " --repo ${repository}" +
+                            " run" +
+                            " --pr ${params.PR_NUMBER}" +
+                            " --check-name helm_charts_tests" +
+                            " --command susemanager-utils/testing/automation/helm-charts-tests.sh"
+                        )
+                    } else {
+                        echo "Missing PR_NUMBER parameter"
                     }
-                    sh "export PRODUCT=SUSE-Manager && ${helmcharts_test_cmd}"
                 }
             }
         }


### PR DESCRIPTION
Gitarro was not maintainable and had design flaws. Rather than sticking with a language that only a handful master, pr-checker switches to python.

This commit uses pr-checker in two pipelines to minimize disruption. If it turns out to be successful, the other pipelines will be replaced too.