### PR TITLE
Add RHEL 7, 8, 9 and 10 clients to the sandbox build validation environment

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
@@ -29,6 +29,7 @@ node('sumaform-cucumber') {
                     'centos7_minion:selected', 'centos7_sshminion:selected',
                     'liberty9_minion:selected', 'liberty9_sshminion:selected', 'liberty10_minion', 'liberty10_sshminion',
                     'oracle9_minion:selected', 'oracle9_sshminion:selected', 'oracle10_minion:selected', 'oracle10_sshminion:selected',
+                    'rhel7_minion', 'rhel7_sshminion', 'rhel8_minion', 'rhel8_sshminion', 'rhel9_minion', 'rhel9_sshminion', 'rhel10_minion', 'rhel10_sshminion',
                     'rocky8_minion:selected', 'rocky8_sshminion:selected', 'rocky9_minion:selected', 'rocky9_sshminion:selected', 'rocky10_minion:selected', 'rocky10_sshminion:selected',
                     'ubuntu2204_minion:selected', 'ubuntu2204_sshminion:selected', 'ubuntu2404_minion:selected', 'ubuntu2404_sshminion:selected',
                     'debian12_minion:selected', 'debian12_sshminion:selected', 'debian13_minion:selected', 'debian13_sshminion:selected',

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm_sandbox_build_validation_nue.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm_sandbox_build_validation_nue.tfvars
@@ -96,6 +96,22 @@ ENVIRONMENT_CONFIGURATION = {
     mac  = "aa:b2:93:01:02:a5"
     name = "liberty9-minion"
   }
+  rhel7_minion = {
+    mac  = "aa:b2:93:01:02:88"
+    name = "rhel7-minion"
+  }
+  rhel8_minion = {
+    mac  = "aa:b2:93:01:02:89"
+    name = "rhel8-minion"
+  }
+  rhel9_minion = {
+    mac  = "aa:b2:93:01:02:8a"
+    name = "rhel9-minion"
+  }
+  rhel10_minion = {
+    mac  = "aa:b2:93:01:02:8b"
+    name = "rhel10-minion"
+  }
   ubuntu2204_minion = {
     mac  = "aa:b2:93:01:02:9b"
     name = "ubuntu2204-minion"
@@ -220,6 +236,22 @@ ENVIRONMENT_CONFIGURATION = {
   liberty9_sshminion = {
     mac  = "aa:b2:93:01:02:c5"
     name = "liberty9-sshminion"
+  }
+  rhel7_sshminion = {
+    mac  = "aa:b2:93:01:02:8c"
+    name = "rhel7-sshminion"
+  }
+  rhel8_sshminion = {
+    mac  = "aa:b2:93:01:02:8d"
+    name = "rhel8-sshminion"
+  }
+  rhel9_sshminion = {
+    mac  = "aa:b2:93:01:02:8e"
+    name = "rhel9-sshminion"
+  }
+  rhel10_sshminion = {
+    mac  = "aa:b2:93:01:02:8f"
+    name = "rhel10-sshminion"
   }
   ubuntu2204_sshminion = {
     mac  = "aa:b2:93:01:02:bb"


### PR DESCRIPTION
Extends the RHEL 7, 8, 9 and 10 clients added to the head, 5.2 and 5.1 SLES build validation environments in #2201 to the sandbox environment, which that PR explicitly left untouched.

Adds the `rhel7`/`rhel8`/`rhel9`/`rhel10` minion and SSH minion entries to `manager-sandbox-qe-build-validation`'s `minions_to_run`, unselected by default until the testsuite can bootstrap these clients, the same way the other environments list them. Uses the `aa:b2:93:01:02:88`-`8f` MAC range and `10.146.8.136`-`143` addresses, the block the traditional clients freed in this environment, matching the DNS and DHCP entries from [infrastructure!1281](https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/1281).

No changes needed to the maintenance JSON generator, `v51_nodes.py` already maps `rhel7`/`rhel8`/`rhel9`/`rhel10` from #2201, or to the shared build-validation image defaults.

Cards:

- [SUSE/spacewalk#31302](https://github.com/SUSE/spacewalk/issues/31302)
- [SUSE/spacewalk#31303](https://github.com/SUSE/spacewalk/issues/31303)
- [SUSE/spacewalk#31304](https://github.com/SUSE/spacewalk/issues/31304)
- [SUSE/spacewalk#31305](https://github.com/SUSE/spacewalk/issues/31305)