### PR TITLE
Declare the real schema of BASE_CONFIGURATIONS

### DIFF
--- a/terracumber_config/tf_files/templates/build-validation-single-provider.tf
+++ b/terracumber_config/tf_files/templates/build-validation-single-provider.tf
@@ -22,7 +22,7 @@ module "base_core" {
   use_avahi       = false
   domain          = var.PLATFORM_LOCATION_CONFIGURATION[var.LOCATION].domain
   ssh_key_path    = var.CONTROLLER_PUBLIC_SSH_KEY_PATH
-  images = lookup(var.BASE_CONFIGURATIONS.base_core, "images", [
+  images = coalesce(try(var.BASE_CONFIGURATIONS.base_core.images, null), [
     "sles12sp5o",
     "sles15sp4o", "sles15sp5o", "sles15sp6o", "sles15sp7o",
     "sles160o",

--- a/terracumber_config/tf_files/variables/build-validation-variables.tf
+++ b/terracumber_config/tf_files/variables/build-validation-variables.tf
@@ -155,8 +155,14 @@ variable "PRODUCT_VERSION" {
 }
 
 variable "BASE_CONFIGURATIONS" {
-  type        = map
-  description = "Describe the base configuration (default core for NUE and all bases for SLC1)"
+  type = map(object({
+    images             = optional(list(string))
+    pool               = string
+    bridge             = string
+    additional_network = optional(string)
+    hypervisor         = string
+  }))
+  description = "Describe the base configuration (default core for NUE and all bases for SLC1). A base without images gets the default list of the template"
 }
 
 variable "HYPERVISOR_PRIVATE_SSH_KEY_PATH" {


### PR DESCRIPTION
Describes the bases as objects with an optional `images` attribute, so a base that takes the image list of the template no longer has to declare the same attributes as the others.

The variable was a plain map, which requires every element to have the same type. Since the ARM base got its own `images` list, the build validations where `base_core` has none stopped planning: sandbox, head NUE, 5.1 SLES NUE, 5.2 SLES PRG, 4.3 NUE and 5.0 micro NUE.

```
Error: Invalid value for input variable

  on terraform.tfvars line 69:
  69: BASE_CONFIGURATIONS = {

The given value is not suitable for var.BASE_CONFIGURATIONS declared at
variables.tf:157,1-31: attribute types must all match for conversion to map.
```