### PR TITLE
Update orion default branch to test hibernate version bump

### DIFF
--- a/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
+++ b/jenkins_pipelines/environments/manager-TEST-Orion-acceptance-tests
@@ -8,7 +8,7 @@ node('sumaform-cucumber') {
         pipelineTriggers([cron('H H/4 * * *')]),
         parameters([
             string(name: 'cucumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/uyuni.git', description: 'Testsuite Git Repository'),
-            string(name: 'cucumber_ref', defaultValue: 'master-staging-branch', description: 'Testsuite Git reference (branch, tag...)'),
+            string(name: 'cucumber_ref', defaultValue: 'mu_update_hibernate_7_4_7', description: 'Testsuite Git reference (branch, tag...)'),
             string(name: 'tf_file', defaultValue: 'susemanager-ci/terracumber_config/tf_files/MLM-Test-Orion-NUE.tf', description: 'Path to the tf file to be used'),
             string(name: 'sumaform_gitrepo', defaultValue: 'https://github.com/uyuni-project/sumaform.git', description: 'Sumaform Git Repository'),
             string(name: 'sumaform_ref', defaultValue: 'master', description: 'Sumaform Git reference (branch, tag...)'),


### PR DESCRIPTION
This pr configures Orion's test machine for testing hibernate bump to v7.4.7