### PR TITLE
Default the sandbox build validation to Multi-Linux Manager 5.2

### DIFF
--- a/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
+++ b/jenkins_pipelines/environments/build-validation/manager-sandbox-qe-build-validation
@@ -13,7 +13,7 @@ node('sumaform-cucumber') {
             string(name: 'deploy_parallelism', defaultValue: '', description: 'Advanced: Define the number of parallel resource operations for the executable binary'),
             string(name: 'terracumber_gitrepo', defaultValue: 'https://github.com/uyuni-project/terracumber.git', description: 'Terracumber Git Repository'),
             string(name: 'terracumber_ref', defaultValue: 'master', description: 'Terracumber Git ref (branch, tag...)'),
-            string(name: 'product_version', defaultValue: '5.1-released', description: 'Server product version'),
+            string(name: 'product_version', defaultValue: '5.2-released', description: 'Server product version'),
             choice(name: 'base_os', choices: ['slmicro62o', 'slmicro61o', 'sles15sp7o', 'slemicro55o', 'sles15sp6o'], description: 'Server and Proxy base OS'),
             activeChoice(name: 'minions_to_run', description: 'Node list to run during BV', choiceType: 'PT_CHECKBOX', script: [$class: 'GroovyScript', script: [$class: 'SecureGroovyScript', sandbox: true, script: """
                 return [
@@ -40,8 +40,8 @@ node('sumaform-cucumber') {
                     'slmicro60_minion:selected', 'slmicro61_minion:selected', 'slmicro62_minion:selected'
                 ]
             """.stripIndent()], fallbackScript: [$class: 'SecureGroovyScript', sandbox: true, script: "return ['error_loading_minions']"]]),
-            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/totest/containerfile', description: 'Server container registry'),
-            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/totest/containerfile', description: 'Proxy container registry'),
+            string(name: 'server_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Server container registry'),
+            string(name: 'proxy_container_registry', defaultValue: 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager52/totest/containerfile', description: 'Proxy container registry'),
             string(name: 'server_container_image', defaultValue: '', description: 'Server container image'),
             booleanParam(name: 'use_previous_terraform_state', defaultValue: false, description: 'Use previous Terraform state'),
             booleanParam(name: 'must_deploy', defaultValue: true, description: 'Deploy'),
@@ -62,7 +62,7 @@ node('sumaform-cucumber') {
             booleanParam(name: 'confirm_before_continue', defaultValue: false, description: 'Confirmation button between stages'),
             booleanParam(name: 'push_new_custom_repositories', defaultValue: false, description: 'Force push new custom repositories for client tools if pipeline rerun after deployment'),
             text(name: 'mi_ids', defaultValue: '', description: 'MI Identifiers separated by comma or whitespaces (Option A)'),
-            choice(name: 'json_generator_version', choices: ['51-micro', '51-sles', '52-micro', '52-sles', '50-micro', '50-sles', '43'], description: 'Version the MI Identifiers above are resolved for. Has to match product_version and base_os: a SL Micro base_os is a -micro version, a SLES one a -sles version'),
+            choice(name: 'json_generator_version', choices: ['52-micro', '52-sles', '51-micro', '51-sles', '50-micro', '50-sles', '43'], description: 'Version the MI Identifiers above are resolved for. Has to match product_version and base_os: a SL Micro base_os is a -micro version, a SLES one a -sles version'),
             text(name: 'custom_repositories', defaultValue: '{}', description: 'MU Repositories in json format (Option B)')
             ])
     ])


### PR DESCRIPTION
Defaults the sandbox build validation to Multi-Linux Manager 5.2, so launching it without touching anything deploys a coherent environment.

The version dependent parameters were set by hand and had drifted apart: the job defaulted to 5.1-released while its base OS defaulted to SL Micro 6.2 and its container registries pointed at the 5.1 containers. The product version, both registries and the JSON generator version now default to 5.2, which the SL Micro 6.2 base OS already matched.
