### PR TITLE
Add non MU base OS repositories for the RHEL 7 and 8 clients

### DIFF
--- a/jenkins_pipelines/data/non_MU_channels_tasks_51.json
+++ b/jenkins_pipelines/data/non_MU_channels_tasks_51.json
@@ -1,6 +1,8 @@
 {
   "_comment":  "List of minions that require specific custom channels with corresponding run_set",
   "centos7_minion" : "build_validation_centos7_minion_add_iso",
+  "rhel7_minion" : "build_validation_rhel7_minion_add_iso",
+  "rhel8_minion" : "build_validation_rhel8_minion_add_ubi_repository",
   "rocky8_minion" : "build_validation_rocky8_minion_add_iso",
   "ubuntu2404_minion" : "build_validation_ubuntu2404_minion_add_universe_and_main_noble_repositories"
 }

--- a/jenkins_pipelines/data/non_MU_channels_tasks_52.json
+++ b/jenkins_pipelines/data/non_MU_channels_tasks_52.json
@@ -1,6 +1,8 @@
 {
   "_comment":  "List of minions that require specific custom channels with corresponding run_set",
   "centos7_minion" : "build_validation_centos7_minion_add_iso",
+  "rhel7_minion" : "build_validation_rhel7_minion_add_iso",
+  "rhel8_minion" : "build_validation_rhel8_minion_add_ubi_repository",
   "rocky8_minion" : "build_validation_rocky8_minion_add_iso",
   "ubuntu2404_minion" : "build_validation_ubuntu2404_minion_add_universe_and_main_noble_repositories"
 }

--- a/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
@@ -75,7 +75,7 @@ node('sumaform-cucumber') {
     mutableParams.bin_path = "/usr/bin/tofu"
     mutableParams.bin_plugins_path = "/usr/bin"
     mutableParams.product_version_display = mutableParams.product_version
-    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_50.json'
+    mutableParams.non_MU_channels_tasks_file = 'susemanager-ci/jenkins_pipelines/data/non_MU_channels_tasks_52.json'
     mutableParams.deployment_tfvars = 'susemanager-ci/terracumber_config/tf_files/tfvars/build-validation-tfvars/mlm_sandbox_build_validation_nue.tfvars'
 
     def pipeline = load "jenkins_pipelines/environments/common/pipeline-build-validation.groovy"


### PR DESCRIPTION
Maps `rhel7_minion` and `rhel8_minion` to the new non MU repository run_sets, and points the sandbox build validation job at the 5.2 mapping file instead of the 5.0 one no other job uses.

The RHEL 7 and 8 pool channels are empty on purpose — a real customer syncs their own RHEL media into them — but `mgr-create-bootstrap-repo` still needs `logrotate` and `dmidecode` from the parent channel or one of its children, so bootstrap repo creation fails for both clients without this. Needs the testsuite side in https://github.com/uyuni-project/uyuni/pull/12553.
