### PR TITLE
Pass isNewJenkins to the client testing stages

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -442,7 +442,7 @@ def run(params) {
                     // Call the minion testing.
                     try {
                         stage('Clients stages') {
-                            clientTestingStages(params, muLockSlots, smokeTestSlots, bootstrapRepoSlots)
+                            clientTestingStages(params, muLockSlots, smokeTestSlots, bootstrapRepoSlots, isNewJenkins)
                         }
                     } catch (Exception ex) {
                         println('ERROR: one or more clients have failed')
@@ -687,7 +687,7 @@ def runCucumberRakeTarget(String rake_target, boolean return_status = false, dis
 
 // Develop a function that outlines the various stages of a minion.
 // These stages will be executed concurrently.
-def clientTestingStages(params, muLockSlots, smokeTestSlots, bootstrapRepoSlots) {
+def clientTestingStages(params, muLockSlots, smokeTestSlots, bootstrapRepoSlots, isNewJenkins) {
 
     // Implement a hash map to store the various stages of nodes.
     def tests = [:]


### PR DESCRIPTION
Passes `isNewJenkins` as an argument to `clientTestingStages()`, which references it in every stage-skipping branch but cannot see it: it is a local variable of `run()`.

Each reference throws and kills that client's branch — the ssh minions in `Add MUs`, and every minion that is not a key of the non MU channels task file in `Add non MU Repositories`:

```
groovy.lang.MissingPropertyException: No such property: isNewJenkins for class: groovy.lang.Binding
```
