### PR TITLE
Use minima mirror in Prague for suma-arm

### DIFF
--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm52_sles_build_validation_slc.tfvars
@@ -334,6 +334,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br0"
     additional_network = null
     hypervisor         = "suma-arm.mgr.suse.de"
+    mirror             = "minima-mirror-ci-bv.mgr.suse.de"
   }
 }
 MAIL_SUBJECT          = "Results 5.2 Build Validation $status: $tests scenarios ($failures failed, $errors errors, $skipped skipped, $passed passed)"

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlmhead_build_validation_slc.tfvars
@@ -333,6 +333,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br0"
     additional_network = null
     hypervisor         = "suma-arm.mgr.suse.de"
+    mirror             = "minima-mirror-ci-bv.mgr.suse.de"
   }
 }
 

--- a/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars
+++ b/terracumber_config/tf_files/tfvars/build-validation-tfvars/suma43_build_validation_slc.tfvars
@@ -283,6 +283,7 @@ BASE_CONFIGURATIONS = {
     bridge             = "br0"
     additional_network = null
     hypervisor         = "suma-arm.mgr.suse.de"
+    mirror             = "minima-mirror-ci-bv.mgr.suse.de"
   }
 }
 


### PR DESCRIPTION
Always use minima mirror in Prague for suma-arm hypervisor in Prague,
even though it runs test suites both in Prague and Salt Lake city.

Note: we might have same case for s390. We have no mainframe in SLC...