### PR TITLE
Add non MU base OS repositories for the RHEL 9 and 10 clients

### DIFF
--- a/jenkins_pipelines/data/non_MU_channels_tasks_51.json
+++ b/jenkins_pipelines/data/non_MU_channels_tasks_51.json
@@ -3,6 +3,8 @@
   "centos7_minion" : "build_validation_centos7_minion_add_iso",
   "rhel7_minion" : "build_validation_rhel7_minion_add_iso",
   "rhel8_minion" : "build_validation_rhel8_minion_add_ubi_repository",
+  "rhel9_minion" : "build_validation_rhel9_minion_add_ubi_repository",
+  "rhel10_minion" : "build_validation_rhel10_minion_add_ubi_repository",
   "rocky8_minion" : "build_validation_rocky8_minion_add_iso",
   "ubuntu2404_minion" : "build_validation_ubuntu2404_minion_add_universe_and_main_noble_repositories"
 }

--- a/jenkins_pipelines/data/non_MU_channels_tasks_52.json
+++ b/jenkins_pipelines/data/non_MU_channels_tasks_52.json
@@ -3,6 +3,8 @@
   "centos7_minion" : "build_validation_centos7_minion_add_iso",
   "rhel7_minion" : "build_validation_rhel7_minion_add_iso",
   "rhel8_minion" : "build_validation_rhel8_minion_add_ubi_repository",
+  "rhel9_minion" : "build_validation_rhel9_minion_add_ubi_repository",
+  "rhel10_minion" : "build_validation_rhel10_minion_add_ubi_repository",
   "rocky8_minion" : "build_validation_rocky8_minion_add_iso",
   "ubuntu2404_minion" : "build_validation_ubuntu2404_minion_add_universe_and_main_noble_repositories"
 }


### PR DESCRIPTION
Maps `rhel9_minion` and `rhel10_minion` to the run_sets that fill a custom child channel of their pool channel with the subscription-free UBI 9 and UBI 10 BaseOS and AppStream repositories, the same way `rhel7_minion` and `rhel8_minion` already are.

The EL9 and EL10 pool channels are empty and have no base OS child channel, so `autoconf` is in no channel MLM knows about and `spacecmd` cannot resolve its dependency on `file`. The run_sets themselves come with uyuni-project/uyuni#12553.
