### PR TITLE
Report the custom channel failure in the Add Activation Keys stage

### DIFF
--- a/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
+++ b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy
@@ -782,7 +782,7 @@ def clientTestingStages(params, muLockSlots, smokeTestSlots, bootstrapRepoSlots,
                             required_custom_channel_status[minion_name_without_ssh] != 'NOT_CREATED'
                         }
                         if (required_custom_channel_status[minion_name_without_ssh] == 'FAIL') {
-                            error("${minion_name_without_ssh} creates bootstrap repository failed")
+                            error("${minion_name_without_ssh} creates mandatory custom channel failed")
                         }
                     }
                     if (params.confirm_before_continue) {


### PR DESCRIPTION
Fixes the error message in the `Add Activation Keys <sshminion>` stage.

The stage waits for the custom channel, but printed the error text from `Create bootstrap repository`, a stage it never runs. So a failed `Add MUs` looked like a bootstrap repository problem. It now says:

```
rhel7_minion creates mandatory custom channel failed
```
